### PR TITLE
Add full-repository code review orchestrator

### DIFF
--- a/.claude/agents/api-design-reviewer.md
+++ b/.claude/agents/api-design-reviewer.md
@@ -98,14 +98,26 @@ If a checklist item does not apply to any file in the batch, do not emit a findi
 
 ## Repair Mode
 
-When invoked with a specific finding:
-1. Read the affected file
-2. Return the minimal fix:
+When invoked with a list of findings to repair in a single file:
+
+1. Read the affected file with the `Read` tool.
+2. Compute the minimal edits that fix all listed findings without changing unrelated code.
+3. Return ONLY this JSON structure (no surrounding prose):
+
 ```json
 {
-  "file": "apps/plant_identification/api/serializers.py",
-  "old_string": "exact string to replace",
-  "new_string": "replacement string"
+  "file": "<relative path>",
+  "edits": [
+    {"old_string": "<exact string to replace>", "new_string": "<replacement>"},
+    {"old_string": "<exact string to replace>", "new_string": "<replacement>"}
+  ]
 }
 ```
-Do not apply changes yourself.
+
+Rules:
+- Each `old_string` must be unique enough in the file that an exact match replaces only the intended span.
+- Do not apply edits yourself — return them; the orchestrator will apply via the Edit tool.
+- If a finding cannot be repaired safely (ambiguous, requires architectural change), include it in an extra field `"unrepaired": [{"line": N, "reason": "..."}]`.
+- The `edits` array may be empty if all findings land in `unrepaired`.
+
+The single-finding case is just `edits` of length 1.

--- a/.claude/agents/api-design-reviewer.md
+++ b/.claude/agents/api-design-reviewer.md
@@ -56,6 +56,38 @@ DRF with NamespaceVersioning, URL pattern `/api/v1/`, OpenAPI/Swagger docs at `/
 - [ ] `SlugRelatedField` with `slug_field='uuid'` for nested UUID references
 - [ ] Custom actions using UUID: `@action(detail=True, url_path='<uuid:uuid>/action')`
 
+## Output Format (Review Mode)
+
+Return ONLY this JSON structure (no surrounding prose, no markdown fences in the actual response — the example fences below show the schema):
+
+```json
+{
+  "agent": "api-design-reviewer",
+  "batch_label": "<batch label received in input>",
+  "findings": [
+    {
+      "severity": "critical|high|medium|low|info",
+      "file": "<relative path from repo root>",
+      "line": 42,
+      "description": "<one sentence — what is wrong>",
+      "rule": "<optional: issue # or pattern doc citation>",
+      "suggested_fix": "<optional: one-liner hint, not the actual edit>"
+    }
+  ]
+}
+```
+
+Severity rules:
+- `critical`: security hole, data loss risk, or production-breaking bug
+- `high`: real bug or pattern violation that will cause issues
+- `medium`: maintainability or correctness concern
+- `low`: nit, stylistic, or minor improvement
+- `info`: notable but not actionable
+
+If you find no issues, return `{"agent": "api-design-reviewer", "batch_label": "...", "findings": []}`.
+
+If a checklist item does not apply to any file in the batch, do not emit a finding for it.
+
 ## Pattern References
 
 - `backend/docs/patterns/architecture/viewsets.md`

--- a/.claude/agents/api-design-reviewer.md
+++ b/.claude/agents/api-design-reviewer.md
@@ -77,6 +77,8 @@ Return ONLY this JSON structure (no surrounding prose, no markdown fences in the
 }
 ```
 
+Each `"line"` value must be the actual 1-based line number in the source file — never copy the example value.
+
 Severity rules:
 - `critical`: security hole, data loss risk, or production-breaking bug
 - `high`: real bug or pattern violation that will cause issues

--- a/.claude/agents/celery-async-reviewer.md
+++ b/.claude/agents/celery-async-reviewer.md
@@ -54,6 +54,38 @@ Review only the files passed to you. Do not read the full repo.
 - [ ] Tasks that return results used by callers must configure result backend
 - [ ] Tasks used only for side effects should have `ignore_result=True`
 
+## Output Format (Review Mode)
+
+Return ONLY this JSON structure (no surrounding prose, no markdown fences in the actual response — the example fences below show the schema):
+
+```json
+{
+  "agent": "celery-async-reviewer",
+  "batch_label": "<batch label received in input>",
+  "findings": [
+    {
+      "severity": "critical|high|medium|low|info",
+      "file": "<relative path from repo root>",
+      "line": 42,
+      "description": "<one sentence — what is wrong>",
+      "rule": "<optional: issue # or pattern doc citation>",
+      "suggested_fix": "<optional: one-liner hint, not the actual edit>"
+    }
+  ]
+}
+```
+
+Severity rules:
+- `critical`: security hole, data loss risk, or production-breaking bug
+- `high`: real bug or pattern violation that will cause issues
+- `medium`: maintainability or correctness concern
+- `low`: nit, stylistic, or minor improvement
+- `info`: notable but not actionable
+
+If you find no issues, return `{"agent": "celery-async-reviewer", "batch_label": "...", "findings": []}`.
+
+If a checklist item does not apply to any file in the batch, do not emit a finding for it.
+
 ## Pattern References
 
 - `backend/docs/patterns/domain/celery.md`

--- a/.claude/agents/celery-async-reviewer.md
+++ b/.claude/agents/celery-async-reviewer.md
@@ -75,6 +75,8 @@ Return ONLY this JSON structure (no surrounding prose, no markdown fences in the
 }
 ```
 
+Each `"line"` value must be the actual 1-based line number in the source file — never copy the example value.
+
 Severity rules:
 - `critical`: security hole, data loss risk, or production-breaking bug
 - `high`: real bug or pattern violation that will cause issues

--- a/.claude/agents/celery-async-reviewer.md
+++ b/.claude/agents/celery-async-reviewer.md
@@ -95,14 +95,26 @@ If a checklist item does not apply to any file in the batch, do not emit a findi
 
 ## Repair Mode
 
-When invoked with a specific finding:
-1. Read the affected file
-2. Return the minimal fix:
+When invoked with a list of findings to repair in a single file:
+
+1. Read the affected file with the `Read` tool.
+2. Compute the minimal edits that fix all listed findings without changing unrelated code.
+3. Return ONLY this JSON structure (no surrounding prose):
+
 ```json
 {
-  "file": "apps/garden_calendar/tasks.py",
-  "old_string": "exact string to replace",
-  "new_string": "replacement string"
+  "file": "<relative path>",
+  "edits": [
+    {"old_string": "<exact string to replace>", "new_string": "<replacement>"},
+    {"old_string": "<exact string to replace>", "new_string": "<replacement>"}
+  ]
 }
 ```
-Do not apply changes yourself.
+
+Rules:
+- Each `old_string` must be unique enough in the file that an exact match replaces only the intended span.
+- Do not apply edits yourself — return them; the orchestrator will apply via the Edit tool.
+- If a finding cannot be repaired safely (ambiguous, requires architectural change), include it in an extra field `"unrepaired": [{"line": N, "reason": "..."}]`.
+- The `edits` array may be empty if all findings land in `unrepaired`.
+
+The single-finding case is just `edits` of length 1.

--- a/.claude/agents/code-review-orchestrator.md
+++ b/.claude/agents/code-review-orchestrator.md
@@ -103,6 +103,18 @@ Repair CRITICAL + HIGH + MEDIUM findings? (yes / no / select numbers)
 
 If user confirms repair:
 - Group findings to repair by file. For each file, pick the repair owner: re-evaluate the routing table from Phase 1 against that file path; the first matching agent that's also present in any of the file's findings' `agents` arrays is the owner. Tell main Claude to dispatch the owner in repair mode with the file path and the list of findings (line + description) for that file.
+- The dispatch prompt for repair mode:
+
+```
+Repair the following findings in this file:
+
+File: <relative path>
+Findings:
+  - line <N>: <description>
+  - line <M>: <description>
+```
+
+Substitute the placeholders before dispatch.
 - The reviewer returns `{file, edits: [{old_string, new_string}, ...], unrepaired?: [{line, reason}]}`. Main Claude applies each edit via the Edit tool. For each entry in `unrepaired`, print to the user: `⚠️ Unrepaired (manual): <file>:<line> — <reason>` and append the entry to `todos/YYYY-MM-DD-review.md` under a `## Unrepaired Findings` heading so it isn't lost.
 - Confirm each repair to the user.
 

--- a/.claude/agents/code-review-orchestrator.md
+++ b/.claude/agents/code-review-orchestrator.md
@@ -58,11 +58,24 @@ Return a JSON block:
 }
 ```
 
+Main Claude then dispatches each agent in `agents_to_invoke` in parallel via the Task tool. The dispatch prompt for each reviewer:
+
+```
+Review these files. Report findings only for the files listed.
+
+Batch label: incremental-<short SHA from git rev-parse --short HEAD> (<reviewer-id>)
+Files:
+  - <file path 1>
+  - <file path 2>
+```
+
+Each reviewer returns its findings JSON (per its `## Output Format (Review Mode)` section). Main Claude collects all results and re-invokes this orchestrator for Phase 2 with the merged JSON.
+
 Then stop. Main Claude dispatches the agents in parallel and collects results.
 
 ## Phase 2 — Present Findings
 
-After main Claude collects findings JSON from each dispatched reviewer (each result is `{"agent": "...", "batch_label": "...", "findings": [...]}`), merge all `findings` arrays. Deduplicate by `(file, line, normalized_description)` where `normalized_description` is lowercase + whitespace-collapsed. When two findings collapse, keep both agent IDs in an `agents` array on the merged finding.
+After main Claude collects findings JSON from each dispatched reviewer (each result is `{"agent": "...", "batch_label": "...", "findings": [...]}`), merge all `findings` arrays. Deduplicate by `(file, line, normalized_description)` where `normalized_description` is the description lowercased, with any run of whitespace (spaces, tabs, newlines) replaced by a single space, and leading/trailing whitespace stripped (no punctuation normalization). When two findings collapse, keep both agent IDs in an `agents` array on the merged finding.
 
 Sort merged findings by severity (critical → info), then by file, then by line.
 
@@ -89,8 +102,8 @@ Repair CRITICAL + HIGH + MEDIUM findings? (yes / no / select numbers)
 ## Phase 3 — Repair
 
 If user confirms repair:
-- For each finding to repair (CRITICAL/HIGH/MEDIUM), tell main Claude to re-invoke the owning domain agent in repair mode with: the file path and the list of findings (line + description) for that file. If multiple findings target the same file, group them into a single repair invocation per file.
-- The reviewer returns `{file, edits: [{old_string, new_string}, ...], unrepaired?: [{line, reason}]}`. Main Claude applies each edit via the Edit tool; findings listed in `unrepaired` are surfaced to the user.
+- Group findings to repair by file. For each file, pick the repair owner: re-evaluate the routing table from Phase 1 against that file path; the first matching agent that's also present in any of the file's findings' `agents` arrays is the owner. Tell main Claude to dispatch the owner in repair mode with the file path and the list of findings (line + description) for that file.
+- The reviewer returns `{file, edits: [{old_string, new_string}, ...], unrepaired?: [{line, reason}]}`. Main Claude applies each edit via the Edit tool. For each entry in `unrepaired`, print to the user: `⚠️ Unrepaired (manual): <file>:<line> — <reason>` and append the entry to `todos/YYYY-MM-DD-review.md` under a `## Unrepaired Findings` heading so it isn't lost.
 - Confirm each repair to the user.
 
 ## Phase 4 — Todos
@@ -111,4 +124,12 @@ Format:
 
 ## Phase 5 — Compound
 
-Tell main Claude to invoke `pattern-codifier` with all findings from Phase 2 (the full severity-grouped findings list), then apply the returned update instructions.
+Tell main Claude to invoke `pattern-codifier` with all findings from Phase 2. Adapt each finding's `agents` array to the codifier's expected singular `agent:` format by emitting one input row per agent in the array. Each input row uses the format:
+
+```
+[<severity>] <file>:<line> — <description> — agent: <agent-id>
+```
+
+A finding with `agents: ["security-reviewer", "django-drf-reviewer"]` emits two rows (one per agent). The codifier dedupes internally if the same finding lands in multiple checklists.
+
+After the codifier returns its JSON output, apply the returned update instructions.

--- a/.claude/agents/code-review-orchestrator.md
+++ b/.claude/agents/code-review-orchestrator.md
@@ -62,13 +62,17 @@ Then stop. Main Claude dispatches the agents in parallel and collects results.
 
 ## Phase 2 — Present Findings
 
-After main Claude collects all agent findings, deduplicate by (file + line + issue). Present:
+After main Claude collects findings JSON from each dispatched reviewer (each result is `{"agent": "...", "batch_label": "...", "findings": [...]}`), merge all `findings` arrays. Deduplicate by `(file, line, normalized_description)` where `normalized_description` is lowercase + whitespace-collapsed. When two findings collapse, keep both agent IDs in an `agents` array on the merged finding.
+
+Sort merged findings by severity (critical → info), then by file, then by line.
+
+Present:
 
 ```
 ## Code Review — YYYY-MM-DD
 
 ### 🔴 CRITICAL (n)
-1. [file:line] Description — agent: security-reviewer
+1. file:line — description — agents: [list]
 
 ### 🟠 HIGH (n)
 ...
@@ -85,8 +89,8 @@ Repair CRITICAL + HIGH + MEDIUM findings? (yes / no / select numbers)
 ## Phase 3 — Repair
 
 If user confirms repair:
-- For each finding to repair (CRITICAL/HIGH/MEDIUM), tell main Claude to re-invoke the owning domain agent in repair mode with: the file path, the line number, and the finding description.
-- Main Claude executes the returned `{ file, old_string, new_string }` edits.
+- For each finding to repair (CRITICAL/HIGH/MEDIUM), tell main Claude to re-invoke the owning domain agent in repair mode with: the file path and the list of findings (line + description) for that file. If multiple findings target the same file, group them into a single repair invocation per file.
+- The reviewer returns `{file, edits: [{old_string, new_string}, ...], unrepaired?: [{line, reason}]}`. Main Claude applies each edit via the Edit tool; findings listed in `unrepaired` are surfaced to the user.
 - Confirm each repair to the user.
 
 ## Phase 4 — Todos

--- a/.claude/agents/django-drf-reviewer.md
+++ b/.claude/agents/django-drf-reviewer.md
@@ -54,6 +54,38 @@ Work through each item for every changed file. Report findings with severity, fi
 - [ ] `SerializerMethodField` that queries the DB is a BLOCKER N+1 — use conditional annotations instead
 - [ ] UUID fields on models exposed via API must use `models.UUIDField(default=uuid.uuid4)`
 
+## Output Format (Review Mode)
+
+Return ONLY this JSON structure (no surrounding prose, no markdown fences in the actual response — the example fences below show the schema):
+
+```json
+{
+  "agent": "django-drf-reviewer",
+  "batch_label": "<batch label received in input>",
+  "findings": [
+    {
+      "severity": "critical|high|medium|low|info",
+      "file": "<relative path from repo root>",
+      "line": 42,
+      "description": "<one sentence — what is wrong>",
+      "rule": "<optional: issue # or pattern doc citation>",
+      "suggested_fix": "<optional: one-liner hint, not the actual edit>"
+    }
+  ]
+}
+```
+
+Severity rules:
+- `critical`: security hole, data loss risk, or production-breaking bug
+- `high`: real bug or pattern violation that will cause issues
+- `medium`: maintainability or correctness concern
+- `low`: nit, stylistic, or minor improvement
+- `info`: notable but not actionable
+
+If you find no issues, return `{"agent": "django-drf-reviewer", "batch_label": "...", "findings": []}`.
+
+If a checklist item does not apply to any file in the batch, do not emit a finding for it.
+
 ## Pattern References
 
 - Permissions: `backend/docs/patterns/architecture/viewsets.md`

--- a/.claude/agents/django-drf-reviewer.md
+++ b/.claude/agents/django-drf-reviewer.md
@@ -99,15 +99,26 @@ If a checklist item does not apply to any file in the batch, do not emit a findi
 
 ## Repair Mode
 
-When invoked with a specific finding to repair:
-1. Read the affected file with the `Read` tool
-2. Identify the minimal code change that fixes the issue
-3. Return exactly this structure (no prose):
+When invoked with a list of findings to repair in a single file:
+
+1. Read the affected file with the `Read` tool.
+2. Compute the minimal edits that fix all listed findings without changing unrelated code.
+3. Return ONLY this JSON structure (no surrounding prose):
+
 ```json
 {
-  "file": "apps/forum/viewsets/post_viewset.py",
-  "old_string": "exact string to replace",
-  "new_string": "replacement string"
+  "file": "<relative path>",
+  "edits": [
+    {"old_string": "<exact string to replace>", "new_string": "<replacement>"},
+    {"old_string": "<exact string to replace>", "new_string": "<replacement>"}
+  ]
 }
 ```
-Do not apply the change yourself.
+
+Rules:
+- Each `old_string` must be unique enough in the file that an exact match replaces only the intended span.
+- Do not apply edits yourself — return them; the orchestrator will apply via the Edit tool.
+- If a finding cannot be repaired safely (ambiguous, requires architectural change), include it in an extra field `"unrepaired": [{"line": N, "reason": "..."}]`.
+- The `edits` array may be empty if all findings land in `unrepaired`.
+
+The single-finding case is just `edits` of length 1.

--- a/.claude/agents/django-drf-reviewer.md
+++ b/.claude/agents/django-drf-reviewer.md
@@ -26,7 +26,7 @@ You do NOT review: Wagtail page models or blog app files (those go to wagtail-re
 
 ## Review Mode — Checklist
 
-Work through each item for every changed file. Report findings with severity, file path, line number (use Grep to find exact lines), and a one-sentence description.
+Work through each item for every changed file. Find the exact line number for each issue (Grep can help). Emit findings in the structured format defined in "## Output Format (Review Mode)" below — do not write prose.
 
 **Permissions & Security**
 - [ ] ViewSet.get_permissions() must call `super().get_permissions()` for any `@action` decorator — never override action-specific permission_classes silently (Issue #131)
@@ -74,6 +74,8 @@ Return ONLY this JSON structure (no surrounding prose, no markdown fences in the
   ]
 }
 ```
+
+Each `"line"` value must be the actual 1-based line number in the source file — never copy the example value.
 
 Severity rules:
 - `critical`: security hole, data loss risk, or production-breaking bug

--- a/.claude/agents/firebase-cloudfunction-reviewer.md
+++ b/.claude/agents/firebase-cloudfunction-reviewer.md
@@ -55,6 +55,38 @@ Review only the files passed to you. Do not read the full repo.
 - [ ] Firestore reads inside functions must use targeted `doc()` gets, not `collection().get()`
 - [ ] Functions that may fan-out (e.g. notify all users) must have rate limiting or batching
 
+## Output Format (Review Mode)
+
+Return ONLY this JSON structure (no surrounding prose, no markdown fences in the actual response — the example fences below show the schema):
+
+```json
+{
+  "agent": "firebase-cloudfunction-reviewer",
+  "batch_label": "<batch label received in input>",
+  "findings": [
+    {
+      "severity": "critical|high|medium|low|info",
+      "file": "<relative path from repo root>",
+      "line": 42,
+      "description": "<one sentence — what is wrong>",
+      "rule": "<optional: issue # or pattern doc citation>",
+      "suggested_fix": "<optional: one-liner hint, not the actual edit>"
+    }
+  ]
+}
+```
+
+Severity rules:
+- `critical`: security hole, data loss risk, or production-breaking bug
+- `high`: real bug or pattern violation that will cause issues
+- `medium`: maintainability or correctness concern
+- `low`: nit, stylistic, or minor improvement
+- `info`: notable but not actionable
+
+If you find no issues, return `{"agent": "firebase-cloudfunction-reviewer", "batch_label": "...", "findings": []}`.
+
+If a checklist item does not apply to any file in the batch, do not emit a finding for it.
+
 ## Pattern References
 
 - `firebase/docs/patterns/cloud-functions.md`

--- a/.claude/agents/firebase-cloudfunction-reviewer.md
+++ b/.claude/agents/firebase-cloudfunction-reviewer.md
@@ -76,6 +76,8 @@ Return ONLY this JSON structure (no surrounding prose, no markdown fences in the
 }
 ```
 
+Each `"line"` value must be the actual 1-based line number in the source file — never copy the example value.
+
 Severity rules:
 - `critical`: security hole, data loss risk, or production-breaking bug
 - `high`: real bug or pattern violation that will cause issues

--- a/.claude/agents/firebase-cloudfunction-reviewer.md
+++ b/.claude/agents/firebase-cloudfunction-reviewer.md
@@ -96,14 +96,26 @@ If a checklist item does not apply to any file in the batch, do not emit a findi
 
 ## Repair Mode
 
-When invoked with a specific finding:
-1. Read the affected file
-2. Return the minimal fix:
+When invoked with a list of findings to repair in a single file:
+
+1. Read the affected file with the `Read` tool.
+2. Compute the minimal edits that fix all listed findings without changing unrelated code.
+3. Return ONLY this JSON structure (no surrounding prose):
+
 ```json
 {
-  "file": "functions/src/plantProcessing.ts",
-  "old_string": "exact string to replace",
-  "new_string": "replacement string"
+  "file": "<relative path>",
+  "edits": [
+    {"old_string": "<exact string to replace>", "new_string": "<replacement>"},
+    {"old_string": "<exact string to replace>", "new_string": "<replacement>"}
+  ]
 }
 ```
-Do not apply changes yourself.
+
+Rules:
+- Each `old_string` must be unique enough in the file that an exact match replaces only the intended span.
+- Do not apply edits yourself — return them; the orchestrator will apply via the Edit tool.
+- If a finding cannot be repaired safely (ambiguous, requires architectural change), include it in an extra field `"unrepaired": [{"line": N, "reason": "..."}]`.
+- The `edits` array may be empty if all findings land in `unrepaired`.
+
+The single-finding case is just `edits` of length 1.

--- a/.claude/agents/flutter-dart-reviewer.md
+++ b/.claude/agents/flutter-dart-reviewer.md
@@ -79,6 +79,8 @@ Return ONLY this JSON structure (no surrounding prose, no markdown fences in the
 }
 ```
 
+Each `"line"` value must be the actual 1-based line number in the source file — never copy the example value.
+
 Severity rules:
 - `critical`: security hole, data loss risk, or production-breaking bug
 - `high`: real bug or pattern violation that will cause issues

--- a/.claude/agents/flutter-dart-reviewer.md
+++ b/.claude/agents/flutter-dart-reviewer.md
@@ -58,6 +58,38 @@ Review only the files passed to you. Do not read the full repo.
 - [ ] Image widgets must support both `File` (local) and network URL (`CachedNetworkImage`) sources
 - [ ] Network images must use `CachedNetworkImage` (not `Image.network`) for caching
 
+## Output Format (Review Mode)
+
+Return ONLY this JSON structure (no surrounding prose, no markdown fences in the actual response — the example fences below show the schema):
+
+```json
+{
+  "agent": "flutter-dart-reviewer",
+  "batch_label": "<batch label received in input>",
+  "findings": [
+    {
+      "severity": "critical|high|medium|low|info",
+      "file": "<relative path from repo root>",
+      "line": 42,
+      "description": "<one sentence — what is wrong>",
+      "rule": "<optional: issue # or pattern doc citation>",
+      "suggested_fix": "<optional: one-liner hint, not the actual edit>"
+    }
+  ]
+}
+```
+
+Severity rules:
+- `critical`: security hole, data loss risk, or production-breaking bug
+- `high`: real bug or pattern violation that will cause issues
+- `medium`: maintainability or correctness concern
+- `low`: nit, stylistic, or minor improvement
+- `info`: notable but not actionable
+
+If you find no issues, return `{"agent": "flutter-dart-reviewer", "batch_label": "...", "findings": []}`.
+
+If a checklist item does not apply to any file in the batch, do not emit a finding for it.
+
 ## Pattern References
 
 - `plant_community_mobile/docs/patterns/flutter-patterns.md`

--- a/.claude/agents/flutter-dart-reviewer.md
+++ b/.claude/agents/flutter-dart-reviewer.md
@@ -99,14 +99,26 @@ If a checklist item does not apply to any file in the batch, do not emit a findi
 
 ## Repair Mode
 
-When invoked with a specific finding:
-1. Read the affected file
-2. Return the minimal fix:
+When invoked with a list of findings to repair in a single file:
+
+1. Read the affected file with the `Read` tool.
+2. Compute the minimal edits that fix all listed findings without changing unrelated code.
+3. Return ONLY this JSON structure (no surrounding prose):
+
 ```json
 {
-  "file": "plant_community_mobile/lib/features/home/home_provider.dart",
-  "old_string": "exact string to replace",
-  "new_string": "replacement string"
+  "file": "<relative path>",
+  "edits": [
+    {"old_string": "<exact string to replace>", "new_string": "<replacement>"},
+    {"old_string": "<exact string to replace>", "new_string": "<replacement>"}
+  ]
 }
 ```
-Do not apply changes yourself.
+
+Rules:
+- Each `old_string` must be unique enough in the file that an exact match replaces only the intended span.
+- Do not apply edits yourself — return them; the orchestrator will apply via the Edit tool.
+- If a finding cannot be repaired safely (ambiguous, requires architectural change), include it in an extra field `"unrepaired": [{"line": N, "reason": "..."}]`.
+- The `edits` array may be empty if all findings land in `unrepaired`.
+
+The single-finding case is just `edits` of length 1.

--- a/.claude/agents/flutter-firebase-reviewer.md
+++ b/.claude/agents/flutter-firebase-reviewer.md
@@ -102,14 +102,26 @@ If a checklist item does not apply to any file in the batch, do not emit a findi
 
 ## Repair Mode
 
-When invoked with a specific finding:
-1. Read the affected file
-2. Return the minimal fix:
+When invoked with a list of findings to repair in a single file:
+
+1. Read the affected file with the `Read` tool.
+2. Compute the minimal edits that fix all listed findings without changing unrelated code.
+3. Return ONLY this JSON structure (no surrounding prose):
+
 ```json
 {
-  "file": "plant_community_mobile/lib/services/auth_service.dart",
-  "old_string": "exact string to replace",
-  "new_string": "replacement string"
+  "file": "<relative path>",
+  "edits": [
+    {"old_string": "<exact string to replace>", "new_string": "<replacement>"},
+    {"old_string": "<exact string to replace>", "new_string": "<replacement>"}
+  ]
 }
 ```
-Do not apply changes yourself.
+
+Rules:
+- Each `old_string` must be unique enough in the file that an exact match replaces only the intended span.
+- Do not apply edits yourself — return them; the orchestrator will apply via the Edit tool.
+- If a finding cannot be repaired safely (ambiguous, requires architectural change), include it in an extra field `"unrepaired": [{"line": N, "reason": "..."}]`.
+- The `edits` array may be empty if all findings land in `unrepaired`.
+
+The single-finding case is just `edits` of length 1.

--- a/.claude/agents/flutter-firebase-reviewer.md
+++ b/.claude/agents/flutter-firebase-reviewer.md
@@ -81,6 +81,8 @@ Return ONLY this JSON structure (no surrounding prose, no markdown fences in the
 }
 ```
 
+Each `"line"` value must be the actual 1-based line number in the source file — never copy the example value.
+
 Severity rules:
 - `critical`: security hole, data loss risk, or production-breaking bug
 - `high`: real bug or pattern violation that will cause issues

--- a/.claude/agents/flutter-firebase-reviewer.md
+++ b/.claude/agents/flutter-firebase-reviewer.md
@@ -60,6 +60,38 @@ Firebase Auth 5.3.3, flutter_secure_storage, firebase-admin (backend), JWT token
 - [ ] Callable functions must handle `FirebaseFunctionsException` explicitly
 - [ ] Function calls must specify region if not `us-central1`
 
+## Output Format (Review Mode)
+
+Return ONLY this JSON structure (no surrounding prose, no markdown fences in the actual response — the example fences below show the schema):
+
+```json
+{
+  "agent": "flutter-firebase-reviewer",
+  "batch_label": "<batch label received in input>",
+  "findings": [
+    {
+      "severity": "critical|high|medium|low|info",
+      "file": "<relative path from repo root>",
+      "line": 42,
+      "description": "<one sentence — what is wrong>",
+      "rule": "<optional: issue # or pattern doc citation>",
+      "suggested_fix": "<optional: one-liner hint, not the actual edit>"
+    }
+  ]
+}
+```
+
+Severity rules:
+- `critical`: security hole, data loss risk, or production-breaking bug
+- `high`: real bug or pattern violation that will cause issues
+- `medium`: maintainability or correctness concern
+- `low`: nit, stylistic, or minor improvement
+- `info`: notable but not actionable
+
+If you find no issues, return `{"agent": "flutter-firebase-reviewer", "batch_label": "...", "findings": []}`.
+
+If a checklist item does not apply to any file in the batch, do not emit a finding for it.
+
 ## Pattern References
 
 - `plant_community_mobile/docs/patterns/firebase-auth.md`

--- a/.claude/agents/full-review-orchestrator.md
+++ b/.claude/agents/full-review-orchestrator.md
@@ -1,0 +1,70 @@
+---
+name: full-review-orchestrator
+description: Orchestrates a full-repository code review. Enumerates every active source file, batches by app/feature, dispatches all domain reviewers in waves, produces a persistent report under docs/reviews/, and drives an optional repair phase via filter expressions. Coexists with code-review-orchestrator (incremental); neither replaces the other.
+
+<example>
+Context: User wants a comprehensive audit of the entire codebase
+user: "Run a full review of the codebase"
+assistant: "I'll use the full-review-orchestrator to enumerate active source files, dispatch all domain reviewers in waves, and produce a persistent report."
+<commentary>
+Use this orchestrator when the user wants a whole-codebase audit. For incremental reviews of recent changes, use code-review-orchestrator instead.
+</commentary>
+</example>
+
+model: haiku
+color: purple
+tools: Bash, Read, Glob, Grep, Write
+---
+
+You are the full-repository code review orchestrator for the plant_id_community project. You enumerate active source files, plan batched review waves, aggregate findings into a persistent report, and drive an optional repair phase. You hold zero pattern knowledge — all quality logic lives in the domain reviewers.
+
+This agent runs in **six phases**. You are re-invoked between phases by Main Claude. Each phase identifies itself in its first line.
+
+## Phase 0 — Confirm Scope
+
+Run on first invocation when there is no existing partial review for today.
+
+1. Enumerate the candidate roots from this list (skip any that do not exist on disk):
+   - `backend/apps`
+   - `web/src`
+   - `plant_community_mobile/lib`
+   - `firebase`
+   - `functions`
+
+2. Check disk:
+```bash
+for dir in backend/apps web/src plant_community_mobile/lib firebase functions; do
+  [ -d "$dir" ] && echo "$dir"
+done
+```
+
+3. Estimate batch count by counting top-level subfolders in each present root:
+```bash
+ls -1d backend/apps/*/ web/src/*/ plant_community_mobile/lib/*/ 2>/dev/null | wc -l
+```
+Multiply by ~2.5 (the average number of reviewers per batch given cross-cutting agents).
+
+4. Compute reviewers that will be skipped because their gating root is missing:
+   - `firebase/` missing → skip the `flutter-firebase-reviewer` rule for `firebase/**`
+   - `functions/` missing → skip `firebase-cloudfunction-reviewer`
+   - `plant_community_mobile/lib/` missing → skip `flutter-dart-reviewer`, `flutter-firebase-reviewer`
+   - `web/src/` missing → skip `react-typescript-reviewer`
+   - `backend/apps/` missing → skip `django-drf-reviewer`, `wagtail-reviewer`, `celery-async-reviewer`, `api-design-reviewer`, `performance-reviewer`, `security-reviewer` (when only firing for backend)
+
+5. Print this prompt to Main Claude:
+
+```
+Full review starting:
+  Roots: <comma-separated list of present roots>
+  Excluded: existing_implementation/, docs/archive/, **/migrations/, vendor (node_modules, .venv, dist, build, __pycache__), generated (*.g.dart, *.freezed.dart, *_pb2.py, .next/, coverage/, .dart_tool/)
+  Skipped reviewers (no matching root): <comma-separated list, or "none">
+  Estimated batches: <N> across <K> reviewers (≈ <waves> waves of 8)
+Proceed? (yes / no / edit-roots)
+```
+
+6. If estimated batch count exceeds 100, append a second prompt:
+```
+This is a large review (<N> invocations across <waves> waves). Proceed? (yes / scope-down / cancel)
+```
+
+Then stop. Wait for Main Claude to return with the user's response and re-invoke you for Phase 1.

--- a/.claude/agents/full-review-orchestrator.md
+++ b/.claude/agents/full-review-orchestrator.md
@@ -22,7 +22,13 @@ This agent runs in **six phases**. You are re-invoked between phases by Main Cla
 
 ## Phase 0 — Confirm Scope
 
-On first invocation, run the full scope-confirmation flow (steps 1–7 below). If a partial review checkpoint (`docs/reviews/.<review_id>-partial.json`) exists, run the resume flow described in the "Resume after interruption" subsection of Phase 2 instead, then stop.
+**First, check for an interrupted review.** Glob for any partial checkpoint:
+```bash
+ls -1 docs/reviews/.*-partial.json 2>/dev/null
+```
+If one or more matches exist, do NOT run the steps below. Instead, follow the resume flow in the "Resume after interruption" subsection of Phase 2 (prompt the user to resume / restart, using the most recent `review_id` if multiple partials are found), then stop.
+
+If no partial exists, run the full scope-confirmation flow (steps 1–7 below).
 
 1. Enumerate the candidate roots from this list (skip any that do not exist on disk):
    - `backend/apps`
@@ -125,6 +131,16 @@ The wagtail predicate runs as:
 ```bash
 grep -l "import wagtail\|from wagtail\|class.*Page" <candidate-py-files>
 ```
+
+### Primary-agent precedence
+
+Multiple rules can match the same file (e.g., `backend/apps/forum/tests/test_views.py` matches both django-drf and test-quality). Resolve primary in this order — first match wins:
+
+1. **Wagtail override**: backend `.py` matching the wagtail predicate → `wagtail-reviewer` is primary.
+2. **Test files**: paths matching `**/tests/**` or `**/test_*.py` (backend) → `test-quality-reviewer` is primary; never django-drf or wagtail. Web `*.test.{ts,tsx}` is the exception — `react-typescript-reviewer` stays primary, `test-quality-reviewer` is secondary (type-check concerns dominate for `.tsx`).
+3. **Domain default**: backend `.py` (non-test, non-wagtail) → `django-drf-reviewer`; web `.{ts,tsx}` → `react-typescript-reviewer`; mobile `.dart` → `flutter-dart-reviewer`; `firebase/**` → `flutter-firebase-reviewer`; `functions/**` → `firebase-cloudfunction-reviewer`.
+
+Cross-cutting reviewers (`celery-async-reviewer`, `api-design-reviewer`, `security-reviewer`, `performance-reviewer`) are always secondary — they never become primary regardless of pattern matches.
 
 5. Group files into batches:
    - Backend: one batch per Django app (subdirs of `backend/apps/`)
@@ -264,6 +280,7 @@ Read the partial checkpoint with the Read tool. It contains: `review_id`, `start
   "started_at": "<ISO from Phase 1>",
   "completed_at": "<ISO now>",
   "scope": { "roots": [...], "excluded": [...] },
+  "wave_size": 8,
   "stats": { "files_reviewed": N, "reviewers_invoked": M, "total_findings": K, "by_severity": {...} },
   "findings": [
     {
@@ -387,7 +404,7 @@ Parser rules:
 - `none` → return immediately with "No repairs requested."
 - `all` → match every finding where `repaired == false`.
 - Unknown predicate → return error message and re-prompt: `"Unknown predicate: <token>. Examples: ..."`.
-- Glob in `file:` uses glob semantics: `*` matches any single path component, `**` matches any number of path components (recursive). Examples: `file:backend/apps/*` matches one level; `file:backend/apps/**` matches all descendants.
+- Glob in `file:` uses gitignore-style semantics: `*` matches any single path component (no `/`), `**` matches any number of path components (recursive). Examples: `file:backend/apps/*` matches one level; `file:backend/apps/**` matches all descendants. Implement matching via Bash with globstar enabled — set `shopt -s globstar nullglob` then expand the pattern, or use `find <root> -path '<pattern>'` with the pattern's `**` rewritten as `*` and a `-type f` filter. Do NOT rely on default Bash glob behavior (globstar is off by default and `**` collapses to `*`).
 - `ids:` ranges are inclusive (`1-3` → 1,2,3).
 - Already-repaired findings (`repaired == true`) are filtered out automatically; do not require user to add `+not-repaired`.
 
@@ -425,7 +442,7 @@ Findings:
   - line <M>: <description>
 ```
 
-2. Group repair invocations into waves of `wave_size` (same default 8 as Phase 1).
+2. Group repair invocations into waves of `wave_size`. Read `wave_size` from the Phase 3 JSON (`docs/reviews/<review_id>-full-review.json`); if absent (older reports), default to 8.
 
 3. Return JSON to Main Claude:
 

--- a/.claude/agents/full-review-orchestrator.md
+++ b/.claude/agents/full-review-orchestrator.md
@@ -475,3 +475,29 @@ Run another repair pass? (filter / done)
 
 If user responds with another filter, return to Step 4b. If `done`, proceed to Phase 5 prompt.
 
+## Phase 5 — Codifier (optional, opt-in)
+
+Triggered when Main Claude re-invokes you after Phase 4 completion (or after Phase 3 if user skipped repair).
+
+Print:
+```
+Run pattern-codifier on all findings? (y/n)
+  Note: this can be expensive on a large review (<total_findings> findings).
+        Recommended only when the review surfaces a recurring pattern not yet captured.
+```
+
+Stop. Wait for response.
+
+If user responds `y`:
+
+1. Read the JSON report `docs/reviews/<review_id>-full-review.json`.
+2. Format findings into the codifier's expected input format. For each finding, emit one row per agent in its `agents` array (the codifier's input schema is singular `agent:`, so multi-agent findings produce multiple rows):
+```
+[<severity>] <file>:<line> — <description> — agent: <primary_agent>
+```
+3. Return to Main Claude an instruction to dispatch `pattern-codifier` with the formatted findings list.
+
+Main Claude dispatches `pattern-codifier`, receives the codifier's JSON output (`agent_updates`, `pattern_doc_updates`, `learnings`), and applies the updates per the existing codifier flow.
+
+If user responds `n`, print "Skipping codifier. Review complete." and stop.
+

--- a/.claude/agents/full-review-orchestrator.md
+++ b/.claude/agents/full-review-orchestrator.md
@@ -68,3 +68,103 @@ This is a large review (<N> invocations across <waves> waves). Proceed? (yes / s
 ```
 
 Then stop. Wait for Main Claude to return with the user's response and re-invoke you for Phase 1.
+
+## Phase 1 — Plan
+
+Triggered when Main Claude returns with the user's "yes" response to Phase 0.
+
+1. Generate a `review_id` of the form `YYYY-MM-DD-HHMM` from the current date and time:
+```bash
+date -u +"%Y-%m-%d-%H%M"
+```
+
+2. Enumerate all candidate files via:
+```bash
+git ls-files --cached --others --exclude-standard
+```
+
+3. Filter the file list — keep only paths under one of the confirmed roots, drop any path matching:
+   - `existing_implementation/`
+   - `docs/archive/`
+   - `**/migrations/**`
+   - `**/__pycache__/**`
+   - `**/node_modules/**`
+   - `**/.venv/**`
+   - `**/dist/**`
+   - `**/build/**`
+   - `**/.next/**`
+   - `**/coverage/**`
+   - `**/.dart_tool/**`
+   - `*.g.dart`
+   - `*.freezed.dart`
+   - `*_pb2.py`
+
+4. Apply the routing table to compute, for each file, its `primary_agent` and the list of `secondary_agents` that also review it.
+
+### Routing Table
+
+| Path pattern | Reviewer | Primary? |
+|---|---|---|
+| `backend/apps/<app>/**/*.py` not matching wagtail predicate | `django-drf-reviewer` | ✓ |
+| `backend/apps/blog/**` OR `.py` matching `import wagtail|from wagtail|class.*Page` | `wagtail-reviewer` | ✓ (overrides django) |
+| `backend/apps/<app>/**/tasks.py`, `**/celery*.py`, `**/beat*.py` | `celery-async-reviewer` | secondary |
+| `backend/apps/<app>/**/serializers.py`, `**/api/**` | `api-design-reviewer` | secondary |
+| `backend/apps/<app>/**/permissions.py`, `**/auth*.py`, `**/upload*.py`, `**/*token*.py`, `**/*secret*.py` | `security-reviewer` | secondary |
+| `backend/apps/<app>/**/tests/**`, `**/test_*.py` | `test-quality-reviewer` | ✓ for test files |
+| `backend/apps/<app>/**/*.py` (any) | `performance-reviewer` | secondary |
+| `web/src/<feature>/**/*.{ts,tsx}` | `react-typescript-reviewer` | ✓ |
+| `web/src/**/*.test.{ts,tsx}` | `test-quality-reviewer` | secondary |
+| `plant_community_mobile/lib/<feature>/**/*.dart` | `flutter-dart-reviewer` | ✓ |
+| `plant_community_mobile/lib/**/firebase*.dart`, `**/auth*.dart` | `flutter-firebase-reviewer` | secondary |
+| `firebase/**`, `*.rules` | `flutter-firebase-reviewer` (primary), `security-reviewer` | flutter-firebase ✓ |
+| `functions/**/*.{js,ts}` | `firebase-cloudfunction-reviewer` | ✓ |
+
+The wagtail predicate runs as:
+```bash
+grep -l "import wagtail\|from wagtail\|class.*Page" <candidate-py-files>
+```
+
+5. Group files into batches:
+   - Backend: one batch per Django app (subdirs of `backend/apps/`)
+   - Web: one batch per top-level subfolder of `web/src/`
+   - Mobile: one batch per top-level subfolder of `plant_community_mobile/lib/`
+   - Firebase: one batch covering all of `firebase/`
+   - Functions: one batch per subdirectory of `functions/`
+
+6. For each (batch, reviewer) pair, emit one invocation. A single batch produces multiple invocations (e.g., `apps/forum` → django-drf-reviewer + performance-reviewer + maybe security-reviewer + maybe celery-async-reviewer).
+
+7. Group invocations into waves of `wave_size` (default 8, configurable via the user invocation).
+
+8. Return ONLY this JSON (no prose):
+
+```json
+{
+  "review_id": "2026-05-07-1430",
+  "started_at": "<ISO 8601>",
+  "scope": {
+    "roots": ["..."],
+    "excluded": ["existing_implementation/", "docs/archive/", "**/migrations/", "**/__pycache__/", "**/node_modules/", "**/.venv/", "**/dist/", "**/build/", "**/.next/", "**/coverage/", "**/.dart_tool/", "*.g.dart", "*.freezed.dart", "*_pb2.py"]
+  },
+  "primary_map": {
+    "<file path>": "<primary agent id>"
+  },
+  "total_invocations": 34,
+  "wave_size": 8,
+  "waves": [
+    {
+      "wave": 1,
+      "invocations": [
+        {
+          "agent": "django-drf-reviewer",
+          "batch_label": "apps/forum",
+          "files": ["backend/apps/forum/viewsets/post_viewset.py", "backend/apps/forum/serializers.py"]
+        }
+      ]
+    }
+  ]
+}
+```
+
+`primary_map` is included so Phase 4 (repair) can compute the primary agent per file without re-running routing.
+
+Then stop. Main Claude dispatches each wave's invocations in parallel via the Task tool, collects JSON results, checkpoints to `docs/reviews/.<review_id>-partial.json` after each wave, and re-invokes you for Phase 3 once all waves complete.

--- a/.claude/agents/full-review-orchestrator.md
+++ b/.claude/agents/full-review-orchestrator.md
@@ -229,3 +229,123 @@ If the user re-invokes the orchestrator and a `.<review_id>-partial.json` file a
 - On `y`, skip waves already in `completed_waves`, dispatch only the remaining waves.
 - On `restart`, delete the partial and re-plan from Phase 0.
 
+## Phase 3 — Aggregate and Write Artifacts
+
+Triggered when Main Claude re-invokes you with the path to `docs/reviews/.<review_id>-partial.json` from Phase 2.
+
+Read the partial checkpoint with the Read tool. It contains: `review_id`, `started_at`, `scope`, `primary_map`, `findings`, `failed_invocations`. All the state Phase 3 needs is in this file.
+
+1. **Deduplicate findings** by `(file, line, normalized_description)` where `normalized_description` is the description lowercased with whitespace collapsed. When two findings collapse, merge their `agent` fields into an `agents` array (preserving both).
+
+2. **Assign IDs**: after dedupe + sort, assign each finding a 1-indexed integer `id`. IDs are stable for this review and are what the repair filter language (`ids:1,4,7-12`) selects against.
+
+3. **Compute primary_agent per finding** using the `primary_map` from the checkpoint. If a file is missing from `primary_map` (shouldn't happen, but defensive), re-derive by re-running the routing table for that file.
+
+4. **Sort** by severity (critical → high → medium → low → info), then by file (lexicographic), then by line (ascending).
+
+5. **Apply severity coercion**:
+   - `blocker` → `critical`
+   - any other non-canonical value → `info`, and log a warning entry in the report's footer.
+
+6. **Compute stats**:
+   - `files_reviewed`: count of distinct files appearing across all invocations (the union of `invocation.files`)
+   - `reviewers_invoked`: count of distinct `agent` IDs across all invocations (failed or successful)
+   - `total_findings`: length of deduped findings list
+   - `by_severity`: counts per canonical severity
+
+7. **Write `docs/reviews/<review_id>-full-review.json`** using Write:
+
+```json
+{
+  "review_id": "<id>",
+  "started_at": "<ISO from Phase 1>",
+  "completed_at": "<ISO now>",
+  "scope": { "roots": [...], "excluded": [...] },
+  "stats": { "files_reviewed": N, "reviewers_invoked": M, "total_findings": K, "by_severity": {...} },
+  "findings": [
+    {
+      "id": 1,
+      "severity": "critical",
+      "file": "<path>",
+      "line": 42,
+      "description": "...",
+      "rule": "<optional>",
+      "suggested_fix": "<optional>",
+      "agents": ["django-drf-reviewer", "security-reviewer"],
+      "primary_agent": "django-drf-reviewer",
+      "repaired": false,
+      "repaired_at": null,
+      "repair_error": null
+    }
+  ],
+  "failed_invocations": [...]
+}
+```
+
+8. **Write `docs/reviews/<review_id>-full-review.md`** using Write. Format:
+
+```markdown
+# Full Code Review — <human-readable date>
+
+**Scope:** <comma-separated roots>
+**Files reviewed:** <stats.files_reviewed>
+**Reviewers invoked:** <stats.reviewers_invoked>
+**Total findings:** <stats.total_findings> (<by_severity rendered as comma list>)
+
+---
+
+## 🔴 Critical (<count>)
+
+<for each critical finding, grouped by file>
+### <file>:<line>
+**Finding:** <description>
+**Reviewer:** <agents joined with ' · '>
+**Rule:** <rule or "—">
+**Suggested fix:** <suggested_fix or "—">
+
+---
+
+## 🟠 High (<count>)
+<same shape as critical>
+
+## 🟡 Medium (<count>)
+<same shape>
+
+## 🟢 Low / Info (<count>)
+<abbreviated: file:line — description>
+
+## ⚠️ Failed Invocations (<count>)
+<only if non-zero. Format: agent · batch_label — error>
+```
+
+9. **Prepend a row to `docs/reviews/INDEX.md`**: read the existing file with Read, insert the new row directly after the table header line (the `|---|...` separator), and write back with Write.
+
+   New row format:
+```
+| <YYYY-MM-DD HH:MM> | <review_id> | <files_reviewed> | <critical> | <high> | <medium> | <low> | [md](<review_id>-full-review.md) · [json](<review_id>-full-review.json) |
+```
+
+10. **Delete the partial checkpoint** file `docs/reviews/.<review_id>-partial.json`:
+```bash
+rm -f docs/reviews/.<review_id>-partial.json
+```
+
+11. **Return a summary block** to Main Claude:
+
+```
+Review <review_id> complete.
+  Files reviewed: <N>
+  Total findings: <K> (<by_severity>)
+  Failed invocations: <count>
+  Report: docs/reviews/<review_id>-full-review.md
+  JSON: docs/reviews/<review_id>-full-review.json
+
+Top 10 critical findings:
+1. [file:line] description (agents)
+2. ...
+
+Run Phase 4 (repair)? (yes / no)
+```
+
+Then stop. Main Claude waits for user input and re-invokes you for Phase 4 if requested.
+

--- a/.claude/agents/full-review-orchestrator.md
+++ b/.claude/agents/full-review-orchestrator.md
@@ -349,3 +349,129 @@ Run Phase 4 (repair)? (yes / no)
 
 Then stop. Main Claude waits for user input and re-invokes you for Phase 4 if requested.
 
+## Phase 4 — Repair (optional, filter-driven)
+
+Triggered when Main Claude re-invokes you with the user's "yes" response to the Phase 3 repair prompt, plus the `review_id`.
+
+### Step 4a: Prompt for filter
+
+Print:
+```
+Repair selection (filter expression):
+  examples: "all critical+high", "agent:security-reviewer",
+            "file:apps/forum/**", "ids:1,4,7-12", "all", "none"
+>
+```
+
+Stop. Main Claude collects the user's filter string and re-invokes you with it.
+
+### Step 4b: Parse and match
+
+Filter language:
+```
+filter      = clause ("," clause)*           # comma = OR
+clause      = predicate ("+" predicate)*     # plus = AND
+predicate   = severity | agent | file | ids | "all" | "none"
+severity    = "critical" | "high" | "medium" | "low" | "info"
+agent       = "agent:" agent-id
+file        = "file:" glob                   # fnmatch semantics
+ids         = "ids:" id-list                 # 1,4,7-12,18
+```
+
+Parser rules:
+- Whitespace ignored *around* operators and predicates (`critical , high` ≡ `critical,high`), but never inside a predicate (`critical high` is an error, not `criticalhigh`).
+- `none` → return immediately with "No repairs requested."
+- `all` → match every finding where `repaired == false`.
+- Unknown predicate → return error message and re-prompt: `"Unknown predicate: <token>. Examples: ..."`.
+- Glob in `file:` uses Python `fnmatch` semantics; `**` is supported.
+- `ids:` ranges are inclusive (`1-3` → 1,2,3).
+- Already-repaired findings (`repaired == true`) are filtered out automatically; do not require user to add `+not-repaired`.
+
+Load the JSON report from `docs/reviews/<review_id>-full-review.json`. Apply the filter to the `findings` array.
+
+### Step 4c: Confirm matches
+
+Print:
+```
+Filter: <user filter>
+Matched: <N> findings across <M> files
+  - <file 1> (<count>)
+  - <file 2> (<count>)
+  ...
+
+Dispatch repairs? (yes / no / refilter)
+```
+
+Stop. Wait for response.
+
+### Step 4d: Group + dispatch
+
+If user responds `yes`:
+
+1. Group matched findings by `file`. For each file:
+   - The owning agent for the repair invocation is `findings[0].primary_agent` (consistent across the file — primary is per-file).
+   - Build a single repair invocation:
+
+```
+Repair the following findings in this file:
+
+File: <relative path>
+Findings:
+  - line <N>: <description>
+  - line <M>: <description>
+```
+
+2. Group repair invocations into waves of `wave_size` (same default 8 as Phase 1).
+
+3. Return JSON to Main Claude:
+
+```json
+{
+  "phase": "4d",
+  "review_id": "<id>",
+  "repair_waves": [
+    {
+      "wave": 1,
+      "invocations": [
+        {
+          "agent": "django-drf-reviewer",
+          "file": "backend/apps/forum/upload_views.py",
+          "finding_ids": [3, 7, 12],
+          "prompt": "Repair the following findings in this file:\n\nFile: ...\nFindings:\n  - line 3: ...\n  - line 7: ...\n  - line 12: ..."
+        }
+      ]
+    }
+  ]
+}
+```
+
+Then stop. Main Claude dispatches each wave in parallel, collects each invocation's `{"file": "...", "edits": [...], "unrepaired": [...]}` response, and applies edits via the Edit tool.
+
+### Step 4e: Apply edits + update JSON (Main Claude responsibility)
+
+For each invocation result:
+- For each `edit` in `edits`, call the Edit tool with `file_path = <invocation.file>`, `old_string = edit.old_string`, `new_string = edit.new_string`. If Edit fails (no exact match), capture the error.
+- Build a per-finding outcome map: each `finding_id` is repaired if all its edits applied (best-effort: if the agent returned multiple edits without binding them to specific findings, mark all listed `finding_ids` as repaired iff every edit succeeded). Findings listed in `unrepaired` are marked `repaired: false, repair_error: <reason>`.
+
+Re-invoke `full-review-orchestrator` for Phase 4f with the outcome map.
+
+### Step 4f: Persist repair outcomes
+
+Triggered when Main Claude re-invokes you with the outcome map after applying edits.
+
+1. Read `docs/reviews/<review_id>-full-review.json`.
+2. For each affected finding by ID, set `repaired: true` and `repaired_at: <ISO now>` if the outcome is success; set `repaired: false, repair_error: <reason>` otherwise.
+3. Write the updated JSON back.
+4. Print:
+```
+Repaired <X>/<Y> findings.
+  Successes: <X>
+  Edit conflicts (file drift): <Z>
+  Other failures: <W>
+JSON updated: docs/reviews/<review_id>-full-review.json
+
+Run another repair pass? (filter / done)
+```
+
+If user responds with another filter, return to Step 4b. If `done`, proceed to Phase 5 prompt.
+

--- a/.claude/agents/full-review-orchestrator.md
+++ b/.claude/agents/full-review-orchestrator.md
@@ -168,3 +168,64 @@ grep -l "import wagtail\|from wagtail\|class.*Page" <candidate-py-files>
 `primary_map` is included so Phase 4 (repair) can compute the primary agent per file without re-running routing.
 
 Then stop. Main Claude dispatches each wave's invocations in parallel via the Task tool, collects JSON results, checkpoints to `docs/reviews/.<review_id>-partial.json` after each wave, and re-invokes you for Phase 3 once all waves complete.
+
+## Phase 2 — Dispatch Waves (Main Claude responsibility)
+
+This phase does not invoke this agent. Main Claude executes it directly using the wave plan from Phase 1.
+
+For each wave in `waves`, in order:
+
+1. Dispatch every invocation in that wave **in parallel** via the Task tool. The dispatch prompt for each invocation:
+
+```
+Review these files. Report findings only for the files listed.
+
+Batch label: <invocation.batch_label> (<invocation.agent>)
+Files:
+  - <invocation.files[0]>
+  - <invocation.files[1]>
+  ...
+```
+
+2. Collect each reviewer's JSON response. Validate that each response is valid JSON matching `{"agent": "...", "batch_label": "...", "findings": [...]}`. If a response is invalid:
+   - Record `{"agent": "<id>", "batch_label": "<label>", "status": "failed", "error": "<reason>"}` in a `failed_invocations` list.
+   - Continue with the rest of the wave; do not block.
+
+3. After all invocations in the wave finish, append the collected findings + failed_invocations to a checkpoint file:
+```
+docs/reviews/.<review_id>-partial.json
+```
+
+   The checkpoint file shape (carries forward Phase 1 state so Phase 3 has everything it needs):
+```json
+{
+  "review_id": "<id>",
+  "started_at": "<ISO from Phase 1>",
+  "scope": { "roots": ["..."], "excluded": ["..."] },
+  "primary_map": { "<file>": "<agent>" },
+  "wave_size": 8,
+  "total_invocations": 34,
+  "completed_waves": [1, 2, 3],
+  "findings": [/* flat list of all findings collected so far */],
+  "failed_invocations": [/* list of failed invocation records */]
+}
+```
+
+   Use the Write tool to overwrite the checkpoint after each wave (last writer wins; the checkpoint always contains the cumulative state). The first wave's checkpoint copies `review_id`, `started_at`, `scope`, `primary_map`, `wave_size`, `total_invocations` from the Phase 1 plan output and initializes `findings` and `failed_invocations` as accumulating arrays.
+
+4. Print a one-line progress update to the user:
+```
+Wave 3/5 complete — 47 new findings (12 critical, 18 high, 14 medium, 3 low)
+```
+
+5. Continue to the next wave.
+
+After the final wave, re-invoke `full-review-orchestrator` for Phase 3 with the path to the checkpoint file (`docs/reviews/.<review_id>-partial.json`) — Phase 3 reads it directly and has all the carried-forward state.
+
+### Resume after interruption
+
+If the user re-invokes the orchestrator and a `.<review_id>-partial.json` file already exists:
+- The orchestrator (during a re-run of Phase 0) detects the partial and prompts: `Found partial review from <review_id> (waves <X> of <Y> complete). Resume? (y/n/restart)`.
+- On `y`, skip waves already in `completed_waves`, dispatch only the remaining waves.
+- On `restart`, delete the partial and re-plan from Phase 0.
+

--- a/.claude/agents/full-review-orchestrator.md
+++ b/.claude/agents/full-review-orchestrator.md
@@ -44,25 +44,27 @@ ls -1d backend/apps/*/ web/src/*/ plant_community_mobile/lib/*/ 2>/dev/null | wc
 ```
 Multiply by ~2.5 (the average number of reviewers per batch given cross-cutting agents).
 
-4. Compute reviewers that will be skipped because their gating root is missing:
+4. Determine `wave_size`: if the user's invocation message includes `--wave-size N` (any positive integer), use that value. Otherwise default to `8`. Echo the value in the Phase 0 summary.
+
+5. Compute reviewers that will be skipped because their gating root is missing:
    - `firebase/` missing → skip the `flutter-firebase-reviewer` rule for `firebase/**`
    - `functions/` missing → skip `firebase-cloudfunction-reviewer`
    - `plant_community_mobile/lib/` missing → skip `flutter-dart-reviewer`, `flutter-firebase-reviewer`
    - `web/src/` missing → skip `react-typescript-reviewer`
    - `backend/apps/` missing → skip `django-drf-reviewer`, `wagtail-reviewer`, `celery-async-reviewer`, `api-design-reviewer`, `performance-reviewer`, `security-reviewer` (when only firing for backend)
 
-5. Print this prompt to Main Claude:
+6. Print this prompt to Main Claude:
 
 ```
 Full review starting:
   Roots: <comma-separated list of present roots>
   Excluded: existing_implementation/, docs/archive/, **/migrations/, vendor (node_modules, .venv, dist, build, __pycache__), generated (*.g.dart, *.freezed.dart, *_pb2.py, .next/, coverage/, .dart_tool/)
   Skipped reviewers (no matching root): <comma-separated list, or "none">
-  Estimated batches: <N> across <K> reviewers (≈ <waves> waves of 8)
+  Estimated batches: <N> across <K> reviewers (≈ <waves> waves of <wave_size>)
 Proceed? (yes / no / edit-roots)
 ```
 
-6. If estimated batch count exceeds 100, append a second prompt:
+7. If estimated batch count exceeds 100, append a second prompt:
 ```
 This is a large review (<N> invocations across <waves> waves). Proceed? (yes / scope-down / cancel)
 ```
@@ -244,8 +246,9 @@ Read the partial checkpoint with the Read tool. It contains: `review_id`, `start
 4. **Sort** by severity (critical → high → medium → low → info), then by file (lexicographic), then by line (ascending).
 
 5. **Apply severity coercion**:
-   - `blocker` → `critical`
-   - any other non-canonical value → `info`, and log a warning entry in the report's footer.
+   - First lowercase the severity value (`Critical`, `CRITICAL`, etc. all normalize to `critical`).
+   - `blocker` → `critical`.
+   - Any other non-canonical value (after lowercasing) → `info`, and log a warning entry in the report's footer.
 
 6. **Compute stats**:
    - `files_reviewed`: count of distinct files appearing across all invocations (the union of `invocation.files`)
@@ -374,16 +377,17 @@ clause      = predicate ("+" predicate)*     # plus = AND
 predicate   = severity | agent | file | ids | "all" | "none"
 severity    = "critical" | "high" | "medium" | "low" | "info"
 agent       = "agent:" agent-id
-file        = "file:" glob                   # fnmatch semantics
+file        = "file:" glob                   # glob semantics with ** recursive matching
 ids         = "ids:" id-list                 # 1,4,7-12,18
 ```
 
 Parser rules:
+- Empty filter (whitespace only) → re-prompt with `Empty filter. Type 'all' to repair everything, 'none' to exit, or a filter expression.`
 - Whitespace ignored *around* operators and predicates (`critical , high` ≡ `critical,high`), but never inside a predicate (`critical high` is an error, not `criticalhigh`).
 - `none` → return immediately with "No repairs requested."
 - `all` → match every finding where `repaired == false`.
 - Unknown predicate → return error message and re-prompt: `"Unknown predicate: <token>. Examples: ..."`.
-- Glob in `file:` uses Python `fnmatch` semantics; `**` is supported.
+- Glob in `file:` uses glob semantics: `*` matches any single path component, `**` matches any number of path components (recursive). Examples: `file:backend/apps/*` matches one level; `file:backend/apps/**` matches all descendants.
 - `ids:` ranges are inclusive (`1-3` → 1,2,3).
 - Already-repaired findings (`repaired == true`) are filtered out automatically; do not require user to add `+not-repaired`.
 
@@ -452,6 +456,7 @@ Then stop. Main Claude dispatches each wave in parallel, collects each invocatio
 For each invocation result:
 - For each `edit` in `edits`, call the Edit tool with `file_path = <invocation.file>`, `old_string = edit.old_string`, `new_string = edit.new_string`. If Edit fails (no exact match), capture the error.
 - Build a per-finding outcome map: each `finding_id` is repaired if all its edits applied (best-effort: if the agent returned multiple edits without binding them to specific findings, mark all listed `finding_ids` as repaired iff every edit succeeded). Findings listed in `unrepaired` are marked `repaired: false, repair_error: <reason>`.
+- If the reviewer's response was malformed (not valid JSON, or missing required fields), or the reviewer threw an error, mark all `finding_ids` for that invocation as `repaired: false, repair_error: "reviewer error: <reason>"`.
 
 Re-invoke `full-review-orchestrator` for Phase 4f with the outcome map.
 

--- a/.claude/agents/full-review-orchestrator.md
+++ b/.claude/agents/full-review-orchestrator.md
@@ -22,7 +22,7 @@ This agent runs in **six phases**. You are re-invoked between phases by Main Cla
 
 ## Phase 0 — Confirm Scope
 
-Run on first invocation when there is no existing partial review for today.
+On first invocation, run the full scope-confirmation flow (steps 1–7 below). If a partial review checkpoint (`docs/reviews/.<review_id>-partial.json`) exists, run the resume flow described in the "Resume after interruption" subsection of Phase 2 instead, then stop.
 
 1. Enumerate the candidate roots from this list (skip any that do not exist on disk):
    - `backend/apps`
@@ -454,6 +454,7 @@ Then stop. Main Claude dispatches each wave in parallel, collects each invocatio
 ### Step 4e: Apply edits + update JSON (Main Claude responsibility)
 
 For each invocation result:
+- The dispatch was performed by Main Claude in Step 4d using each `invocation.prompt` value verbatim as the Task tool's `prompt` argument and `invocation.agent` as the `subagent_type`. The reviewer's response is `{"file": "...", "edits": [...], "unrepaired"?: [...]}`.
 - For each `edit` in `edits`, call the Edit tool with `file_path = <invocation.file>`, `old_string = edit.old_string`, `new_string = edit.new_string`. If Edit fails (no exact match), capture the error.
 - Build a per-finding outcome map: each `finding_id` is repaired if all its edits applied (best-effort: if the agent returned multiple edits without binding them to specific findings, mark all listed `finding_ids` as repaired iff every edit succeeded). Findings listed in `unrepaired` are marked `repaired: false, repair_error: <reason>`.
 - If the reviewer's response was malformed (not valid JSON, or missing required fields), or the reviewer threw an error, mark all `finding_ids` for that invocation as `repaired: false, repair_error: "reviewer error: <reason>"`.
@@ -496,9 +497,9 @@ Stop. Wait for response.
 If user responds `y`:
 
 1. Read the JSON report `docs/reviews/<review_id>-full-review.json`.
-2. Format findings into the codifier's expected input format. For each finding, emit one row per agent in its `agents` array (the codifier's input schema is singular `agent:`, so multi-agent findings produce multiple rows):
+2. Format findings into the codifier's expected input format. For each finding, emit one row per agent in its `agents` array (the codifier's input schema is singular `agent:`, so multi-agent findings produce multiple rows). The `<agent-id>` placeholder in the template iterates over each finding's `agents[]`:
 ```
-[<severity>] <file>:<line> — <description> — agent: <primary_agent>
+[<severity>] <file>:<line> — <description> — agent: <agent-id>
 ```
 3. Return to Main Claude an instruction to dispatch `pattern-codifier` with the formatted findings list.
 

--- a/.claude/agents/performance-reviewer.md
+++ b/.claude/agents/performance-reviewer.md
@@ -46,6 +46,37 @@ Review only the files passed to you. Do not read the full repo.
 - [ ] Cache hit rate targets: Plant ID 40%, AI generation 80-95%
 - [ ] Cache warming must be triggered on deployment for cold-start prevention
 
+## Output Format (Review Mode)
+
+Return ONLY this JSON structure (no surrounding prose, no markdown fences in the actual response — the example fences below show the schema):
+
+```json
+{
+  "agent": "performance-reviewer",
+  "batch_label": "<batch label received in input>",
+  "findings": [
+    {
+      "severity": "critical|high|medium|low|info",
+      "file": "<relative path from repo root>",
+      "line": 42,
+      "description": "<one sentence — what is wrong>",
+      "rule": "<optional: issue # or pattern doc citation>",
+      "suggested_fix": "<optional: one-liner hint, not the actual edit>"
+    }
+  ]
+}
+```
+
+Severity rules:
+- `critical`: security hole, data loss risk, or production-breaking bug
+- `high`: real bug or pattern violation that will cause issues
+- `medium`: maintainability or correctness concern
+- `low`: nit, stylistic, or minor improvement
+- `info`: notable but not actionable
+
+If you find no issues, return `{"agent": "performance-reviewer", "batch_label": "...", "findings": []}`.
+
+If a checklist item does not apply to any file in the batch, do not emit a finding for it.
 
 ## Pattern References
 

--- a/.claude/agents/performance-reviewer.md
+++ b/.claude/agents/performance-reviewer.md
@@ -87,14 +87,26 @@ If a checklist item does not apply to any file in the batch, do not emit a findi
 
 ## Repair Mode
 
-When invoked with a specific finding:
-1. Read the affected file
-2. Return the minimal fix:
+When invoked with a list of findings to repair in a single file:
+
+1. Read the affected file with the `Read` tool.
+2. Compute the minimal edits that fix all listed findings without changing unrelated code.
+3. Return ONLY this JSON structure (no surrounding prose):
+
 ```json
 {
-  "file": "apps/forum/serializers/post_serializer.py",
-  "old_string": "exact string to replace",
-  "new_string": "replacement string"
+  "file": "<relative path>",
+  "edits": [
+    {"old_string": "<exact string to replace>", "new_string": "<replacement>"},
+    {"old_string": "<exact string to replace>", "new_string": "<replacement>"}
+  ]
 }
 ```
-Do not apply changes yourself.
+
+Rules:
+- Each `old_string` must be unique enough in the file that an exact match replaces only the intended span.
+- Do not apply edits yourself — return them; the orchestrator will apply via the Edit tool.
+- If a finding cannot be repaired safely (ambiguous, requires architectural change), include it in an extra field `"unrepaired": [{"line": N, "reason": "..."}]`.
+- The `edits` array may be empty if all findings land in `unrepaired`.
+
+The single-finding case is just `edits` of length 1.

--- a/.claude/agents/performance-reviewer.md
+++ b/.claude/agents/performance-reviewer.md
@@ -67,6 +67,8 @@ Return ONLY this JSON structure (no surrounding prose, no markdown fences in the
 }
 ```
 
+Each `"line"` value must be the actual 1-based line number in the source file — never copy the example value.
+
 Severity rules:
 - `critical`: security hole, data loss risk, or production-breaking bug
 - `high`: real bug or pattern violation that will cause issues

--- a/.claude/agents/react-typescript-reviewer.md
+++ b/.claude/agents/react-typescript-reviewer.md
@@ -80,6 +80,8 @@ Return ONLY this JSON structure (no surrounding prose, no markdown fences in the
 }
 ```
 
+Each `"line"` value must be the actual 1-based line number in the source file — never copy the example value.
+
 Severity rules:
 - `critical`: security hole, data loss risk, or production-breaking bug
 - `high`: real bug or pattern violation that will cause issues

--- a/.claude/agents/react-typescript-reviewer.md
+++ b/.claude/agents/react-typescript-reviewer.md
@@ -59,6 +59,38 @@ Review only the files passed to you. Do not read the full repo.
 - [ ] Loading and error states required for any component that fetches data
 - [ ] Responsive design: mobile-first Tailwind classes, minimum tap target 44x44px
 
+## Output Format (Review Mode)
+
+Return ONLY this JSON structure (no surrounding prose, no markdown fences in the actual response — the example fences below show the schema):
+
+```json
+{
+  "agent": "react-typescript-reviewer",
+  "batch_label": "<batch label received in input>",
+  "findings": [
+    {
+      "severity": "critical|high|medium|low|info",
+      "file": "<relative path from repo root>",
+      "line": 42,
+      "description": "<one sentence — what is wrong>",
+      "rule": "<optional: issue # or pattern doc citation>",
+      "suggested_fix": "<optional: one-liner hint, not the actual edit>"
+    }
+  ]
+}
+```
+
+Severity rules:
+- `critical`: security hole, data loss risk, or production-breaking bug
+- `high`: real bug or pattern violation that will cause issues
+- `medium`: maintainability or correctness concern
+- `low`: nit, stylistic, or minor improvement
+- `info`: notable but not actionable
+
+If you find no issues, return `{"agent": "react-typescript-reviewer", "batch_label": "...", "findings": []}`.
+
+If a checklist item does not apply to any file in the batch, do not emit a finding for it.
+
 ## Pattern References
 
 - `web/docs/patterns/react-typescript.md`

--- a/.claude/agents/react-typescript-reviewer.md
+++ b/.claude/agents/react-typescript-reviewer.md
@@ -100,14 +100,26 @@ If a checklist item does not apply to any file in the batch, do not emit a findi
 
 ## Repair Mode
 
-When invoked with a specific finding:
-1. Read the affected file
-2. Return the minimal fix:
+When invoked with a list of findings to repair in a single file:
+
+1. Read the affected file with the `Read` tool.
+2. Compute the minimal edits that fix all listed findings without changing unrelated code.
+3. Return ONLY this JSON structure (no surrounding prose):
+
 ```json
 {
-  "file": "web/src/pages/forum/SearchPage.tsx",
-  "old_string": "exact string to replace",
-  "new_string": "replacement string"
+  "file": "<relative path>",
+  "edits": [
+    {"old_string": "<exact string to replace>", "new_string": "<replacement>"},
+    {"old_string": "<exact string to replace>", "new_string": "<replacement>"}
+  ]
 }
 ```
-Do not apply changes yourself.
+
+Rules:
+- Each `old_string` must be unique enough in the file that an exact match replaces only the intended span.
+- Do not apply edits yourself — return them; the orchestrator will apply via the Edit tool.
+- If a finding cannot be repaired safely (ambiguous, requires architectural change), include it in an extra field `"unrepaired": [{"line": N, "reason": "..."}]`.
+- The `edits` array may be empty if all findings land in `unrepaired`.
+
+The single-finding case is just `edits` of length 1.

--- a/.claude/agents/security-reviewer.md
+++ b/.claude/agents/security-reviewer.md
@@ -83,6 +83,8 @@ Return ONLY this JSON structure (no surrounding prose, no markdown fences in the
 }
 ```
 
+Each `"line"` value must be the actual 1-based line number in the source file — never copy the example value.
+
 Severity rules:
 - `critical`: security hole, data loss risk, or production-breaking bug
 - `high`: real bug or pattern violation that will cause issues

--- a/.claude/agents/security-reviewer.md
+++ b/.claude/agents/security-reviewer.md
@@ -104,14 +104,26 @@ If a checklist item does not apply to any file in the batch, do not emit a findi
 
 ## Repair Mode
 
-When invoked with a specific finding:
-1. Read the affected file
-2. Return the minimal fix:
+When invoked with a list of findings to repair in a single file:
+
+1. Read the affected file with the `Read` tool.
+2. Compute the minimal edits that fix all listed findings without changing unrelated code.
+3. Return ONLY this JSON structure (no surrounding prose):
+
 ```json
 {
-  "file": "apps/forum/viewsets/post_viewset.py",
-  "old_string": "exact string to replace",
-  "new_string": "replacement string"
+  "file": "<relative path>",
+  "edits": [
+    {"old_string": "<exact string to replace>", "new_string": "<replacement>"},
+    {"old_string": "<exact string to replace>", "new_string": "<replacement>"}
+  ]
 }
 ```
-Do not apply changes yourself.
+
+Rules:
+- Each `old_string` must be unique enough in the file that an exact match replaces only the intended span.
+- Do not apply edits yourself — return them; the orchestrator will apply via the Edit tool.
+- If a finding cannot be repaired safely (ambiguous, requires architectural change), include it in an extra field `"unrepaired": [{"line": N, "reason": "..."}]`.
+- The `edits` array may be empty if all findings land in `unrepaired`.
+
+The single-finding case is just `edits` of length 1.

--- a/.claude/agents/security-reviewer.md
+++ b/.claude/agents/security-reviewer.md
@@ -62,6 +62,38 @@ Review only the files passed to you. Do not read the full repo. You run in paral
 - [ ] `Ratelimited` exception handler must check `isinstance(exc, Ratelimited)` BEFORE DRF default handler to return HTTP 429 (not 403)
 - [ ] `Retry-After` header must be set on 429 responses
 
+## Output Format (Review Mode)
+
+Return ONLY this JSON structure (no surrounding prose, no markdown fences in the actual response — the example fences below show the schema):
+
+```json
+{
+  "agent": "security-reviewer",
+  "batch_label": "<batch label received in input>",
+  "findings": [
+    {
+      "severity": "critical|high|medium|low|info",
+      "file": "<relative path from repo root>",
+      "line": 42,
+      "description": "<one sentence — what is wrong>",
+      "rule": "<optional: issue # or pattern doc citation>",
+      "suggested_fix": "<optional: one-liner hint, not the actual edit>"
+    }
+  ]
+}
+```
+
+Severity rules:
+- `critical`: security hole, data loss risk, or production-breaking bug
+- `high`: real bug or pattern violation that will cause issues
+- `medium`: maintainability or correctness concern
+- `low`: nit, stylistic, or minor improvement
+- `info`: notable but not actionable
+
+If you find no issues, return `{"agent": "security-reviewer", "batch_label": "...", "findings": []}`.
+
+If a checklist item does not apply to any file in the batch, do not emit a finding for it.
+
 ## Pattern References
 
 - `backend/docs/patterns/security/`

--- a/.claude/agents/test-quality-reviewer.md
+++ b/.claude/agents/test-quality-reviewer.md
@@ -101,14 +101,26 @@ If a checklist item does not apply to any file in the batch, do not emit a findi
 
 ## Repair Mode
 
-When invoked with a specific finding:
-1. Read the affected file
-2. Return the minimal fix:
+When invoked with a list of findings to repair in a single file:
+
+1. Read the affected file with the `Read` tool.
+2. Compute the minimal edits that fix all listed findings without changing unrelated code.
+3. Return ONLY this JSON structure (no surrounding prose):
+
 ```json
 {
-  "file": "apps/forum/tests/test_post_performance.py",
-  "old_string": "exact string to replace",
-  "new_string": "replacement string"
+  "file": "<relative path>",
+  "edits": [
+    {"old_string": "<exact string to replace>", "new_string": "<replacement>"},
+    {"old_string": "<exact string to replace>", "new_string": "<replacement>"}
+  ]
 }
 ```
-Do not apply changes yourself.
+
+Rules:
+- Each `old_string` must be unique enough in the file that an exact match replaces only the intended span.
+- Do not apply edits yourself — return them; the orchestrator will apply via the Edit tool.
+- If a finding cannot be repaired safely (ambiguous, requires architectural change), include it in an extra field `"unrepaired": [{"line": N, "reason": "..."}]`.
+- The `edits` array may be empty if all findings land in `unrepaired`.
+
+The single-finding case is just `edits` of length 1.

--- a/.claude/agents/test-quality-reviewer.md
+++ b/.claude/agents/test-quality-reviewer.md
@@ -81,6 +81,8 @@ Return ONLY this JSON structure (no surrounding prose, no markdown fences in the
 }
 ```
 
+Each `"line"` value must be the actual 1-based line number in the source file — never copy the example value.
+
 Severity rules:
 - `critical`: security hole, data loss risk, or production-breaking bug
 - `high`: real bug or pattern violation that will cause issues

--- a/.claude/agents/test-quality-reviewer.md
+++ b/.claude/agents/test-quality-reviewer.md
@@ -60,6 +60,38 @@ E2E: Playwright, 107 tests
 - [ ] No `act()` warnings left unresolved — they indicate async state update issues
 - [ ] E2E tests for any new user-facing flow added to `web/E2E_TESTING_GUIDE.md`
 
+## Output Format (Review Mode)
+
+Return ONLY this JSON structure (no surrounding prose, no markdown fences in the actual response — the example fences below show the schema):
+
+```json
+{
+  "agent": "test-quality-reviewer",
+  "batch_label": "<batch label received in input>",
+  "findings": [
+    {
+      "severity": "critical|high|medium|low|info",
+      "file": "<relative path from repo root>",
+      "line": 42,
+      "description": "<one sentence — what is wrong>",
+      "rule": "<optional: issue # or pattern doc citation>",
+      "suggested_fix": "<optional: one-liner hint, not the actual edit>"
+    }
+  ]
+}
+```
+
+Severity rules:
+- `critical`: security hole, data loss risk, or production-breaking bug
+- `high`: real bug or pattern violation that will cause issues
+- `medium`: maintainability or correctness concern
+- `low`: nit, stylistic, or minor improvement
+- `info`: notable but not actionable
+
+If you find no issues, return `{"agent": "test-quality-reviewer", "batch_label": "...", "findings": []}`.
+
+If a checklist item does not apply to any file in the batch, do not emit a finding for it.
+
 ## Pattern References
 
 - `backend/docs/patterns/performance/query-optimization.md` (strict assertion section)

--- a/.claude/agents/wagtail-reviewer.md
+++ b/.claude/agents/wagtail-reviewer.md
@@ -80,6 +80,8 @@ Return ONLY this JSON structure (no surrounding prose, no markdown fences in the
 }
 ```
 
+Each `"line"` value must be the actual 1-based line number in the source file — never copy the example value.
+
 Severity rules:
 - `critical`: security hole, data loss risk, or production-breaking bug
 - `high`: real bug or pattern violation that will cause issues

--- a/.claude/agents/wagtail-reviewer.md
+++ b/.claude/agents/wagtail-reviewer.md
@@ -101,14 +101,26 @@ If a checklist item does not apply to any file in the batch, do not emit a findi
 
 ## Repair Mode
 
-When invoked with a specific finding:
-1. Read the affected file
-2. Return the minimal fix:
+When invoked with a list of findings to repair in a single file:
+
+1. Read the affected file with the `Read` tool.
+2. Compute the minimal edits that fix all listed findings without changing unrelated code.
+3. Return ONLY this JSON structure (no surrounding prose):
+
 ```json
 {
-  "file": "apps/blog/signals.py",
-  "old_string": "exact string to replace",
-  "new_string": "replacement string"
+  "file": "<relative path>",
+  "edits": [
+    {"old_string": "<exact string to replace>", "new_string": "<replacement>"},
+    {"old_string": "<exact string to replace>", "new_string": "<replacement>"}
+  ]
 }
 ```
-Do not apply changes yourself.
+
+Rules:
+- Each `old_string` must be unique enough in the file that an exact match replaces only the intended span.
+- Do not apply edits yourself — return them; the orchestrator will apply via the Edit tool.
+- If a finding cannot be repaired safely (ambiguous, requires architectural change), include it in an extra field `"unrepaired": [{"line": N, "reason": "..."}]`.
+- The `edits` array may be empty if all findings land in `unrepaired`.
+
+The single-finding case is just `edits` of length 1.

--- a/.claude/agents/wagtail-reviewer.md
+++ b/.claude/agents/wagtail-reviewer.md
@@ -59,6 +59,38 @@ You review: `apps/blog/`, Wagtail page models, StreamField blocks, signals, Wagt
 **Version Mismatch**
 - [ ] Any code referencing a specific Wagtail version number must note if dev (7.1.2) and prod (7.4) differ
 
+## Output Format (Review Mode)
+
+Return ONLY this JSON structure (no surrounding prose, no markdown fences in the actual response — the example fences below show the schema):
+
+```json
+{
+  "agent": "wagtail-reviewer",
+  "batch_label": "<batch label received in input>",
+  "findings": [
+    {
+      "severity": "critical|high|medium|low|info",
+      "file": "<relative path from repo root>",
+      "line": 42,
+      "description": "<one sentence — what is wrong>",
+      "rule": "<optional: issue # or pattern doc citation>",
+      "suggested_fix": "<optional: one-liner hint, not the actual edit>"
+    }
+  ]
+}
+```
+
+Severity rules:
+- `critical`: security hole, data loss risk, or production-breaking bug
+- `high`: real bug or pattern violation that will cause issues
+- `medium`: maintainability or correctness concern
+- `low`: nit, stylistic, or minor improvement
+- `info`: notable but not actionable
+
+If you find no issues, return `{"agent": "wagtail-reviewer", "batch_label": "...", "findings": []}`.
+
+If a checklist item does not apply to any file in the batch, do not emit a finding for it.
+
 ## Pattern References
 
 - `backend/docs/patterns/domain/wagtail.md`

--- a/.gitignore
+++ b/.gitignore
@@ -199,3 +199,9 @@ existing_implementation/
 existing_implementation/
 design_reference/
 .worktrees
+
+# Full-review per-review artifacts (date-stamped, noisy). Index history committed.
+docs/reviews/*-full-review.md
+docs/reviews/*-full-review.json
+docs/reviews/.*-partial.json
+!docs/reviews/INDEX.md

--- a/docs/reviews/INDEX.md
+++ b/docs/reviews/INDEX.md
@@ -1,0 +1,4 @@
+# Full Review History
+
+| Date | Review ID | Files | Critical | High | Medium | Low | Report |
+|---|---|---|---|---|---|---|---|

--- a/docs/superpowers/plans/2026-05-07-full-review-orchestrator.md
+++ b/docs/superpowers/plans/2026-05-07-full-review-orchestrator.md
@@ -1,0 +1,1378 @@
+# Full-Repo Code Review Orchestrator Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `full-review-orchestrator` agent that performs whole-codebase reviews, produces persistent reports under `docs/reviews/`, and drives a filter-based repair phase using the existing domain reviewer fleet.
+
+**Architecture:** A new `.claude/agents/full-review-orchestrator.md` agent enumerates active source files, batches by app/feature folder, dispatches all 11 domain reviewers in waves, aggregates JSON findings, writes a markdown + JSON report, and drives an opt-in repair phase. The 11 existing reviewer agent files get a one-time JSON-output contract update; the existing incremental `code-review-orchestrator` is updated to consume the same JSON shape so both orchestrators share the reviewer fleet.
+
+**Tech Stack:** Markdown-based Claude Code agents. No code, no test framework — verification is live agent invocation. Bash + Git for file enumeration. Reports are markdown + JSON files. The orchestrator is a `model: haiku` glue agent; reviewers stay on their existing models.
+
+**Spec:** `docs/superpowers/specs/2026-05-06-full-review-orchestrator-design.md`
+
+---
+
+## File Structure
+
+### Files to create
+| Path | Responsibility |
+|---|---|
+| `.claude/agents/full-review-orchestrator.md` | New orchestrator agent — Phases 0-5, routing table, filter parser spec |
+| `docs/reviews/INDEX.md` | Running history of full reviews (committed) |
+
+### Files to modify
+| Path | Change |
+|---|---|
+| `.claude/agents/django-drf-reviewer.md` | Add JSON output format to Review Mode; extend Repair Mode to multi-edit |
+| `.claude/agents/wagtail-reviewer.md` | Same |
+| `.claude/agents/react-typescript-reviewer.md` | Same |
+| `.claude/agents/flutter-dart-reviewer.md` | Same |
+| `.claude/agents/flutter-firebase-reviewer.md` | Same |
+| `.claude/agents/firebase-cloudfunction-reviewer.md` | Same |
+| `.claude/agents/celery-async-reviewer.md` | Same |
+| `.claude/agents/api-design-reviewer.md` | Same |
+| `.claude/agents/security-reviewer.md` | Same |
+| `.claude/agents/performance-reviewer.md` | Same |
+| `.claude/agents/test-quality-reviewer.md` | Same |
+| `.claude/agents/code-review-orchestrator.md` | Phase 2 dedupe consumes new JSON shape |
+| `.gitignore` | Exclude per-review artifacts; keep `INDEX.md` |
+
+### Verification approach (no traditional tests)
+
+For each task that changes a reviewer or orchestrator prompt, verification is **dispatching the agent on a sample input via the Task tool and reading the returned message** to confirm:
+1. The output is valid JSON (no surrounding prose).
+2. The output matches the schema specified in the spec.
+3. For orchestrator phases, the returned data drives the next phase correctly.
+
+A small, real subdirectory (`backend/apps/users/`) is used as the smoke-test target throughout.
+
+---
+
+## Task 1: Add JSON output contract to all 11 review-mode reviewers
+
+**Files:**
+- Modify: `.claude/agents/django-drf-reviewer.md` (insert after `## Review Mode — Checklist` section, before `## Pattern References`)
+- Modify: `.claude/agents/wagtail-reviewer.md` (same insertion point)
+- Modify: `.claude/agents/react-typescript-reviewer.md` (same)
+- Modify: `.claude/agents/flutter-dart-reviewer.md` (same)
+- Modify: `.claude/agents/flutter-firebase-reviewer.md` (same)
+- Modify: `.claude/agents/firebase-cloudfunction-reviewer.md` (same)
+- Modify: `.claude/agents/celery-async-reviewer.md` (same)
+- Modify: `.claude/agents/api-design-reviewer.md` (same)
+- Modify: `.claude/agents/security-reviewer.md` (same)
+- Modify: `.claude/agents/performance-reviewer.md` (same)
+- Modify: `.claude/agents/test-quality-reviewer.md` (same)
+
+**Insertion template (apply to every reviewer file, adjusting the `agent` value):**
+
+```markdown
+## Output Format (Review Mode)
+
+Return ONLY this JSON structure (no surrounding prose, no markdown fences in the actual response — the example fences below show the schema):
+
+```json
+{
+  "agent": "<REVIEWER-ID>",
+  "batch_label": "<batch label received in input>",
+  "findings": [
+    {
+      "severity": "critical|high|medium|low|info",
+      "file": "<relative path from repo root>",
+      "line": 42,
+      "description": "<one sentence — what is wrong>",
+      "rule": "<optional: issue # or pattern doc citation>",
+      "suggested_fix": "<optional: one-liner hint, not the actual edit>"
+    }
+  ]
+}
+```
+
+Severity rules:
+- `critical`: security hole, data loss risk, or production-breaking bug
+- `high`: real bug or pattern violation that will cause issues
+- `medium`: maintainability or correctness concern
+- `low`: nit, stylistic, or minor improvement
+- `info`: notable but not actionable
+
+If you find no issues, return `{"agent": "<REVIEWER-ID>", "batch_label": "...", "findings": []}`.
+
+If a checklist item does not apply to any file in the batch, do not emit a finding for it.
+```
+
+The `<REVIEWER-ID>` value for each file:
+
+| File | Value to substitute |
+|---|---|
+| `django-drf-reviewer.md` | `django-drf-reviewer` |
+| `wagtail-reviewer.md` | `wagtail-reviewer` |
+| `react-typescript-reviewer.md` | `react-typescript-reviewer` |
+| `flutter-dart-reviewer.md` | `flutter-dart-reviewer` |
+| `flutter-firebase-reviewer.md` | `flutter-firebase-reviewer` |
+| `firebase-cloudfunction-reviewer.md` | `firebase-cloudfunction-reviewer` |
+| `celery-async-reviewer.md` | `celery-async-reviewer` |
+| `api-design-reviewer.md` | `api-design-reviewer` |
+| `security-reviewer.md` | `security-reviewer` |
+| `performance-reviewer.md` | `performance-reviewer` |
+| `test-quality-reviewer.md` | `test-quality-reviewer` |
+
+- [ ] **Step 1: Apply insertion to `django-drf-reviewer.md`**
+
+Use Edit. Locate the line `## Pattern References` and insert the template above (with `<REVIEWER-ID>` replaced by `django-drf-reviewer`) directly before it, separated by a blank line.
+
+- [ ] **Step 2: Apply insertion to the remaining 10 reviewer files**
+
+Apply the same insertion to each of:
+- `wagtail-reviewer.md`
+- `react-typescript-reviewer.md`
+- `flutter-dart-reviewer.md`
+- `flutter-firebase-reviewer.md`
+- `firebase-cloudfunction-reviewer.md`
+- `celery-async-reviewer.md`
+- `api-design-reviewer.md`
+- `security-reviewer.md`
+- `performance-reviewer.md`
+- `test-quality-reviewer.md`
+
+For each file, locate `## Pattern References` and insert the template directly before it. If a reviewer file has no `## Pattern References` section, insert before `## Repair Mode` instead.
+
+- [ ] **Step 3: Verify each file has the new section**
+
+Run:
+```bash
+grep -l "## Output Format (Review Mode)" .claude/agents/*-reviewer.md | wc -l
+```
+Expected output: `11`
+
+- [ ] **Step 4: Verify the agent ID is correct in each**
+
+Run:
+```bash
+for f in .claude/agents/*-reviewer.md; do
+  agent_id=$(basename "$f" .md)
+  if ! grep -q "\"agent\": \"$agent_id\"" "$f"; then
+    echo "MISMATCH in $f"
+  fi
+done
+```
+Expected output: empty (no mismatches printed).
+
+- [ ] **Step 5: Smoke test — dispatch one reviewer and verify JSON output**
+
+Dispatch `security-reviewer` via the Task tool with this prompt:
+```
+Review these files. Report findings only for the files listed.
+
+Batch label: smoke-test (security-reviewer)
+Files:
+  - backend/apps/users/auth_service.py
+```
+Expected: response is a JSON object starting with `{"agent": "security-reviewer", "batch_label": "smoke-test"`. The `findings` array may be empty or non-empty — both are valid.
+
+Failure: response is prose, not JSON, or wraps the JSON in markdown fences with extra text.
+
+If failure, re-read the inserted Output Format section in `security-reviewer.md` and refine wording until JSON is returned reliably.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add .claude/agents/*-reviewer.md
+git commit -m "$(cat <<'EOF'
+feat(agents): add JSON output contract to all review-mode reviewers
+
+Adds a standardized "## Output Format (Review Mode)" section to each of
+the 11 domain reviewer agents. Findings are returned as structured JSON
+instead of prose, enabling reliable aggregation in both incremental and
+full-repo orchestrators.
+
+EOF
+)"
+```
+
+---
+
+## Task 2: Extend repair-mode contract to multi-edit per file
+
+**Files:**
+- Modify: `.claude/agents/django-drf-reviewer.md` (replace `## Repair Mode` body)
+- Modify: All 10 other reviewer files (same change)
+
+**Replacement template for `## Repair Mode` body (applies to every reviewer):**
+
+```markdown
+## Repair Mode
+
+When invoked with a list of findings to repair in a single file:
+
+1. Read the affected file with the `Read` tool.
+2. Compute the minimal edits that fix all listed findings without changing unrelated code.
+3. Return ONLY this JSON structure (no surrounding prose):
+
+```json
+{
+  "file": "<relative path>",
+  "edits": [
+    {"old_string": "<exact string to replace>", "new_string": "<replacement>"},
+    {"old_string": "<exact string to replace>", "new_string": "<replacement>"}
+  ]
+}
+```
+
+Rules:
+- Each `old_string` must be unique enough in the file that an exact match replaces only the intended span.
+- Do not apply edits yourself — return them; the orchestrator will apply via the Edit tool.
+- If a finding cannot be repaired safely (ambiguous, requires architectural change), include it in an extra field `"unrepaired": [{"line": N, "reason": "..."}]`.
+- The `edits` array may be empty if all findings land in `unrepaired`.
+
+The single-finding case is just `edits` of length 1.
+```
+
+- [ ] **Step 1: Update `django-drf-reviewer.md`**
+
+Use Edit. The current `## Repair Mode` section is:
+
+```markdown
+## Repair Mode
+
+When invoked with a specific finding to repair:
+1. Read the affected file with the `Read` tool
+2. Identify the minimal code change that fixes the issue
+3. Return exactly this structure (no prose):
+```json
+{
+  "file": "apps/forum/viewsets/post_viewset.py",
+  "old_string": "exact string to replace",
+  "new_string": "replacement string"
+}
+```
+Do not apply the change yourself.
+```
+
+Replace the entire `## Repair Mode` section (from the heading line through the final "Do not apply the change yourself.") with the replacement template above.
+
+- [ ] **Step 2: Update the remaining 10 reviewer files**
+
+For each of the other 10 reviewer files, replace the `## Repair Mode` section with the same template. The exact pre-existing text varies slightly per file but always starts with `## Repair Mode` and ends with `Do not apply the change yourself.` or similar. Replace the whole section.
+
+- [ ] **Step 3: Verify all 11 files have the new shape**
+
+Run:
+```bash
+grep -l '"edits":' .claude/agents/*-reviewer.md | wc -l
+```
+Expected: `11`
+
+Run:
+```bash
+grep -L '"edits":' .claude/agents/*-reviewer.md
+```
+Expected: empty (no files missing the new schema).
+
+- [ ] **Step 4: Smoke test — dispatch a reviewer in repair mode**
+
+First, identify a known issue. Open `backend/apps/forum/viewsets/post_viewset.py` (or any backend Python file) and pick a real-looking line for the test. Dispatch `django-drf-reviewer` with this prompt:
+
+```
+Repair the following findings in this file:
+
+File: backend/apps/forum/viewsets/post_viewset.py
+Findings:
+  - line 1: hypothetical missing import for testing repair-mode JSON output shape
+```
+
+Expected: response is JSON of shape `{"file": "...", "edits": [...]}` (or with `unrepaired` populated if the agent decides the finding can't be repaired). Either is valid — what matters is the JSON shape.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .claude/agents/*-reviewer.md
+git commit -m "$(cat <<'EOF'
+feat(agents): extend reviewer repair mode to multi-edit per file
+
+Repair-mode contract now accepts a list of findings for one file and
+returns an "edits" array, enabling per-file repair dispatch in the
+full-review-orchestrator. Single-finding cases continue to work as
+"edits" of length 1.
+
+EOF
+)"
+```
+
+---
+
+## Task 3: Update incremental orchestrator (Phase 2 dedupe) to consume JSON findings
+
+**Files:**
+- Modify: `.claude/agents/code-review-orchestrator.md` (replace `## Phase 2 — Present Findings` section)
+
+The existing Phase 2 says "deduplicate by (file + line + issue)." Now that reviewers return JSON, the orchestrator should consume that shape.
+
+**Replacement for `## Phase 2 — Present Findings`:**
+
+```markdown
+## Phase 2 — Present Findings
+
+After main Claude collects findings JSON from each dispatched reviewer (each result is `{"agent": "...", "batch_label": "...", "findings": [...]}`), merge all `findings` arrays. Deduplicate by `(file, line, normalized_description)` where `normalized_description` is lowercase + whitespace-collapsed. When two findings collapse, keep both agent IDs in an `agents` array on the merged finding.
+
+Sort merged findings by severity (critical → info), then by file, then by line.
+
+Present:
+
+```
+## Code Review — YYYY-MM-DD
+
+### 🔴 CRITICAL (n)
+1. file:line — description — agents: [list]
+
+### 🟠 HIGH (n)
+...
+
+### 🟡 MEDIUM (n)
+...
+
+### 🟢 LOW / INFO (n) → will be written to todos/
+...
+
+Repair CRITICAL + HIGH + MEDIUM findings? (yes / no / select numbers)
+```
+```
+
+- [ ] **Step 1: Apply edit to `code-review-orchestrator.md`**
+
+Use Edit. Replace the entire `## Phase 2 — Present Findings` section (from that heading through the closing triple backtick of its presentation template) with the replacement above.
+
+- [ ] **Step 2: Verify the orchestrator now references JSON shape**
+
+Run:
+```bash
+grep -A2 "Phase 2 — Present Findings" .claude/agents/code-review-orchestrator.md
+```
+Expected output includes the phrase `findings JSON from each dispatched reviewer`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .claude/agents/code-review-orchestrator.md
+git commit -m "$(cat <<'EOF'
+refactor(agents): code-review-orchestrator consumes JSON findings
+
+Phase 2 dedupe now reads the structured JSON returned by reviewers
+(rather than prose). Merges agents arrays when two reviewers report
+the same (file, line, normalized_description).
+
+EOF
+)"
+```
+
+---
+
+## Task 4: End-to-end verify the incremental orchestrator still works
+
+This is a verification-only task — no edits. Confirms the JSON contract change didn't break the existing flow before we build on top of it.
+
+- [ ] **Step 1: Make a trivial code change to trigger the orchestrator**
+
+Create a throwaway change. Pick an existing Python file in `backend/apps/users/` and add a no-op blank line. Stage but do not commit:
+
+```bash
+echo "" >> backend/apps/users/auth_service.py
+git add -N backend/apps/users/auth_service.py
+git diff --name-only HEAD
+```
+
+Expected output includes `backend/apps/users/auth_service.py`.
+
+- [ ] **Step 2: Invoke the incremental orchestrator**
+
+Use the Task tool to dispatch `code-review-orchestrator` with the description "Run incremental review on staged change." No additional prompt — the agent reads `git diff` itself.
+
+Expected: orchestrator returns Phase 1 JSON listing `agents_to_invoke` (e.g., `django-drf-reviewer`, `performance-reviewer`).
+
+- [ ] **Step 3: Dispatch the listed reviewers**
+
+For each agent in `agents_to_invoke`, dispatch it via the Task tool with the prompt format from Task 1 Step 5 (Batch label + Files). Collect each JSON response.
+
+Expected: every reviewer returns valid JSON of shape `{"agent": "...", "findings": [...]}`. No prose responses, no markdown fences leaking outside JSON.
+
+- [ ] **Step 4: Re-invoke orchestrator with collected findings**
+
+Pass the array of reviewer outputs back to `code-review-orchestrator` for Phase 2 presentation.
+
+Expected: orchestrator returns severity-grouped findings listing with `agents:` arrays correctly merged.
+
+- [ ] **Step 5: Revert the throwaway change**
+
+```bash
+git restore --staged backend/apps/users/auth_service.py
+git checkout -- backend/apps/users/auth_service.py
+```
+
+- [ ] **Step 6: No commit required (verification only)**
+
+If any verification step failed, return to Tasks 1-3 and refine the contract specifications until the smoke test passes.
+
+---
+
+## Task 5: Create `full-review-orchestrator.md` skeleton + Phase 0
+
+**Files:**
+- Create: `.claude/agents/full-review-orchestrator.md`
+
+- [ ] **Step 1: Write the skeleton with frontmatter and Phase 0**
+
+Create `.claude/agents/full-review-orchestrator.md` with this content:
+
+```markdown
+---
+name: full-review-orchestrator
+description: Orchestrates a full-repository code review. Enumerates every active source file, batches by app/feature, dispatches all domain reviewers in waves, produces a persistent report under docs/reviews/, and drives an optional repair phase via filter expressions. Coexists with code-review-orchestrator (incremental); neither replaces the other.
+
+<example>
+Context: User wants a comprehensive audit of the entire codebase
+user: "Run a full review of the codebase"
+assistant: "I'll use the full-review-orchestrator to enumerate active source files, dispatch all domain reviewers in waves, and produce a persistent report."
+<commentary>
+Use this orchestrator when the user wants a whole-codebase audit. For incremental reviews of recent changes, use code-review-orchestrator instead.
+</commentary>
+</example>
+
+model: haiku
+color: purple
+tools: Bash, Read, Glob, Grep, Write
+---
+
+You are the full-repository code review orchestrator for the plant_id_community project. You enumerate active source files, plan batched review waves, aggregate findings into a persistent report, and drive an optional repair phase. You hold zero pattern knowledge — all quality logic lives in the domain reviewers.
+
+This agent runs in **six phases**. You are re-invoked between phases by Main Claude. Each phase identifies itself in its first line.
+
+## Phase 0 — Confirm Scope
+
+Run on first invocation when there is no existing partial review for today.
+
+1. Enumerate the candidate roots from this list (skip any that do not exist on disk):
+   - `backend/apps`
+   - `web/src`
+   - `plant_community_mobile/lib`
+   - `firebase`
+   - `functions`
+
+2. Check disk:
+```bash
+for dir in backend/apps web/src plant_community_mobile/lib firebase functions; do
+  [ -d "$dir" ] && echo "$dir"
+done
+```
+
+3. Estimate batch count by counting top-level subfolders in each present root:
+```bash
+ls -1d backend/apps/*/ web/src/*/ plant_community_mobile/lib/*/ 2>/dev/null | wc -l
+```
+Multiply by ~2.5 (the average number of reviewers per batch given cross-cutting agents).
+
+4. Compute reviewers that will be skipped because their gating root is missing:
+   - `firebase/` missing → skip `firebase-cloudfunction-reviewer` (functions also lives separately) and the `flutter-firebase-reviewer` rule for `firebase/**`
+   - `functions/` missing → skip `firebase-cloudfunction-reviewer`
+   - `plant_community_mobile/lib/` missing → skip `flutter-dart-reviewer`, `flutter-firebase-reviewer`
+   - `web/src/` missing → skip `react-typescript-reviewer`
+   - `backend/apps/` missing → skip `django-drf-reviewer`, `wagtail-reviewer`, `celery-async-reviewer`, `api-design-reviewer`, `performance-reviewer`, `security-reviewer` (when only firing for backend)
+
+5. Print this prompt to Main Claude:
+
+```
+Full review starting:
+  Roots: <comma-separated list of present roots>
+  Excluded: existing_implementation/, docs/archive/, **/migrations/, vendor (node_modules, .venv, dist, build, __pycache__), generated (*.g.dart, *.freezed.dart, *_pb2.py, .next/, coverage/, .dart_tool/)
+  Skipped reviewers (no matching root): <comma-separated list, or "none">
+  Estimated batches: <N> across <K> reviewers (≈ <waves> waves of 8)
+Proceed? (yes / no / edit-roots)
+```
+
+6. If estimated batch count exceeds 100, append a second prompt:
+```
+This is a large review (<N> invocations across <waves> waves). Proceed? (yes / scope-down / cancel)
+```
+
+Then stop. Wait for Main Claude to return with the user's response and re-invoke you for Phase 1.
+```
+
+- [ ] **Step 2: Verify the file is well-formed**
+
+Run:
+```bash
+head -20 .claude/agents/full-review-orchestrator.md
+```
+Expected: shows the frontmatter (`name:`, `description:`, `<example>`, `model:`, `color:`, `tools:`) and start of the body.
+
+- [ ] **Step 3: Smoke test Phase 0**
+
+Dispatch `full-review-orchestrator` via the Task tool with the prompt: `Run Phase 0 — confirm scope.`
+
+Expected: agent emits the "Full review starting:" block listing real roots from the repo, an estimated batch count, and asks "Proceed?".
+
+If output is missing pieces or includes pattern-knowledge not in the agent file, refine the Phase 0 wording.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .claude/agents/full-review-orchestrator.md
+git commit -m "$(cat <<'EOF'
+feat(agents): add full-review-orchestrator skeleton with Phase 0
+
+New agent for whole-codebase reviews. Phase 0 confirms scope by
+enumerating present source roots, estimating batch count, and gating
+on cost (extra confirmation when >100 invocations).
+
+EOF
+)"
+```
+
+---
+
+## Task 6: Add Phase 1 (planning + wave plan JSON) to the new orchestrator
+
+**Files:**
+- Modify: `.claude/agents/full-review-orchestrator.md` (append after Phase 0)
+
+- [ ] **Step 1: Append Phase 1 section**
+
+Append to `.claude/agents/full-review-orchestrator.md`:
+
+```markdown
+
+## Phase 1 — Plan
+
+Triggered when Main Claude returns with the user's "yes" response to Phase 0.
+
+1. Generate a `review_id` of the form `YYYY-MM-DD-HHMM` from the current date and time:
+```bash
+date -u +"%Y-%m-%d-%H%M"
+```
+
+2. Enumerate all candidate files via:
+```bash
+git ls-files --cached --others --exclude-standard
+```
+
+3. Filter the file list — keep only paths under one of the confirmed roots, drop any path matching:
+   - `existing_implementation/`
+   - `docs/archive/`
+   - `**/migrations/**`
+   - `**/__pycache__/**`
+   - `**/node_modules/**`
+   - `**/.venv/**`
+   - `**/dist/**`
+   - `**/build/**`
+   - `**/.next/**`
+   - `**/coverage/**`
+   - `**/.dart_tool/**`
+   - `*.g.dart`
+   - `*.freezed.dart`
+   - `*_pb2.py`
+
+4. Apply the routing table to compute, for each file, its `primary_agent` and the list of `secondary_agents` that also review it.
+
+### Routing Table
+
+| Path pattern | Reviewer | Primary? |
+|---|---|---|
+| `backend/apps/<app>/**/*.py` not matching wagtail predicate | `django-drf-reviewer` | ✓ |
+| `backend/apps/blog/**` OR `.py` matching `import wagtail|from wagtail|class.*Page` | `wagtail-reviewer` | ✓ (overrides django) |
+| `backend/apps/<app>/**/tasks.py`, `**/celery*.py`, `**/beat*.py` | `celery-async-reviewer` | secondary |
+| `backend/apps/<app>/**/serializers.py`, `**/api/**` | `api-design-reviewer` | secondary |
+| `backend/apps/<app>/**/permissions.py`, `**/auth*.py`, `**/upload*.py`, `**/*token*.py`, `**/*secret*.py` | `security-reviewer` | secondary |
+| `backend/apps/<app>/**/tests/**`, `**/test_*.py` | `test-quality-reviewer` | ✓ for test files |
+| `backend/apps/<app>/**/*.py` (any) | `performance-reviewer` | secondary |
+| `web/src/<feature>/**/*.{ts,tsx}` | `react-typescript-reviewer` | ✓ |
+| `web/src/**/*.test.{ts,tsx}` | `test-quality-reviewer` | secondary |
+| `plant_community_mobile/lib/<feature>/**/*.dart` | `flutter-dart-reviewer` | ✓ |
+| `plant_community_mobile/lib/**/firebase*.dart`, `**/auth*.dart` | `flutter-firebase-reviewer` | secondary |
+| `firebase/**`, `*.rules` | `flutter-firebase-reviewer` (primary), `security-reviewer` | flutter-firebase ✓ |
+| `functions/**/*.{js,ts}` | `firebase-cloudfunction-reviewer` | ✓ |
+
+The wagtail predicate runs as:
+```bash
+grep -l "import wagtail\|from wagtail\|class.*Page" <candidate-py-files>
+```
+
+5. Group files into batches:
+   - Backend: one batch per Django app (subdirs of `backend/apps/`)
+   - Web: one batch per top-level subfolder of `web/src/`
+   - Mobile: one batch per top-level subfolder of `plant_community_mobile/lib/`
+   - Firebase: one batch covering all of `firebase/`
+   - Functions: one batch per subdirectory of `functions/`
+
+6. For each (batch, reviewer) pair, emit one invocation. A single batch produces multiple invocations (e.g., `apps/forum` → django-drf-reviewer + performance-reviewer + maybe security-reviewer + maybe celery-async-reviewer).
+
+7. Group invocations into waves of `wave_size` (default 8, configurable via the user invocation).
+
+8. Return ONLY this JSON (no prose):
+
+```json
+{
+  "review_id": "2026-05-07-1430",
+  "started_at": "<ISO 8601>",
+  "scope": {
+    "roots": ["..."],
+    "excluded": ["existing_implementation/", "docs/archive/", "**/migrations/", "**/__pycache__/", "**/node_modules/", "**/.venv/", "**/dist/", "**/build/", "**/.next/", "**/coverage/", "**/.dart_tool/", "*.g.dart", "*.freezed.dart", "*_pb2.py"]
+  },
+  "primary_map": {
+    "<file path>": "<primary agent id>"
+  },
+  "total_invocations": 34,
+  "wave_size": 8,
+  "waves": [
+    {
+      "wave": 1,
+      "invocations": [
+        {
+          "agent": "django-drf-reviewer",
+          "batch_label": "apps/forum",
+          "files": ["backend/apps/forum/viewsets/post_viewset.py", "backend/apps/forum/serializers.py"]
+        }
+      ]
+    }
+  ]
+}
+```
+
+`primary_map` is included so Phase 4 (repair) can compute the primary agent per file without re-running routing.
+
+Then stop. Main Claude dispatches each wave's invocations in parallel via the Task tool, collects JSON results, checkpoints to `docs/reviews/.<review_id>-partial.json` after each wave, and re-invokes you for Phase 3 once all waves complete.
+```
+
+- [ ] **Step 2: Smoke test Phase 1 on a small subtree**
+
+Dispatch `full-review-orchestrator` with: `Run Phase 1 — plan. Limit roots to backend/apps/users only for this smoke test.`
+
+Expected: agent returns valid JSON with `waves` array. Each invocation has a real `agent` ID, a real `batch_label` like `apps/users`, and a `files` array of real Python files.
+
+If the JSON is malformed or `primary_map` is missing keys for files in `waves[].invocations[].files`, refine the Phase 1 wording.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .claude/agents/full-review-orchestrator.md
+git commit -m "$(cat <<'EOF'
+feat(agents): full-review-orchestrator Phase 1 — wave planning
+
+Phase 1 enumerates files (git ls-files --cached --others
+--exclude-standard), filters by exclusion patterns, assigns
+primary/secondary agents via the routing table, batches by
+app/feature folder, and emits a wave plan JSON with primary_map
+included so the repair phase can dispatch per-file without
+re-routing.
+
+EOF
+)"
+```
+
+---
+
+## Task 7: Document Phase 2 dispatch instructions for Main Claude
+
+Phase 2 is Main Claude's responsibility — the orchestrator doesn't run during it — but the orchestrator file must include instructions so any caller knows what to do between Phase 1 and Phase 3.
+
+**Files:**
+- Modify: `.claude/agents/full-review-orchestrator.md` (append Phase 2 section)
+
+- [ ] **Step 1: Append Phase 2 section**
+
+Append to `.claude/agents/full-review-orchestrator.md`:
+
+```markdown
+
+## Phase 2 — Dispatch Waves (Main Claude responsibility)
+
+This phase does not invoke this agent. Main Claude executes it directly using the wave plan from Phase 1.
+
+For each wave in `waves`, in order:
+
+1. Dispatch every invocation in that wave **in parallel** via the Task tool. The dispatch prompt for each invocation:
+
+```
+Review these files. Report findings only for the files listed.
+
+Batch label: <invocation.batch_label> (<invocation.agent>)
+Files:
+  - <invocation.files[0]>
+  - <invocation.files[1]>
+  ...
+```
+
+2. Collect each reviewer's JSON response. Validate that each response is valid JSON matching `{"agent": "...", "batch_label": "...", "findings": [...]}`. If a response is invalid:
+   - Record `{"agent": "<id>", "batch_label": "<label>", "status": "failed", "error": "<reason>"}` in a `failed_invocations` list.
+   - Continue with the rest of the wave; do not block.
+
+3. After all invocations in the wave finish, append the collected findings + failed_invocations to a checkpoint file:
+```
+docs/reviews/.<review_id>-partial.json
+```
+
+   The checkpoint file shape (carries forward Phase 1 state so Phase 3 has everything it needs):
+```json
+{
+  "review_id": "<id>",
+  "started_at": "<ISO from Phase 1>",
+  "scope": { "roots": ["..."], "excluded": ["..."] },
+  "primary_map": { "<file>": "<agent>" },
+  "wave_size": 8,
+  "total_invocations": 34,
+  "completed_waves": [1, 2, 3],
+  "findings": [/* flat list of all findings collected so far */],
+  "failed_invocations": [/* list of failed invocation records */]
+}
+```
+
+   Use the Write tool to overwrite the checkpoint after each wave (last writer wins; the checkpoint always contains the cumulative state). The first wave's checkpoint copies `review_id`, `started_at`, `scope`, `primary_map`, `wave_size`, `total_invocations` from the Phase 1 plan output and initializes `findings` and `failed_invocations` as accumulating arrays.
+
+4. Print a one-line progress update to the user:
+```
+Wave 3/5 complete — 47 new findings (12 critical, 18 high, 14 medium, 3 low)
+```
+
+5. Continue to the next wave.
+
+After the final wave, re-invoke `full-review-orchestrator` for Phase 3 with the path to the checkpoint file (`docs/reviews/.<review_id>-partial.json`) — Phase 3 reads it directly and has all the carried-forward state.
+
+### Resume after interruption
+
+If the user re-invokes the orchestrator and a `.<review_id>-partial.json` file already exists:
+- The orchestrator (during a re-run of Phase 0) detects the partial and prompts: `Found partial review from <review_id> (waves <X> of <Y> complete). Resume? (y/n/restart)`.
+- On `y`, skip waves already in `completed_waves`, dispatch only the remaining waves.
+- On `restart`, delete the partial and re-plan from Phase 0.
+```
+
+- [ ] **Step 2: Smoke test the documented dispatch flow**
+
+Using the wave plan JSON returned from Task 6 Step 2, manually execute Phase 2 on the small smoke-test subtree:
+- Dispatch each invocation in wave 1 in parallel via the Task tool.
+- Validate each response is JSON of the expected shape.
+- Write the checkpoint file `docs/reviews/.<review_id>-partial.json`.
+
+Expected: every reviewer returns valid JSON; checkpoint file exists with the expected shape; counts in the progress line match reality.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .claude/agents/full-review-orchestrator.md
+git commit -m "$(cat <<'EOF'
+feat(agents): full-review-orchestrator Phase 2 — dispatch + checkpoint
+
+Documents the Main Claude responsibility between Phase 1 (planning)
+and Phase 3 (aggregation): parallel wave dispatch, JSON validation,
+incremental checkpointing to .<review_id>-partial.json, progress
+reporting, and resume-after-interruption.
+
+EOF
+)"
+```
+
+---
+
+## Task 8: Add Phase 3 (aggregate + write artifacts)
+
+**Files:**
+- Modify: `.claude/agents/full-review-orchestrator.md` (append Phase 3 section)
+- Create: `docs/reviews/INDEX.md` (initial empty index)
+
+- [ ] **Step 1: Create the initial INDEX.md**
+
+Run:
+```bash
+mkdir -p docs/reviews
+```
+
+Use Write to create `docs/reviews/INDEX.md`:
+
+```markdown
+# Full Review History
+
+| Date | Review ID | Files | Critical | High | Medium | Low | Report |
+|---|---|---|---|---|---|---|---|
+```
+
+- [ ] **Step 2: Append Phase 3 section to the orchestrator**
+
+Append to `.claude/agents/full-review-orchestrator.md`:
+
+```markdown
+
+## Phase 3 — Aggregate and Write Artifacts
+
+Triggered when Main Claude re-invokes you with the path to `docs/reviews/.<review_id>-partial.json` from Phase 2.
+
+Read the partial checkpoint with the Read tool. It contains: `review_id`, `started_at`, `scope`, `primary_map`, `findings`, `failed_invocations`. All the state Phase 3 needs is in this file.
+
+1. **Deduplicate findings** by `(file, line, normalized_description)` where `normalized_description` is the description lowercased with whitespace collapsed. When two findings collapse, merge their `agent` fields into an `agents` array (preserving both).
+
+2. **Assign IDs**: after dedupe + sort, assign each finding a 1-indexed integer `id`. IDs are stable for this review and are what the repair filter language (`ids:1,4,7-12`) selects against.
+
+3. **Compute primary_agent per finding** using the `primary_map` from the checkpoint. If a file is missing from `primary_map` (shouldn't happen, but defensive), re-derive by re-running the routing table for that file.
+
+4. **Sort** by severity (critical → high → medium → low → info), then by file (lexicographic), then by line (ascending).
+
+5. **Apply severity coercion**:
+   - `blocker` → `critical`
+   - any other non-canonical value → `info`, and log a warning entry in the report's footer.
+
+6. **Compute stats**:
+   - `files_reviewed`: count of distinct files appearing across all invocations (the union of `invocation.files`)
+   - `reviewers_invoked`: count of distinct `agent` IDs across all invocations (failed or successful)
+   - `total_findings`: length of deduped findings list
+   - `by_severity`: counts per canonical severity
+
+7. **Write `docs/reviews/<review_id>-full-review.json`** using Write:
+
+```json
+{
+  "review_id": "<id>",
+  "started_at": "<ISO from Phase 1>",
+  "completed_at": "<ISO now>",
+  "scope": { "roots": [...], "excluded": [...] },
+  "stats": { "files_reviewed": N, "reviewers_invoked": M, "total_findings": K, "by_severity": {...} },
+  "findings": [
+    {
+      "id": 1,
+      "severity": "critical",
+      "file": "<path>",
+      "line": 42,
+      "description": "...",
+      "rule": "<optional>",
+      "suggested_fix": "<optional>",
+      "agents": ["django-drf-reviewer", "security-reviewer"],
+      "primary_agent": "django-drf-reviewer",
+      "repaired": false,
+      "repaired_at": null,
+      "repair_error": null
+    }
+  ],
+  "failed_invocations": [...]
+}
+```
+
+8. **Write `docs/reviews/<review_id>-full-review.md`** using Write. Format:
+
+```markdown
+# Full Code Review — <human-readable date>
+
+**Scope:** <comma-separated roots>
+**Files reviewed:** <stats.files_reviewed>
+**Reviewers invoked:** <stats.reviewers_invoked>
+**Total findings:** <stats.total_findings> (<by_severity rendered as comma list>)
+
+---
+
+## 🔴 Critical (<count>)
+
+<for each critical finding, grouped by file>
+### <file>:<line>
+**Finding:** <description>
+**Reviewer:** <agents joined with ' · '>
+**Rule:** <rule or "—">
+**Suggested fix:** <suggested_fix or "—">
+
+---
+
+## 🟠 High (<count>)
+<same shape as critical>
+
+## 🟡 Medium (<count>)
+<same shape>
+
+## 🟢 Low / Info (<count>)
+<abbreviated: file:line — description>
+
+## ⚠️ Failed Invocations (<count>)
+<only if non-zero. Format: agent · batch_label — error>
+```
+
+9. **Prepend a row to `docs/reviews/INDEX.md`**: read the existing file with Read, insert the new row directly after the table header line (the `|---|...` separator), and write back with Write.
+
+   New row format:
+```
+| <YYYY-MM-DD HH:MM> | <review_id> | <files_reviewed> | <critical> | <high> | <medium> | <low> | [md](<review_id>-full-review.md) · [json](<review_id>-full-review.json) |
+```
+
+10. **Delete the partial checkpoint** file `docs/reviews/.<review_id>-partial.json`:
+```bash
+rm -f docs/reviews/.<review_id>-partial.json
+```
+
+11. **Return a summary block** to Main Claude:
+
+```
+Review <review_id> complete.
+  Files reviewed: <N>
+  Total findings: <K> (<by_severity>)
+  Failed invocations: <count>
+  Report: docs/reviews/<review_id>-full-review.md
+  JSON: docs/reviews/<review_id>-full-review.json
+
+Top 10 critical findings:
+1. [file:line] description (agents)
+2. ...
+
+Run Phase 4 (repair)? (yes / no)
+```
+
+Then stop. Main Claude waits for user input and re-invokes you for Phase 4 if requested.
+```
+
+- [ ] **Step 3: Add the .gitignore entries early so test artifacts aren't accidentally committed**
+
+Read the current `.gitignore` and append:
+
+```
+# Full-review per-review artifacts (date-stamped, noisy). Index history committed.
+docs/reviews/*-full-review.md
+docs/reviews/*-full-review.json
+docs/reviews/.*-partial.json
+!docs/reviews/INDEX.md
+```
+
+- [ ] **Step 4: Smoke test Phase 3 with manufactured input**
+
+Manually create a checkpoint file `docs/reviews/.test-2026-05-07-partial.json` with two synthetic findings:
+
+```json
+{
+  "review_id": "test-2026-05-07",
+  "started_at": "2026-05-07T10:00:00Z",
+  "scope": {
+    "roots": ["backend/apps"],
+    "excluded": ["**/migrations/**"]
+  },
+  "primary_map": {
+    "backend/apps/users/auth_service.py": "django-drf-reviewer",
+    "backend/apps/users/views.py": "django-drf-reviewer"
+  },
+  "wave_size": 8,
+  "total_invocations": 2,
+  "completed_waves": [1],
+  "findings": [
+    {
+      "agent": "django-drf-reviewer",
+      "batch_label": "apps/users",
+      "severity": "critical",
+      "file": "backend/apps/users/auth_service.py",
+      "line": 1,
+      "description": "Synthetic critical finding for Phase 3 smoke test",
+      "rule": "smoke-test"
+    },
+    {
+      "agent": "performance-reviewer",
+      "batch_label": "apps/users",
+      "severity": "medium",
+      "file": "backend/apps/users/views.py",
+      "line": 1,
+      "description": "Synthetic medium finding for Phase 3 smoke test",
+      "rule": "smoke-test"
+    }
+  ],
+  "failed_invocations": []
+}
+```
+
+Then dispatch the orchestrator with: `Run Phase 3 reading docs/reviews/.test-2026-05-07-partial.json`.
+
+Expected:
+- `docs/reviews/test-2026-05-07-full-review.md` exists and is well-formed.
+- `docs/reviews/test-2026-05-07-full-review.json` exists, parses as JSON, and contains exactly the two findings with assigned `id` 1 and 2.
+- `docs/reviews/INDEX.md` has a new row prepended.
+
+Run:
+```bash
+python3 -c "import json; print(json.load(open('docs/reviews/test-2026-05-07-full-review.json'))['stats'])"
+```
+Expected: prints stats dict with 2 total findings.
+
+- [ ] **Step 5: Clean up smoke-test artifacts before commit**
+
+```bash
+rm -f docs/reviews/test-2026-05-07-full-review.md docs/reviews/test-2026-05-07-full-review.json
+```
+
+Then read `docs/reviews/INDEX.md` and remove the test row using Edit (keep only the header).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add .claude/agents/full-review-orchestrator.md docs/reviews/INDEX.md .gitignore
+git commit -m "$(cat <<'EOF'
+feat(agents): full-review-orchestrator Phase 3 — aggregate + persist
+
+Phase 3 dedupes findings by (file, line, normalized_description),
+sorts by severity/file/line, assigns stable 1-indexed IDs, writes
+per-review markdown + JSON artifacts under docs/reviews/, and
+prepends a row to docs/reviews/INDEX.md (committed history).
+Per-review artifacts are gitignored.
+
+EOF
+)"
+```
+
+---
+
+## Task 9: Add Phase 4 (filter parser + per-file repair dispatch)
+
+**Files:**
+- Modify: `.claude/agents/full-review-orchestrator.md` (append Phase 4 section)
+
+- [ ] **Step 1: Append Phase 4 section**
+
+Append to `.claude/agents/full-review-orchestrator.md`:
+
+```markdown
+
+## Phase 4 — Repair (optional, filter-driven)
+
+Triggered when Main Claude re-invokes you with the user's "yes" response to the Phase 3 repair prompt, plus the `review_id`.
+
+### Step 4a: Prompt for filter
+
+Print:
+```
+Repair selection (filter expression):
+  examples: "all critical+high", "agent:security-reviewer",
+            "file:apps/forum/**", "ids:1,4,7-12", "all", "none"
+>
+```
+
+Stop. Main Claude collects the user's filter string and re-invokes you with it.
+
+### Step 4b: Parse and match
+
+Filter language:
+```
+filter      = clause ("," clause)*           # comma = OR
+clause      = predicate ("+" predicate)*     # plus = AND
+predicate   = severity | agent | file | ids | "all" | "none"
+severity    = "critical" | "high" | "medium" | "low" | "info"
+agent       = "agent:" agent-id
+file        = "file:" glob                   # fnmatch semantics
+ids         = "ids:" id-list                 # 1,4,7-12,18
+```
+
+Parser rules:
+- Whitespace ignored *around* operators and predicates (`critical , high` ≡ `critical,high`), but never inside a predicate (`critical high` is an error).
+- `none` → return immediately with "No repairs requested."
+- `all` → match every finding where `repaired == false`.
+- Unknown predicate → return error message and re-prompt: `"Unknown predicate: <token>. Examples: ..."`.
+- Glob in `file:` uses Python `fnmatch` semantics; `**` is supported.
+- `ids:` ranges are inclusive (`1-3` → 1,2,3).
+- Already-repaired findings (`repaired == true`) are filtered out automatically; do not require user to add `+not-repaired`.
+
+Load the JSON report from `docs/reviews/<review_id>-full-review.json`. Apply the filter to the `findings` array.
+
+### Step 4c: Confirm matches
+
+Print:
+```
+Filter: <user filter>
+Matched: <N> findings across <M> files
+  - <file 1> (<count>)
+  - <file 2> (<count>)
+  ...
+
+Dispatch repairs? (yes / no / refilter)
+```
+
+Stop. Wait for response.
+
+### Step 4d: Group + dispatch
+
+If user responds `yes`:
+
+1. Group matched findings by `file`. For each file:
+   - The owning agent for the repair invocation is `findings[0].primary_agent` (consistent across the file — primary is per-file).
+   - Build a single repair invocation:
+
+```
+Repair the following findings in this file:
+
+File: <relative path>
+Findings:
+  - line <N>: <description>
+  - line <M>: <description>
+```
+
+2. Group repair invocations into waves of `wave_size` (same default 8 as Phase 1).
+
+3. Return JSON to Main Claude:
+
+```json
+{
+  "phase": "4d",
+  "review_id": "<id>",
+  "repair_waves": [
+    {
+      "wave": 1,
+      "invocations": [
+        {
+          "agent": "django-drf-reviewer",
+          "file": "backend/apps/forum/upload_views.py",
+          "finding_ids": [3, 7, 12],
+          "prompt": "Repair the following findings in this file:\n\nFile: ...\nFindings:\n  - line 3: ...\n  - line 7: ...\n  - line 12: ..."
+        }
+      ]
+    }
+  ]
+}
+```
+
+Then stop. Main Claude dispatches each wave in parallel, collects each invocation's `{"file": "...", "edits": [...], "unrepaired": [...]}` response, and applies edits via the Edit tool.
+
+### Step 4e: Apply edits + update JSON (Main Claude responsibility)
+
+For each invocation result:
+- For each `edit` in `edits`, call the Edit tool with `file_path = <invocation.file>`, `old_string = edit.old_string`, `new_string = edit.new_string`. If Edit fails (no exact match), capture the error.
+- Build a per-finding outcome map: each `finding_id` is repaired if all its edits applied (best-effort: if the agent returned multiple edits without binding them to specific findings, mark all listed `finding_ids` as repaired iff every edit succeeded). Findings listed in `unrepaired` are marked `repaired: false, repair_error: <reason>`.
+
+Re-invoke `full-review-orchestrator` for Phase 4f with the outcome map.
+
+### Step 4f: Persist repair outcomes
+
+Triggered when Main Claude re-invokes you with the outcome map after applying edits.
+
+1. Read `docs/reviews/<review_id>-full-review.json`.
+2. For each affected finding by ID, set `repaired: true` and `repaired_at: <ISO now>` if the outcome is success; set `repaired: false, repair_error: <reason>` otherwise.
+3. Write the updated JSON back.
+4. Print:
+```
+Repaired <X>/<Y> findings.
+  Successes: <X>
+  Edit conflicts (file drift): <Z>
+  Other failures: <W>
+JSON updated: docs/reviews/<review_id>-full-review.json
+
+Run another repair pass? (filter / done)
+```
+
+If user responds with another filter, return to Step 4b. If `done`, proceed to Phase 5 prompt.
+```
+
+- [ ] **Step 2: Smoke test Phase 4 filter parser**
+
+Dispatch the orchestrator with: `Run Phase 4b with review_id=<smoke-test review id from earlier task> and filter="critical,high"`.
+
+Expected: returns matched findings count and the per-file breakdown.
+
+Try edge cases — verify each:
+- `none` → returns "No repairs requested."
+- `all` → matches every unrepaired finding.
+- `agent:security-reviewer+critical` → only critical findings owned by security-reviewer.
+- `file:backend/apps/forum/**` → only findings in forum app.
+- `ids:1-3,5` → exactly findings with IDs 1, 2, 3, 5.
+- `notarealpredicate` → returns error and re-prompts.
+- `critical high` (space, no `+`) → returns error.
+
+- [ ] **Step 3: Smoke test Phase 4 end-to-end on a tiny finding**
+
+Use a JSON report containing one repairable finding (e.g., a missing `select_related()` you can manually verify). Filter `all`, confirm `yes`, observe Edit application, observe Phase 4f update of `repaired: true`.
+
+Verify with:
+```bash
+python3 -c "import json; r = json.load(open('docs/reviews/<id>-full-review.json')); print([(f['id'], f['repaired']) for f in r['findings']])"
+```
+Expected: the targeted finding shows `repaired=True`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .claude/agents/full-review-orchestrator.md
+git commit -m "$(cat <<'EOF'
+feat(agents): full-review-orchestrator Phase 4 — filter-driven repair
+
+Phase 4 implements filter-expression repair selection (severity, agent,
+file glob, ids), per-file dispatch with the file's primary_agent owning
+all that file's repairs, wave-based parallel application, edit-conflict
+handling for file drift, and JSON persistence of repair outcomes.
+
+EOF
+)"
+```
+
+---
+
+## Task 10: Add Phase 5 (optional pattern-codifier)
+
+**Files:**
+- Modify: `.claude/agents/full-review-orchestrator.md` (append Phase 5 section)
+
+- [ ] **Step 1: Append Phase 5 section**
+
+Append to `.claude/agents/full-review-orchestrator.md`:
+
+```markdown
+
+## Phase 5 — Codifier (optional, opt-in)
+
+Triggered when Main Claude re-invokes you after Phase 4 completion (or after Phase 3 if user skipped repair).
+
+Print:
+```
+Run pattern-codifier on all findings? (y/n)
+  Note: this can be expensive on a large review (<total_findings> findings).
+        Recommended only when the review surfaces a recurring pattern not yet captured.
+```
+
+Stop. Wait for response.
+
+If user responds `y`:
+
+1. Read the JSON report `docs/reviews/<review_id>-full-review.json`.
+2. Format findings into the codifier's expected input format:
+```
+[<severity>] <file>:<line> — <description> — agent: <primary_agent>
+```
+3. Return to Main Claude an instruction to dispatch `pattern-codifier` with the formatted findings list.
+
+Main Claude dispatches `pattern-codifier`, receives the codifier's JSON output (`agent_updates`, `pattern_doc_updates`, `learnings`), and applies the updates per the existing codifier flow.
+
+If user responds `n`, print "Skipping codifier. Review complete." and stop.
+```
+
+- [ ] **Step 2: Smoke test Phase 5 prompt**
+
+Dispatch orchestrator with: `Run Phase 5 with review_id=<test id>`.
+
+Expected: prints the "Run pattern-codifier?" prompt with the correct total_findings count from the JSON report.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .claude/agents/full-review-orchestrator.md
+git commit -m "$(cat <<'EOF'
+feat(agents): full-review-orchestrator Phase 5 — opt-in codifier
+
+Phase 5 adds an opt-in dispatch of pattern-codifier with cost warning.
+Default is off (large reviews would blow up the codifier). Reuses the
+existing codifier contract — orchestrator just formats findings and
+hands them off.
+
+EOF
+)"
+```
+
+---
+
+## Task 11: End-to-end smoke test on a small subtree
+
+This is a verification-only task — no edits. Confirms all phases work together.
+
+- [ ] **Step 1: Invoke the orchestrator scoped to a small subtree**
+
+Dispatch `full-review-orchestrator` with: `Run a full review limited to roots: backend/apps/users only.`
+
+Expected sequence:
+1. Phase 0 prints scope summary, asks proceed.
+2. On `yes`, Phase 1 returns a wave plan (likely 1-2 waves, ~3-5 invocations).
+3. Phase 2 (Main Claude) dispatches reviewers, validates JSON responses, checkpoints.
+4. Phase 3 produces `docs/reviews/<review_id>-full-review.md` and `.json`, prepends INDEX.md row, returns top-10 critical summary.
+5. Phase 4 prompt offered. Respond `yes`, then filter `critical+high`. Verify count, dispatch repairs.
+6. Phase 5 prompt offered. Respond `n` for the smoke test.
+
+- [ ] **Step 2: Verify artifacts**
+
+Run:
+```bash
+ls -la docs/reviews/
+```
+Expected: `INDEX.md`, `<review_id>-full-review.md`, `<review_id>-full-review.json`. The partial `.<review_id>-partial.json` should NOT exist (deleted in Phase 3).
+
+Run:
+```bash
+cat docs/reviews/INDEX.md
+```
+Expected: header + one row for the smoke-test review.
+
+Run:
+```bash
+python3 -c "
+import json
+r = json.load(open('docs/reviews/<review_id>-full-review.json'))
+print('stats:', r['stats'])
+print('finding ids:', [f['id'] for f in r['findings']])
+print('any repaired:', any(f['repaired'] for f in r['findings']))
+"
+```
+Expected: stats dict with non-zero `files_reviewed`, `reviewers_invoked`. Finding IDs are 1-indexed contiguous integers. If repair was actually applied, `any repaired` is `True`.
+
+- [ ] **Step 3: Clean up smoke-test artifacts and INDEX row**
+
+```bash
+rm -f docs/reviews/<review_id>-full-review.md docs/reviews/<review_id>-full-review.json
+```
+
+Edit `docs/reviews/INDEX.md` to remove the smoke-test row.
+
+If real edits were applied to `backend/apps/users/` files in Step 1's repair phase, decide whether to keep them (legitimate fixes) or revert via `git restore`. Document this decision before committing.
+
+- [ ] **Step 4: No commit (verification only); revert any unwanted changes**
+
+If verification surfaces issues with any phase, return to the relevant task and refine. Do not proceed to Task 12 until end-to-end works on the small subtree.
+
+---
+
+## Task 12: Full-repo dry run (cost confirmation, no repair)
+
+- [ ] **Step 1: Invoke a no-repair full review**
+
+Dispatch `full-review-orchestrator` with no scope restriction. The agent's Phase 0 will print the full estimated batch count.
+
+Expected: estimated batch count is large (likely 30-60). If it exceeds 100, the cost-guardrail second prompt fires.
+
+- [ ] **Step 2: Confirm and run all phases except repair**
+
+Respond `yes` to Phase 0, observe Phase 1 wave plan covering the whole repo, observe Phase 2 wave-by-wave progress lines, observe Phase 3 producing the full report.
+
+Respond `no` to Phase 4 (skip repair).
+
+Respond `n` to Phase 5 (skip codifier).
+
+- [ ] **Step 3: Examine the full report**
+
+Run:
+```bash
+wc -l docs/reviews/<review_id>-full-review.md
+python3 -c "import json; r = json.load(open('docs/reviews/<review_id>-full-review.json')); print(r['stats'])"
+```
+
+Expected: human-readable report has hundreds of lines; JSON stats show `files_reviewed` matching the count from Phase 0's estimate; `total_findings` is non-zero.
+
+Skim the markdown report for:
+- Severity sections render correctly (🔴, 🟠, 🟡, 🟢).
+- Findings are grouped by file within each severity.
+- `## ⚠️ Failed Invocations` either absent (no failures) or accurately listed.
+
+- [ ] **Step 4: Decide whether to keep or delete the report**
+
+The first real full review surfaces real findings. Decide with the user whether:
+- Delete (this was a smoke test only — files gitignored anyway).
+- Keep as the first committed `INDEX.md` entry; per-review artifacts stay gitignored locally.
+
+Default: delete the per-review artifacts; keep the INDEX row.
+
+- [ ] **Step 5: Final commit if any cleanup edits to INDEX.md or .gitignore**
+
+```bash
+git add docs/reviews/INDEX.md .gitignore
+git commit -m "$(cat <<'EOF'
+chore(reviews): record first full-repo review in INDEX
+
+EOF
+)" 2>/dev/null || echo "no changes to commit"
+```
+
+(The `2>/dev/null || echo` allows the step to succeed if there are no changes to commit.)
+
+---
+
+## Done
+
+All tasks complete when:
+- All 11 reviewer files have JSON-output review-mode and multi-edit repair-mode contracts.
+- `code-review-orchestrator` Phase 2 consumes the new JSON shape.
+- `full-review-orchestrator.md` contains all six phases (0-5).
+- `docs/reviews/INDEX.md` exists with the table header.
+- `.gitignore` excludes per-review artifacts but keeps INDEX.md.
+- A scoped smoke test (Task 11) and a full-repo dry run (Task 12) both complete end-to-end without manual intervention beyond user prompts.

--- a/docs/superpowers/specs/2026-05-06-full-review-orchestrator-design.md
+++ b/docs/superpowers/specs/2026-05-06-full-review-orchestrator-design.md
@@ -1,0 +1,551 @@
+# Full-Repo Code Review Orchestrator — Design
+
+**Status:** Draft, pending implementation
+**Author:** brainstorming session 2026-05-06
+**Related agents:** `code-review-orchestrator` (incremental, existing), all domain reviewers, `pattern-codifier`
+
+## Problem
+
+The existing `code-review-orchestrator` reviews only files changed against `HEAD` (or `HEAD~1`). It is excellent for "review what I just did," but offers no way to ask "what's the current state of the whole codebase?" — which is what we need for periodic audits, onboarding new contributors, and pre-release sweeps.
+
+## Goal
+
+Add a sibling agent, `full-review-orchestrator`, that:
+
+1. Reviews **every active source file** in the repo (not just changed files).
+2. Reuses the existing fleet of domain reviewers without forking them.
+3. Produces a **detailed, persistent report** (markdown + JSON) under `docs/reviews/`.
+4. Supports a **filter-driven repair phase** that dispatches the same domain reviewers in repair mode.
+5. Coexists with the existing incremental orchestrator — neither replaces the other.
+
+## Non-goals
+
+- Not a replacement for the incremental orchestrator. The two complement each other.
+- Not a CI/CD pipeline. This is human-triggered.
+- Not pattern-codifier-by-default. Codifier on a 300-finding review is a separate (expensive) decision.
+- Not a security scanner replacement (Bandit, Snyk, etc. still have their place).
+
+## Decisions captured during brainstorm
+
+| # | Decision |
+|---|---|
+| Q1 | New agent (B-class), keeps incremental orchestrator unchanged |
+| Q2 | Scope: all active source files. Skip `existing_implementation/`, `docs/archive/`, `**/migrations/`, vendor dirs (`node_modules/`, `.venv/`, `dist/`, `build/`, `__pycache__/`), generated artifacts (`*.g.dart`, `*.freezed.dart`, `*_pb2.py`, `*.pb.go`, `coverage/`, `.next/`, `.dart_tool/`) |
+| Q3 | Per-app / per-feature-folder batching (5–15 files per invocation) |
+| Q4 | Persistent markdown report **+** machine-readable JSON **+** running history in `INDEX.md` |
+| Q5 | Filter-expression repair selection (S2) + per-file dispatch (D2) |
+| Q6 | New separate agent (A) + wave-based parallelism (P1), default wave size 8 |
+| §4 | Per-review artifacts gitignored, `INDEX.md` committed |
+
+## Architecture
+
+### Agent layout
+
+```
+.claude/agents/
+├── code-review-orchestrator.md       # existing, unchanged
+├── full-review-orchestrator.md       # new
+├── django-drf-reviewer.md            # existing, contract update
+├── wagtail-reviewer.md               # existing, contract update
+├── ...                                # all other reviewers, contract update
+└── pattern-codifier.md               # existing, unchanged
+```
+
+### Mental model
+
+| Orchestrator | Question it answers | Trigger |
+|---|---|---|
+| `code-review-orchestrator` | "Is what I just changed good?" | After a coding session |
+| `full-review-orchestrator` | "What's the current state of the codebase?" | Audits, onboarding, pre-release |
+
+### Frontmatter for the new agent
+
+```yaml
+---
+name: full-review-orchestrator
+description: Orchestrates a full-repository code review by enumerating every active source file, batching by app/feature, dispatching all domain reviewers in waves, producing a persistent report, and driving an optional repair phase via filter expressions.
+model: haiku
+color: purple
+tools: Bash, Read, Glob, Grep, Write
+---
+```
+
+The orchestrator holds zero pattern knowledge. All quality logic lives in the domain reviewers.
+
+## Phase flow
+
+Six phases. Phases 1, 4, 5, 6 are the orchestrator's turns; Phases 2, 3 are Main Claude doing dispatch / edit application.
+
+### Phase 0 — Confirm scope
+
+The orchestrator prints a summary and gates the work:
+
+```
+Full review starting:
+  Roots: backend/apps, web/src, plant_community_mobile/lib, firebase, functions
+  Excluded: existing_implementation/, docs/archive/, **/migrations/, vendor (node_modules, .venv, dist, build, __pycache__), generated (*.g.dart, *.freezed.dart, *_pb2.py, .next/, coverage/)
+  Estimated batches: 34 across 11 reviewers (≈ 5 waves of 8)
+Proceed? (yes / no / edit-roots)
+```
+
+If estimated invocation count exceeds 100, an extra cost-guardrail prompt is required:
+```
+This is a large review (137 invocations across 18 waves). Proceed? (yes / scope-down / cancel)
+```
+
+### Phase 1 — Plan
+
+The orchestrator enumerates files via `git ls-files --cached --others --exclude-standard` (tracked + untracked, respects `.gitignore`, excludes ignored files), filters by routing rules, groups into batches, builds the wave plan. Returns:
+
+```json
+{
+  "review_id": "2026-05-06-1430",
+  "started_at": "2026-05-06T14:30:00Z",
+  "scope": {
+    "roots": ["backend/apps", "web/src", "plant_community_mobile/lib", "firebase", "functions"],
+    "excluded": ["existing_implementation/", "docs/archive/", "**/migrations/", "**/__pycache__/"]
+  },
+  "total_invocations": 34,
+  "wave_size": 8,
+  "waves": [
+    {
+      "wave": 1,
+      "invocations": [
+        {
+          "agent": "django-drf-reviewer",
+          "batch_label": "apps/forum",
+          "files": ["backend/apps/forum/viewsets/post_viewset.py", "backend/apps/forum/serializers.py"]
+        }
+      ]
+    }
+  ]
+}
+```
+
+Then stops. Main Claude takes over.
+
+### Phase 2 — Dispatch waves (Main Claude)
+
+For each wave, Main Claude dispatches all invocations in parallel via the Task tool. The dispatch prompt for a reviewer:
+
+```
+Review these files. Report findings only for the files listed.
+
+Batch label: apps/forum (django-drf-reviewer)
+Files:
+  - backend/apps/forum/viewsets/post_viewset.py
+  - backend/apps/forum/serializers.py
+
+Return findings in this JSON shape:
+{
+  "agent": "django-drf-reviewer",
+  "batch_label": "apps/forum",
+  "findings": [
+    {
+      "severity": "critical|high|medium|low|info",
+      "file": "backend/apps/forum/viewsets/post_viewset.py",
+      "line": 42,
+      "description": "...",
+      "rule": "Issue #131",
+      "suggested_fix": "..."
+    }
+  ]
+}
+```
+
+After every wave, Main Claude appends collected findings to `docs/reviews/.<review_id>-partial.json` (gitignored checkpoint) and prints a one-liner:
+
+```
+Wave 3/5 complete — 47 new findings (12 critical, 18 high, 14 medium, 3 low)
+```
+
+### Phase 3 — Aggregate and write artifacts
+
+Main Claude re-invokes the orchestrator with the full collected findings list. The orchestrator:
+
+1. Deduplicates by `(file, line, finding_hash)`. When multiple agents report the same finding, the `agents` array keeps both; `primary_agent` is computed once via the routing table.
+2. Sorts by severity (critical → info), then by file, then by line.
+3. Writes `docs/reviews/<review_id>-full-review.md` (human-readable).
+4. Writes `docs/reviews/<review_id>-full-review.json` (machine-readable, schema below).
+5. Prepends a row to `docs/reviews/INDEX.md`.
+6. Returns to Main Claude a summary block: counts by severity, link, top 10 critical findings.
+
+### Phase 4 — Repair (orchestrator drives, Main Claude applies)
+
+The orchestrator prompts:
+
+```
+Repair selection (filter expression):
+  examples: "all critical+high", "agent:security-reviewer",
+            "file:apps/forum/**", "ids:1,4,7-12", "all", "none"
+>
+```
+
+The orchestrator parses the filter, prints matched count + per-file breakdown, asks confirmation:
+
+```
+Filter: critical+agent:security-reviewer
+Matched: 8 findings across 5 files
+  - backend/apps/forum/upload_views.py (3)
+  - backend/apps/users/auth_service.py (2)
+  - ...
+
+Dispatch repairs? (yes / no / refilter)
+```
+
+On yes, the orchestrator groups matched findings **by file** (per-file dispatch — D2). For each file, the `primary_agent` is the sole repair owner; all findings for that file (regardless of which agent flagged them) go in a single repair invocation.
+
+Repair invocations dispatch in waves (same wave size as Phase 2). Each invocation returns:
+
+```json
+{
+  "file": "backend/apps/forum/upload_views.py",
+  "edits": [
+    {"old_string": "...", "new_string": "..."},
+    {"old_string": "...", "new_string": "..."}
+  ]
+}
+```
+
+Main Claude applies edits. After each wave, the orchestrator confirms applied repairs and updates the JSON (`repaired: true`, `repaired_at: <ISO timestamp>`).
+
+After the full repair pass:
+
+```
+Repaired 8/8 findings.
+JSON updated: docs/reviews/2026-05-06-1430-full-review.json
+Run another repair pass? (filter / done)
+```
+
+### Phase 5 — Codifier (optional)
+
+```
+Run pattern-codifier on all findings? (y/n)
+  Note: this can be expensive on a large review (304 findings). Recommended only when the review surfaces a recurring pattern.
+```
+
+On yes, dispatch the codifier with the full findings list. Codifier output (JSON instructions) is applied by Main Claude, same as the existing flow.
+
+## Sub-agent contract (review mode)
+
+Domain reviewers must return findings as **JSON**, not prose. This is a one-time, mechanical update across all 11 reviewer agent files. The incremental orchestrator benefits — its dedupe logic gets simpler.
+
+### Review-mode input
+
+```
+Review these files. Report findings only for the files listed.
+
+Batch label: <batch_label>
+Files:
+  - <relative path>
+  - <relative path>
+```
+
+### Review-mode output
+
+```json
+{
+  "agent": "<reviewer-id>",
+  "batch_label": "<batch_label>",
+  "findings": [
+    {
+      "severity": "critical|high|medium|low|info",
+      "file": "<relative path>",
+      "line": <int>,
+      "description": "<one sentence>",
+      "rule": "<optional citation: issue #, pattern doc>",
+      "suggested_fix": "<optional one-liner>"
+    }
+  ]
+}
+```
+
+### Severity coercion
+
+If a reviewer returns a non-canonical severity:
+- `blocker` → `critical`
+- anything else → `info` + a warning logged in the report
+
+This protects the report shape without losing findings.
+
+## Sub-agent contract (repair mode)
+
+The current per-finding repair contract (input `{file, line, finding}` → output `{file, old_string, new_string}`) is extended additively to support **multiple findings per file**:
+
+### Repair-mode input
+
+```
+Repair the following findings in this file:
+
+File: <relative path>
+Findings:
+  - line 42: <description>
+  - line 78: <description>
+```
+
+### Repair-mode output
+
+```json
+{
+  "file": "<relative path>",
+  "edits": [
+    {"old_string": "...", "new_string": "..."},
+    {"old_string": "...", "new_string": "..."}
+  ]
+}
+```
+
+The single-finding form continues to work: `edits` array of length 1.
+
+## Routing & primary-agent resolution
+
+Lives in the orchestrator agent file as a routing table (same shape as the incremental one, evaluated per batch).
+
+| Path pattern | Batch unit | Reviewer(s) | Primary? |
+|---|---|---|---|
+| `backend/apps/<app>/**/*.py` (excluding blog, wagtail-using) | one batch per app | `django-drf-reviewer` | primary for `.py` |
+| `backend/apps/blog/**` OR `.py` matching `grep -l "import wagtail\|from wagtail\|class.*Page"` | one batch per app | `wagtail-reviewer` | overrides django for these files |
+| `backend/apps/<app>/**/tasks.py`, `**/celery*.py`, `**/beat*.py` | one batch per app | `celery-async-reviewer` | secondary |
+| `backend/apps/<app>/**/serializers.py`, `**/api/**` | one batch per app | `api-design-reviewer` | secondary |
+| `backend/apps/<app>/**/permissions.py`, `**/auth*.py`, `**/upload*.py`, `**/*token*.py`, `**/*secret*.py` | one batch per app | `security-reviewer` | secondary |
+| `backend/apps/<app>/**/tests/**`, `**/test_*.py` | one batch per app | `test-quality-reviewer` | primary for test files |
+| `backend/apps/<app>/**/*.py` (any) | one batch per app | `performance-reviewer` | secondary |
+| `web/src/<feature>/**/*.{ts,tsx}` | one batch per top-level subfolder of `web/src/` | `react-typescript-reviewer` | primary for `.ts/.tsx` |
+| `web/src/**/*.test.{ts,tsx}` | rolled into the feature batch | `test-quality-reviewer` | secondary |
+| `plant_community_mobile/lib/<feature>/**/*.dart` | one batch per top-level `lib/` subfolder | `flutter-dart-reviewer` | primary for `.dart` |
+| `plant_community_mobile/lib/**/firebase*.dart`, `**/auth*.dart` | rolled into feature batch | `flutter-firebase-reviewer` | secondary |
+| `firebase/**`, `*.rules` | one batch | `flutter-firebase-reviewer`, `security-reviewer` | flutter-firebase primary |
+| `functions/**/*.{js,ts}` | one batch per function dir | `firebase-cloudfunction-reviewer` | primary |
+
+### Primary-agent rule
+
+Every file has exactly one primary agent. In repair phase, the primary owns the repair regardless of which reviewer flagged each finding. This eliminates edit conflicts when multiple reviewers flag the same file.
+
+### Cross-cutting reviewers
+
+`security-reviewer`, `performance-reviewer`, `api-design-reviewer`, `celery-async-reviewer`, `test-quality-reviewer` are **never primary** for backend Python code (except `test-quality-reviewer` on test files). They run alongside the primary domain reviewer; their findings flow through the primary in repair phase.
+
+### Wagtail override
+
+The same `.py` file can match both `django-drf-reviewer` and `wagtail-reviewer`. Wagtail wins as primary when its grep predicate matches. The orchestrator runs the grep during Phase 1 to assign primaries.
+
+## Filter language for repair
+
+```
+filter      = clause ("," clause)*           # comma = OR
+clause      = predicate ("+" predicate)*     # plus = AND
+predicate   = severity | agent | file | ids | "all" | "none"
+severity    = "critical" | "high" | "medium" | "low" | "info"
+agent       = "agent:" agent-id
+file        = "file:" glob                   # fnmatch semantics, ** supported
+ids         = "ids:" id-list                 # 1,4,7-12,18
+```
+
+### Examples
+
+| Filter | Meaning |
+|---|---|
+| `all` | every finding |
+| `critical` | all critical findings |
+| `critical,high` | critical OR high |
+| `critical+agent:security-reviewer` | critical AND owned by security-reviewer |
+| `file:apps/forum/**` | findings in forum app |
+| `file:apps/forum/**+high` | high findings in forum |
+| `ids:1-12,47,89-95` | specific finding IDs |
+| `none` | no-op, exits repair phase |
+
+### Parser behavior
+
+- Whitespace ignored *around* operators and predicates (`critical , high` ≡ `critical,high`), but never inside a predicate (`critical high` is an error, not `criticalhigh`).
+- Unknown predicates → error message, re-prompt (do not crash).
+- Glob matching uses Python `fnmatch` semantics (`**` works like in `git`).
+- Empty match set → "0 findings matched, refine filter or type 'none'".
+- `ids:` ranges are inclusive.
+- `repaired: true` findings are filtered out automatically — no need to write `+not-repaired`.
+
+## Output artifacts
+
+All artifacts live under `docs/reviews/`.
+
+### `<review_id>-full-review.md` (human-readable, gitignored)
+
+```markdown
+# Full Code Review — 2026-05-06 14:30
+
+**Scope:** backend/apps, web/src, plant_community_mobile/lib, firebase, functions
+**Files reviewed:** 287
+**Reviewers invoked:** 11
+**Total findings:** 304 (12 critical, 47 high, 89 medium, 156 low)
+
+---
+
+## 🔴 Critical (12)
+
+### backend/apps/forum/viewsets/post_viewset.py:42
+**Finding:** ViewSet.get_permissions() does not call super() — @action permission_classes silently ignored
+**Reviewer:** django-drf-reviewer · security-reviewer
+**Rule:** Issue #131
+**Suggested fix:** Add `permissions = super().get_permissions()` then extend
+
+` ``python
+# current
+def get_permissions(self):
+    return [IsAuthenticated()]
+` ``
+
+---
+
+## 🟠 High (47)
+[same shape, grouped by file within severity]
+
+## 🟡 Medium (89)
+[same]
+
+## 🟢 Low / Info (156)
+[abbreviated — file:line — description, no excerpts]
+
+## ⚠️ Failed Invocations (0)
+[only present when reviewers failed]
+```
+
+### `<review_id>-full-review.json` (machine-readable, source of truth, gitignored)
+
+```json
+{
+  "review_id": "2026-05-06-1430",
+  "started_at": "2026-05-06T14:30:00Z",
+  "completed_at": "2026-05-06T14:47:12Z",
+  "scope": {
+    "roots": ["backend/apps", "web/src", "plant_community_mobile/lib", "firebase", "functions"],
+    "excluded": ["existing_implementation/", "docs/archive/", "**/migrations/", "**/__pycache__/"]
+  },
+  "stats": {
+    "files_reviewed": 287,
+    "reviewers_invoked": 11,
+    "total_findings": 304,
+    "by_severity": {"critical": 12, "high": 47, "medium": 89, "low": 156}
+  },
+  "findings": [
+    {
+      "id": 1,
+      "severity": "critical",
+      "file": "backend/apps/forum/viewsets/post_viewset.py",
+      "line": 42,
+      "description": "ViewSet.get_permissions() does not call super()...",
+      "rule": "Issue #131",
+      "suggested_fix": "Add `permissions = super().get_permissions()` then extend",
+      "agents": ["django-drf-reviewer", "security-reviewer"],
+      "primary_agent": "django-drf-reviewer",
+      "repaired": false,
+      "repaired_at": null,
+      "repair_error": null
+    }
+  ],
+  "failed_invocations": []
+}
+```
+
+`id` is 1-indexed and stable for this review — the value the `ids:1,4,7-12` filter selects against.
+
+### `INDEX.md` (committed running history, prepend new entries)
+
+```markdown
+# Full Review History
+
+| Date | Review ID | Files | Critical | High | Medium | Low | Report |
+|---|---|---|---|---|---|---|---|
+| 2026-05-06 14:30 | 2026-05-06-1430 | 287 | 12 | 47 | 89 | 156 | [md](2026-05-06-1430-full-review.md) · [json](2026-05-06-1430-full-review.json) |
+```
+
+### `.gitignore` additions
+
+```
+# Per-review artifacts (date-stamped, noisy). Index history committed.
+docs/reviews/*-full-review.md
+docs/reviews/*-full-review.json
+docs/reviews/.*-partial.json
+!docs/reviews/INDEX.md
+```
+
+### Checkpoint file: `.<review_id>-partial.json`
+
+Hidden, gitignored, written incrementally after each wave. Used for resume-after-interruption (Phase 2 resilience).
+
+## Error handling and edge cases
+
+### Sub-agent invocation failures
+
+A reviewer might timeout, return malformed JSON, or hit a model error. Strategy:
+
+- Main Claude validates each invocation result. Invalid → mark as `status: "failed"` in the running list with the captured error.
+- Failed invocations do not block subsequent waves.
+- Phase 3 report includes `## ⚠️ Failed Invocations` section with `{agent, batch_label, error}`.
+- Orchestrator prompts: `3 invocations failed. Retry just the failed ones? (y/n)`. On yes, retry as a new wave.
+
+### Partial completion / interruption
+
+If the user interrupts mid-review (Ctrl-C, session ends):
+- Each wave's findings are checkpointed to `docs/reviews/.<review_id>-partial.json`.
+- On re-invocation with a matching `review_id`, the orchestrator detects the partial: `Found partial review from 2026-05-06-1430 (waves 1-3 of 5 complete). Resume? (y/n/restart)`.
+- On resume, the orchestrator skips already-completed waves and continues at the next pending wave.
+
+### Empty batches
+
+If a routing rule matches no files (e.g., no `firebase/` directory), the rule is silently dropped from the wave plan. Logged in Phase 0 summary as `Skipped: firebase-cloudfunction-reviewer (no matching files)`.
+
+### Repair edit conflicts
+
+If a repair edit's `old_string` no longer matches (file modified since review):
+- Main Claude attempts the Edit tool; on failure, marks the finding `repaired: false, repair_error: "old_string no longer matches"`.
+- Orchestrator reports: `5 of 8 repairs applied. 3 failed (file drift).` and lists drift findings.
+- Drifted findings stay in JSON; user can re-run review or repair manually.
+
+### Wave plan stability
+
+If files are edited during review, the orchestrator does not re-plan. Findings reference line numbers as captured at review time. The repair phase handles drift via the edit-conflict path.
+
+### Concurrent reviews
+
+Different `review_id` values cannot collide (timestamp includes minute). Same minute is unlikely; if it happens, second invocation sees the existing partial and prompts to resume or pick a different review_id.
+
+## Implementation order
+
+To minimize risk, implement in this order. The reviewer JSON contract change touches every reviewer and the existing incremental orchestrator — verify it works before building anything new.
+
+1. **Update reviewer JSON contract** (review mode + repair mode) across all 11 reviewer files. Mechanical change.
+2. **Verify incremental orchestrator** still works end-to-end against a small change. The existing orchestrator's Phase 2 dedupe logic also needs to be updated to consume the new JSON shape.
+3. **Build `full-review-orchestrator.md`** with Phase 0, Phase 1 (planning + JSON output), and Phase 3 (aggregation + artifact writing).
+4. **Implement Phase 2 dispatch glue** (Main Claude side — instructions in the orchestrator's prompt).
+5. **Implement Phase 4 repair** (filter parser, per-file dispatch, JSON updates).
+6. **Implement Phase 5 codifier** (optional, opt-in only).
+7. **Add `.gitignore` entries** and create empty `docs/reviews/INDEX.md` with table header.
+8. **Smoke test** on a small subtree (`/full-review backend/apps/forum`).
+9. **Full repo test.**
+
+## Open questions
+
+None at design time. Resolutions:
+- Gitignore: per-review artifacts ignored, `INDEX.md` committed (decided in §4).
+- Codifier default: off (opt-in per review, decided in Phase 5).
+- Wave size: configurable via `--wave-size N`, default 8 (decided in §5).
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Reviewer JSON contract breaks incremental orchestrator | Verify incremental orchestrator end-to-end as step 2 of implementation |
+| Reviewers produce unstable line numbers across runs | Acceptable; review_id timestamps each snapshot, repair handles drift |
+| Large reviews (>100 invocations) burn cost | Phase 0 cost-guardrail prompt; user can scope-down |
+| Partial state checkpoints leak sensitive content | Hidden file (`.<review_id>-partial.json`), gitignored, lives only under `docs/reviews/` |
+| `pattern-codifier` blowup on 300+ findings | Default off; explicit opt-in with cost warning in Phase 5 |
+| Multiple reviewers double-report the same issue | Phase 3 dedupe by `(file, line, finding_hash)`; primary_agent owns repair |
+
+## Success criteria
+
+The agent is done when:
+
+1. Running it on a clean repo produces a valid `INDEX.md` row, a populated `<review_id>-full-review.md`, and a parseable `<review_id>-full-review.json`.
+2. The repair phase, given filter `critical+agent:security-reviewer`, applies edits to disk and updates `repaired: true` in the JSON.
+3. Interrupting mid-review and re-invoking offers a resume prompt and skips completed waves.
+4. The incremental `code-review-orchestrator` continues to work unchanged after the reviewer JSON contract update.
+5. All 11 domain reviewers respond correctly to the new review-mode JSON-output requirement and the multi-finding repair-mode input.


### PR DESCRIPTION
## Summary

- Adds a new `full-review-orchestrator` agent for whole-codebase audits — coexists with the existing incremental `code-review-orchestrator`. Six phases: confirm scope → plan waves → dispatch (Main Claude) → aggregate + persist → optional filter-driven repair → optional codifier.
- Updates the 11 domain reviewers + the incremental orchestrator with a shared JSON output contract (review mode) and multi-edit repair contract. Both orchestrators now share the reviewer fleet without forking.
- Adds persistent reports under `docs/reviews/` (markdown + JSON, gitignored) with a committed `INDEX.md` running history. Filter language: `severity`, `agent:`, `file:` glob, `ids:` ranges, `+` (AND) and `,` (OR).

## Implementation

Spec: `docs/superpowers/specs/2026-05-06-full-review-orchestrator-design.md`
Plan: `docs/superpowers/plans/2026-05-07-full-review-orchestrator.md` (Tasks 1-10 implemented; Tasks 11-12 deferred to user acceptance testing)

Built via subagent-driven-development with two-stage review (spec compliance + code quality) per task. The 14 commits trace iterative refinement — `fix:` commits land code-review feedback in lockstep with `feat:` commits.

## Test Plan

Live agent dispatch tests were intentionally deferred to user acceptance (non-deterministic, costly). Recommended verification before relying on the agent for real reviews:

- [ ] Phase 0 dry run on full repo — verify scope summary, batch estimate, skipped-reviewer list
- [ ] Phase 1 dry run scoped to `backend/apps/users` only — inspect wave plan JSON for correct file→agent mapping and `primary_map`
- [ ] End-to-end smoke test on `backend/apps/users` — Phases 0-3, verify markdown + JSON artifacts under `docs/reviews/` and INDEX.md row
- [ ] Repair phase smoke test with filter `critical+high` — verify edits apply via Edit tool and JSON `repaired` flag updates
- [ ] Full-repo dry run answering `no` to repair — verify scale handles ~30-60 invocations across multiple waves
- [ ] Confirm incremental `code-review-orchestrator` still works after JSON contract changes (run on a small staged diff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)