### PR TITLE
chore: repo housekeeping + Kimi K2.6 bulk I/O delegation setup

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,6 +1,4 @@
 {
   "MD013": false,
-  "MD024": false,
-  "MD036": false,
-  "MD040": false
+  "MD036": false
 }

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,6 @@
+{
+  "MD013": false,
+  "MD024": false,
+  "MD036": false,
+  "MD040": false
+}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -203,7 +203,8 @@ repos:
           (?x)^(
             PLANNING/.*|
             backend/docs/development/SECURITY_INCIDENT_.*\.md$|
-            todos/archive/.*\.md$
+            todos/archive/.*\.md$|
+            docs/archive/.*\.md$
           )
 
   # ===================================

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -81,14 +81,6 @@ repos:
   # ===================================
   - repo: local
     hooks:
-      # Block CLAUDE.md from being committed
-      - id: block-claude-md
-        name: Block CLAUDE.md (local development file only)
-        entry: "bash -c 'if git diff --cached --name-only | grep -q \"^CLAUDE.md$\"; then echo \"ERROR - CLAUDE.md must NEVER be committed.\"; exit 1; fi'"
-        language: system
-        pass_filenames: false
-        always_run: true
-
       # Block .env files (except .env.example)
       - id: block-env-files
         name: Block .env files (use .env.example instead)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,6 +98,7 @@ The pattern library is the primary reference for implementation decisions. Read 
 | `iam.md` | IAM configuration |
 
 ### Incidents (`docs/LEARNINGS.md`)
+
 Append-only log of bugs, incidents, and hard-won patterns. Read before starting a new feature area.
 
 ## Code Review Agents
@@ -120,6 +121,7 @@ Trigger a review: ask Claude to invoke `.claude/agents/code-review-orchestrator.
 | `pattern-codifier.md` | Extracts new patterns after each review |
 
 Non-review agents (invoke directly for implementation tasks):
+
 - `wagtail-cms-orchestrator.md` — CMS content, API integration, data flow tracing
 - `frontend-developer.md` — React UI/UX implementation
 
@@ -136,3 +138,63 @@ Non-review agents (invoke directly for implementation tasks):
 | `CORS_ALLOWED_ORIGINS` | `backend/.env` | Set to `http://localhost:5174` in dev |
 | `GOOGLE_APPLICATION_CREDENTIALS` | `backend/.env` | Path to Firebase service account JSON |
 | `VITE_API_URL` | `web/.env` | Backend URL for React app |
+
+## Cheap-Worker Delegation (Kimi K2.6)
+
+Three CLI tools delegate bulk I/O to a cheap worker model (Kimi K2.6 via OpenRouter).
+Claude handles reasoning and architecture; the worker handles token-heavy reading/writing.
+
+### ask-kimi — bulk file reading
+
+Use when reading 3+ files for context, or any single file >400 lines when the goal is
+understanding (not editing):
+
+```bash
+ask-kimi --paths <file1> <file2>... --question "<specific question>"
+```
+
+Returns structured bullets. Read the summary instead of the raw files.
+Only use Read directly when you need exact line numbers for editing.
+
+### kimi-write — boilerplate generation
+
+Use for pytest tests, DRF viewsets/serializers, Flutter widgets, Riverpod providers —
+anything that follows an existing pattern:
+
+```bash
+kimi-write --spec "<what to write>" --context <existing-similar-file> --target <output-path>
+```
+
+Then review the output and edit only what needs fixing.
+
+### extract-chat — session transcript extraction
+
+Converts Claude Code JSONL session logs to readable text (no API call, stdlib only):
+
+```bash
+extract-chat <session.jsonl> -o /tmp/chat.txt
+```
+
+Use before post-session doc updates: extract → ask-kimi to suggest changes → apply with Edit.
+
+### Delegation rules
+
+**AUTO-delegate (no prompt needed):**
+
+- Reading 3+ files for exploration or context
+- Single file >400 lines when goal is understanding (not editing)
+- Boilerplate: pytest tests, DRF viewsets/serializers, Flutter widgets, Riverpod providers
+- Post-session documentation updates
+
+**NEVER delegate:**
+
+- Architecture decisions, refactoring plans, feature design
+- Debugging (requires reasoning about error state)
+- Security-sensitive code: auth, permissions, input validation, migrations
+- Tasks requiring exact line numbers for editing — use Read directly
+- Tasks under ~2000 tokens (overhead not worth it)
+
+**Ask first (ambiguous):**
+
+- "Summarize what changed in this PR"
+- Anything touching auth or permissions even if it seems mechanical

--- a/docs/DEPLOYMENT_SECURITY_CHECKLIST.md
+++ b/docs/DEPLOYMENT_SECURITY_CHECKLIST.md
@@ -14,7 +14,8 @@ This checklist consolidates all critical security findings from the codebase aud
 
 **Important Context:** Firebase client API keys are NOT secret - they're designed for client apps. Security is enforced by **Firebase Security Rules**, not key secrecy. The real vulnerability was missing Security Rules.
 
-#### Completed Actions:
+#### Completed Actions
+
 - [✅] **Firebase Security Rules deployed** (deny by default, authenticated access only)
 - [✅] **flutter_dotenv implemented** for environment-based configuration
 - [✅] **Keys moved to .env** (gitignored)
@@ -24,6 +25,7 @@ This checklist consolidates all critical security findings from the codebase aud
 #### Firebase Security Rules (Reference)
 
 **Firestore Rules** - Deny by default, authenticated access only:
+
 ```javascript
 // Firebase Console → Firestore Database → Rules
 rules_version = '2';
@@ -57,6 +59,7 @@ service cloud.firestore {
 ```
 
 **Storage Rules** - Authenticated only with 10MB file size limit:
+
 ```javascript
 // Firebase Console → Storage → Rules
 rules_version = '2';
@@ -84,7 +87,8 @@ service firebase.storage {
 }
 ```
 
-#### Maintenance Checklist (Periodic Review):
+#### Maintenance Checklist (Periodic Review)
+
 - [ ] **Audit Firebase activity** monthly (Firebase Console → Analytics → Usage)
 - [ ] **Review Security Rules** after schema changes
 - [ ] **Monitor quota usage** (check for unusual spikes)
@@ -92,6 +96,7 @@ service firebase.storage {
 - [ ] **Run security scan** before deployments
 
 **Risk Assessment:**
+
 - **Before fix:** CVSS 7.5 (HIGH) - Complete database/storage access by anyone
 - **After fix:** CVSS 2.0 (LOW) - Normal Firebase security posture
 
@@ -105,6 +110,7 @@ service firebase.storage {
 
 - [ ] **Fix SQL injection** in `backend/apps/search/migrations/0003_simple_search_vectors.py:31-34`
   - [ ] Replace f-string concatenation with `psycopg2.sql.SQL()` and `sql.Identifier()`
+
   ```python
   # ❌ Current (vulnerable)
   cursor.execute(f"ALTER TABLE {table} ADD COLUMN ...")
@@ -117,6 +123,7 @@ service firebase.storage {
       )
   )
   ```
+
 - [ ] **Review all migrations** for similar patterns
 - [ ] **Test migration** on staging database
 - [ ] **Add pre-commit hook** to detect SQL injection patterns
@@ -132,20 +139,26 @@ service firebase.storage {
 **Status:** [ ] Not Started | [ ] In Progress | [ ] Complete
 
 - [ ] **Change CSRF cookie to HttpOnly** in `backend/plant_community_backend/settings.py:222`
+
   ```python
   CSRF_COOKIE_HTTPONLY = True  # Prevent JavaScript access
   ```
+
 - [ ] **Implement meta tag pattern** for CSRF token
+
   ```html
   <!-- In base template -->
   <meta name="csrf-token" content="{{ csrf_token }}">
   ```
+
 - [ ] **Update frontend** to read from meta tag instead of cookie
+
   ```typescript
   function getCsrfToken(): string | null {
     return document.querySelector<HTMLMetaElement>('meta[name="csrf-token"]')?.content || null;
   }
   ```
+
 - [ ] **Test all forms** still submit correctly
 - [ ] **Verify registration/login** work with HttpOnly cookie
 
@@ -162,6 +175,7 @@ service firebase.storage {
 **Status:** [ ] Not Started | [ ] In Progress | [ ] Complete
 
 - [ ] **Configure Content-Security-Policy** in `backend/plant_community_backend/settings.py`
+
   ```python
   SECURE_CONTENT_TYPE_NOSNIFF = True
   X_FRAME_OPTIONS = 'DENY'
@@ -172,18 +186,24 @@ service firebase.storage {
   CSP_FONT_SRC = ("'self'", "https://fonts.gstatic.com")
   CSP_STYLE_SRC = ("'self'", "'unsafe-inline'", "https://fonts.googleapis.com")
   ```
+
 - [ ] **Add django-csp** to requirements.txt
+
   ```bash
   pip install django-csp
   ```
+
 - [ ] **Configure middleware** in settings.py
+
   ```python
   MIDDLEWARE = [
       'csp.middleware.CSPMiddleware',  # Add this
       # ... existing middleware
   ]
   ```
+
 - [ ] **Set Permissions-Policy** header
+
   ```python
   SECURE_PERMISSIONS_POLICY = {
       'geolocation': [],
@@ -191,6 +211,7 @@ service firebase.storage {
       'microphone': [],
   }
   ```
+
 - [ ] **Test CSP** doesn't break functionality
   - [ ] Check browser console for CSP violations
   - [ ] Verify all resources load correctly
@@ -207,6 +228,7 @@ service firebase.storage {
 **Status:** [ ] Not Started | [ ] In Progress | [ ] Complete
 
 - [ ] **Add cleanup** to `web/src/components/forum/TipTapEditor.tsx:28-55`
+
   ```tsx
   useEffect(() => {
     if (!editor) return;
@@ -216,6 +238,7 @@ service firebase.storage {
     };
   }, [editor]);
   ```
+
 - [ ] **Test editor** in forum post creation
 - [ ] **Monitor memory** in Chrome DevTools
   - [ ] Create 10 posts, navigate away
@@ -233,6 +256,7 @@ service firebase.storage {
 **Status:** [ ] Not Started | [ ] In Progress | [ ] Complete
 
 - [ ] **Replace 10 COUNT queries** with single aggregation in `backend/apps/forum/viewsets/moderation_queue_viewset.py`
+
   ```python
   stats = FlaggedContent.objects.aggregate(
       total_flags=Count('id'),
@@ -240,10 +264,13 @@ service firebase.storage {
       # ... other conditional counts
   )
   ```
+
 - [ ] **Verify cache warming** still works
+
   ```bash
   python manage.py warm_moderation_cache
   ```
+
 - [ ] **Add performance test** with `assertNumQueries(2)`
 - [ ] **Measure improvement** (should be 500ms → 50ms)
 
@@ -274,11 +301,13 @@ service firebase.storage {
 **Status:** [ ] Not Started | [ ] In Progress | [ ] Complete
 
 - [ ] **Reduce token lifetime** to 15 minutes (OWASP compliant)
+
   ```python
   SIMPLE_JWT = {
       'ACCESS_TOKEN_LIFETIME': timedelta(minutes=15),  # Was 60
   }
   ```
+
 - [ ] **Implement auto-refresh** in frontend (10-minute interval)
 - [ ] **Monitor API load** for refresh endpoint
 - [ ] **Test token expiration** behavior
@@ -370,23 +399,29 @@ service firebase.storage {
 ### Django Settings (Production)
 
 - [ ] **DEBUG = False**
+
   ```python
   DEBUG = config('DEBUG', default=False, cast=bool)
   ```
+
 - [ ] **SECRET_KEY is production-grade**
   - [ ] Minimum 50 characters
   - [ ] Generated with: `python -c 'from django.core.management.utils import get_random_secret_key; print(get_random_secret_key())'`
   - [ ] NOT containing: `django-insecure`, `change-me`, `test`, `dev`, `local`
 - [ ] **ALLOWED_HOSTS configured**
+
   ```python
   ALLOWED_HOSTS = config('ALLOWED_HOSTS', default='', cast=Csv())
   # Example: yourdomain.com,www.yourdomain.com
   ```
+
 - [ ] **CORS_ALLOWED_ORIGINS configured**
+
   ```python
   CORS_ALLOWED_ORIGINS = config('CORS_ALLOWED_ORIGINS', default='', cast=Csv())
   # Example: https://yourdomain.com,https://www.yourdomain.com
   ```
+
 - [ ] **SECURE_SSL_REDIRECT = True** (forces HTTPS)
 - [ ] **SESSION_COOKIE_SECURE = True**
 - [ ] **CSRF_COOKIE_SECURE = True**
@@ -397,12 +432,15 @@ service firebase.storage {
 ### Database
 
 - [ ] **PostgreSQL with SSL** connection
+
   ```python
-  DATABASE_URL = "postgres://user:pass@host:5432/db?sslmode=require"
+  DATABASE_URL = "postgres://user:pass@host:5432/db?sslmode=require"  # pragma: allowlist secret
   ```
+
 - [ ] **Database user** has minimum privileges (not superuser)
 - [ ] **Backups configured** (daily minimum)
 - [ ] **GIN indexes created** for full-text search
+
   ```bash
   python manage.py migrate
   ```
@@ -410,15 +448,20 @@ service firebase.storage {
 ### Redis Cache
 
 - [ ] **Redis is running**
+
   ```bash
   redis-cli ping  # Should return "PONG"
   ```
+
 - [ ] **Redis URL configured**
+
   ```python
   REDIS_URL = config('REDIS_URL', default='redis://localhost:6379/1')
   ```
+
 - [ ] **Redis password** set (if production)
 - [ ] **Cache warming** runs on deployment
+
   ```bash
   python manage.py warm_moderation_cache
   ```
@@ -427,7 +470,7 @@ service firebase.storage {
 
 - [ ] **Plant.id API key** is valid (50 characters)
   - [ ] Free tier: 3 identifications/day
-  - [ ] Upgrade for production: https://admin.kindwise.com/
+  - [ ] Upgrade for production: <https://admin.kindwise.com/>
 - [ ] **PlantNet API key** is valid (optional fallback)
 - [ ] **Firebase API keys** rotated (see Issue #142)
 - [ ] **All keys** in environment variables (NOT in code)
@@ -439,24 +482,29 @@ service firebase.storage {
 - [ ] **HTTPS redirect** enabled (SECURE_SSL_REDIRECT)
 - [ ] **HSTS header** configured (SECURE_HSTS_SECONDS)
 - [ ] **Mixed content** warnings resolved
-- [ ] **Test SSL:** https://www.ssllabs.com/ssltest/
+- [ ] **Test SSL:** <https://www.ssllabs.com/ssltest/>
 
 ### Authentication
 
 - [ ] **JWT secret key** is production-grade
+
   ```python
   JWT_SECRET_KEY = config('JWT_SECRET_KEY')  # Different from SECRET_KEY
   ```
+
 - [ ] **Token lifetime** configured (15 minutes recommended)
 - [ ] **Refresh token rotation** enabled
+
   ```python
   SIMPLE_JWT = {
       'ROTATE_REFRESH_TOKENS': True,
       'BLACKLIST_AFTER_ROTATION': True,
   }
   ```
+
 - [ ] **Account lockout** enabled (5 failed attempts)
 - [ ] **Rate limiting** configured
+
   ```python
   RATE_LIMITS = {
       'auth_endpoints': {
@@ -469,17 +517,23 @@ service firebase.storage {
 ### File Uploads
 
 - [ ] **File size limits** enforced (5MB default)
+
   ```python
   MAX_ATTACHMENT_SIZE_BYTES = 5 * 1024 * 1024  # 5MB
   ```
+
 - [ ] **File extension validation** (whitelist only)
+
   ```python
   ALLOWED_IMAGE_EXTENSIONS = ['jpg', 'jpeg', 'png', 'gif', 'webp']
   ```
+
 - [ ] **MIME type validation** (defense in depth)
+
   ```python
   ALLOWED_IMAGE_MIME_TYPES = ['image/jpeg', 'image/png', 'image/gif', 'image/webp']
   ```
+
 - [ ] **Upload directory** outside web root
 - [ ] **Virus scanning** configured (if handling user uploads)
 
@@ -501,26 +555,35 @@ service firebase.storage {
 ### Deployment
 
 - [ ] **Static files** collected
+
   ```bash
   python manage.py collectstatic --noinput
   ```
+
 - [ ] **Database migrations** applied
+
   ```bash
   python manage.py migrate --noinput
   ```
+
 - [ ] **Cache warmed**
+
   ```bash
   python manage.py warm_moderation_cache
   ```
+
 - [ ] **Gunicorn/Daphne** configured with workers
+
   ```bash
   gunicorn plant_community_backend.wsgi:application \
     --bind 0.0.0.0:8000 \
     --workers 4 \
     --timeout 60
   ```
+
 - [ ] **Process manager** configured (systemd, supervisor)
 - [ ] **Health check** endpoint responding
+
   ```bash
   curl https://yourdomain.com/api/health/
   ```
@@ -528,17 +591,23 @@ service firebase.storage {
 ### Web Frontend
 
 - [ ] **Production build** created
+
   ```bash
   cd web && npm run build
   ```
+
 - [ ] **TypeScript compilation** passes
+
   ```bash
   npx tsc --noEmit  # Should show 0 errors
   ```
+
 - [ ] **Environment variables** set
+
   ```bash
   VITE_API_URL=https://api.yourdomain.com
   ```
+
 - [ ] **CDN configured** for static assets (optional)
 - [ ] **Compression enabled** (gzip, brotli)
 
@@ -546,19 +615,26 @@ service firebase.storage {
 
 - [ ] **Firebase production project** configured
 - [ ] **Firebase Security Rules** deployed
+
   ```bash
   firebase deploy --only firestore:rules
   ```
+
 - [ ] **API keys** loaded from environment
+
   ```dart
   await dotenv.load(fileName: ".env");
   ```
+
 - [ ] **Production build** tested
+
   ```bash
   flutter build apk --release
   flutter build ios --release
   ```
+
 - [ ] **Security scan** passes
+
   ```bash
   python scripts/check_flutter_security.py --fail-on-warning
   ```
@@ -587,14 +663,14 @@ curl -I https://yourdomain.com
 # 3. Test CSRF protection
 curl -X POST https://yourdomain.com/api/v1/users/register/ \
   -H "Content-Type: application/json" \
-  -d '{"username":"test","email":"test@example.com","password":"pass123"}'
+  -d '{"username":"test","email":"test@example.com","password":"pass123"}'  # pragma: allowlist secret
 # Should return: 403 Forbidden (CSRF token missing)
 
 # 4. Test rate limiting
 for i in {1..6}; do
   curl -X POST https://yourdomain.com/api/v1/users/login/ \
     -H "Content-Type: application/json" \
-    -d '{"email":"test@example.com","password":"wrong"}'
+    -d '{"email":"test@example.com","password":"wrong"}'  # pragma: allowlist secret
 done
 # 6th request should return: 429 Too Many Requests
 
@@ -681,9 +757,9 @@ Before going live, verify:
 - **Security Audit Report**: Comprehensive code review (November 9, 2025)
 - **Todo Files**: `/todos/011-020-pending-*.md` (10 detailed issues)
 - **GitHub Issues**: #142-#156 (15 tracking issues)
-- **OWASP Top 10**: https://owasp.org/www-project-top-ten/
-- **Django Security**: https://docs.djangoproject.com/en/5.2/topics/security/
-- **CSP Guide**: https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP
+- **OWASP Top 10**: <https://owasp.org/www-project-top-ten/>
+- **Django Security**: <https://docs.djangoproject.com/en/5.2/topics/security/>
+- **CSP Guide**: <https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP>
 
 ---
 
@@ -692,21 +768,24 @@ Before going live, verify:
 If critical issues are discovered post-deployment:
 
 1. **Revert deployment** immediately
+
    ```bash
    git revert HEAD
    git push origin main
    ```
 
 2. **Rotate compromised secrets**
+
    ```bash
    # Generate new SECRET_KEY
    python -c 'from django.core.management.utils import get_random_secret_key; print(get_random_secret_key())'
 
    # Update in production environment
-   heroku config:set SECRET_KEY="new-key-here"
+   heroku config:set SECRET_KEY="new-key-here"  # pragma: allowlist secret
    ```
 
 3. **Check for data breach**
+
    ```bash
    # Review logs for suspicious activity
    tail -f /var/log/django/security.log | grep "WARN\|ERROR"
@@ -719,4 +798,3 @@ If critical issues are discovered post-deployment:
 **Last Review:** November 9, 2025
 **Next Review:** Before every production deployment
 **Contact:** Development team security lead
-

--- a/docs/GARDEN_PLANNER_IMPLEMENTATION_PLAN.md
+++ b/docs/GARDEN_PLANNER_IMPLEMENTATION_PLAN.md
@@ -1,9 +1,10 @@
 # Garden Planner Feature - Implementation Plan (4-6 weeks)
 
 ## Overview
+
 Replicate all Gardening-Planner features as `/garden-planner` section in React web app with hybrid Django + Firebase backend, fully integrated with existing plant ID, forum, and blog features.
 
-**Source Repository**: https://github.com/Ashutosh049-lab/Gardening-Planner
+**Source Repository**: <https://github.com/Ashutosh049-lab/Gardening-Planner>
 **Integration Approach**: Replicate features (not iframe embed)
 **Backend Strategy**: Hybrid Django + Firebase
 **Platform Priority**: React Web First
@@ -14,9 +15,11 @@ Replicate all Gardening-Planner features as `/garden-planner` section in React w
 ## Phase 1: Backend Foundation (Week 1-2)
 
 ### Django Backend (`backend/apps/garden/`)
+
 **New Django app with PostgreSQL models:**
 
 #### Models
+
 ```python
 # apps/garden/models.py
 
@@ -287,6 +290,7 @@ class PlantCareLibrary(models.Model):
 ```
 
 #### REST API Endpoints
+
 ```
 # URLs: backend/apps/garden/urls.py
 
@@ -399,6 +403,7 @@ class PlantCareLibrary(models.Model):
 ```
 
 #### Services Layer
+
 ```python
 # apps/garden/services/
 
@@ -482,6 +487,7 @@ class CareAssistantService:
 ```
 
 #### Constants
+
 ```python
 # apps/garden/constants.py
 
@@ -529,6 +535,7 @@ RATE_LIMIT_WEATHER_API = "100/hour"
 ### Firebase Setup
 
 #### Firestore Structure
+
 ```
 collections/
 ├── users/
@@ -572,6 +579,7 @@ collections/
 ```
 
 #### Firestore Security Rules
+
 ```javascript
 // firestore.rules
 
@@ -620,6 +628,7 @@ service cloud.firestore {
 ```
 
 #### Firebase Cloud Functions
+
 ```javascript
 // functions/index.js
 
@@ -760,6 +769,7 @@ exports.updatePublicGardens = functions.https.onCall(async (data, context) => {
 ```
 
 #### Django + Firebase Auth Integration
+
 ```python
 # apps/users/services/firebase_service.py
 
@@ -826,6 +836,7 @@ class FirebaseTokenView(APIView):
 ## Phase 2: React Web UI (Week 2-4)
 
 ### Directory Structure
+
 ```
 web/src/
 ├── pages/garden/
@@ -877,6 +888,7 @@ web/src/
 ```
 
 ### TypeScript Interfaces
+
 ```typescript
 // web/src/types/garden.ts
 
@@ -1058,6 +1070,7 @@ export interface WeatherForecast {
 ### Key Components
 
 #### 1. Garden Layout Designer
+
 ```typescript
 // web/src/components/garden/GardenCanvas.tsx
 
@@ -1224,6 +1237,7 @@ export const GardenCanvas: React.FC<GardenCanvasProps> = ({
 ```
 
 #### 2. Reminder Calendar
+
 ```typescript
 // web/src/components/garden/ReminderCalendar.tsx
 
@@ -1286,6 +1300,7 @@ export const ReminderCalendar: React.FC<ReminderCalendarProps> = ({
 ```
 
 #### 3. Weather Widget
+
 ```typescript
 // web/src/components/garden/WeatherWidget.tsx
 
@@ -1387,6 +1402,7 @@ export const WeatherWidget: React.FC<WeatherWidgetProps> = ({
 ```
 
 ### API Services
+
 ```typescript
 // web/src/services/gardenApi.ts
 
@@ -1643,6 +1659,7 @@ export const weatherService = {
 ## Phase 3: Integration Points (Week 4-5)
 
 ### Plant ID → Garden Integration
+
 ```typescript
 // web/src/pages/plant-identification/ResultsPage.tsx (extend existing)
 
@@ -1677,6 +1694,7 @@ const saveToGarden = async (gardenId: number) => {
 ```
 
 ### AI Care Plan Generation
+
 ```python
 # backend/apps/garden/services/care_assistant.py
 
@@ -1768,6 +1786,7 @@ class CareAssistantService:
 ```
 
 ### Forum Garden Showcase
+
 ```python
 # backend/apps/forum/models.py (extend existing)
 
@@ -1804,6 +1823,7 @@ class GardenShowcaseSerializer(serializers.ModelSerializer):
 ## Phase 4: Firebase + Django Sync (Week 5)
 
 ### Real-Time Reminder Workflow
+
 ```typescript
 // web/src/hooks/useFirebaseSync.ts
 
@@ -1849,6 +1869,7 @@ export const useFirebaseSync = (userId: string) => {
 ## Phase 5: Testing & Security (Week 6)
 
 ### Django Tests
+
 ```python
 # backend/apps/garden/tests/test_garden_api.py
 
@@ -1862,7 +1883,7 @@ class GardenAPITestCase(TestCase):
         self.client = APIClient()
         self.user = User.objects.create_user(
             username='testuser',
-            password='testpass123'
+            password='testpass123'  # pragma: allowlist secret
         )
         self.client.force_authenticate(user=self.user)
 
@@ -1925,6 +1946,7 @@ class GardenAPITestCase(TestCase):
 ```
 
 ### React Component Tests
+
 ```typescript
 // web/src/components/garden/__tests__/GardenCanvas.test.tsx
 
@@ -1999,6 +2021,7 @@ describe('GardenCanvas', () => {
 ## Phase 6: Future Flutter Mobile (Post-6 weeks)
 
 ### Flutter Garden Feature Structure
+
 ```dart
 // plant_community_mobile/lib/features/garden/
 
@@ -2035,6 +2058,7 @@ services/
 ### Environment Variables
 
 **Django (.env)**:
+
 ```bash
 # Existing
 SECRET_KEY=...
@@ -2048,6 +2072,7 @@ FIREBASE_SERVICE_ACCOUNT_PATH=/path/to/serviceAccountKey.json
 ```
 
 **React (.env)**:
+
 ```bash
 # Existing
 VITE_API_URL=https://your-api.com
@@ -2065,6 +2090,7 @@ VITE_OPENWEATHER_API_KEY=...
 ```
 
 ### Database Migrations
+
 ```bash
 cd backend
 python manage.py makemigrations garden
@@ -2072,6 +2098,7 @@ python manage.py migrate garden
 ```
 
 ### Firebase Deployment
+
 ```bash
 cd backend/firebase_functions
 npm install
@@ -2080,6 +2107,7 @@ firebase deploy --only firestore:rules
 ```
 
 ### Static Files
+
 ```bash
 # Django
 python manage.py collectstatic
@@ -2094,18 +2122,21 @@ npm run build
 ## Success Metrics
 
 ### Technical Performance
+
 - ✅ Garden designer drag latency <100ms
 - ✅ Weather API response <2s (fresh), <50ms (cached)
 - ✅ Reminder calendar render time <200ms
 - ✅ Firebase sync success rate >99%
 
 ### User Engagement
+
 - ✅ 80%+ plant ID users save to garden
 - ✅ 50%+ daily reminder completion rate
 - ✅ 30%+ gardens shared publicly
 - ✅ 5+ journal entries per active user/month
 
 ### Code Quality
+
 - ✅ 100+ comprehensive tests (Django + React)
 - ✅ Zero TypeScript compilation errors
 - ✅ All security patterns implemented (CSRF, file upload, rate limiting)

--- a/docs/LEARNINGS.md
+++ b/docs/LEARNINGS.md
@@ -195,4 +195,14 @@ This file is append-only. New entries are added by main Claude after each code r
 **Mistake**: `apps/users/firebase_auth_views.py` accepted any successfully-verified Firebase ID token and looked up / created the matching Django user purely on `email`. An attacker could sign up with Firebase email/password using a victim's email address, never click the verify link, and still log in as that user once a Django account with the same email existed (account takeover).
 **Fix**: After `decoded_token = firebase_auth.verify_id_token(...)`, explicitly check `decoded_token.get('email_verified')` and `decoded_token.get('firebase', {}).get('sign_in_provider')`. Reject with HTTP 403 unless the email is verified OR the provider is in a TRUSTED_PROVIDERS allowlist (`google.com`, `apple.com` self-verify emails). Confirmed via Context7 docs (`/websites/firebase_google_auth_admin`) that the SDK does not implicitly enforce verification — it returns the claim and leaves the policy to the caller.
 **Rule**: Any backend that exchanges a Firebase ID token for a session/JWT and matches users by email MUST gate on `email_verified == True` (or a federated-provider allowlist). `verify_id_token` only validates signature/expiry/audience — verification status of the email is the integrator's responsibility. See `backend/docs/patterns/security/authentication.md` for the full pattern.
+
+---
+
+## Tooling / Agents (2026-05-08 additions)
+
+### [2026-05-08] Name-gated pre-commit hooks break files that have both a tracked and a local form
+
+**Mistake**: A `block-claude-md` hook used `grep -E "CLAUDE\.md"` against staged filenames to prevent `CLAUDE.md` from ever being committed. The intent was to stop developers accidentally committing local personalisation notes. Instead it blocked the *team-shared* `CLAUDE.md` (project conventions, delegation rules, critical gotchas) which is intentionally tracked. The hook had no way to distinguish the two forms.
+**Fix**: Removed `block-claude-md`. The two concerns are already handled separately: `.gitignore` with a `CLAUDE.md` entry prevents accidental commits of a purely-local file; `scan-api-keys` catches real credentials regardless of filename. The team-shared `CLAUDE.md` is committed normally.
+**Rule**: Name-gating ("block this filename") is only appropriate for files that must *never* appear in git history (e.g. `.env`, `*.pem`). For files that have a legitimate tracked form alongside a private local form, use `.gitignore` to guard the private form and rely on content-scanning hooks (detect-secrets, scan-api-keys) to catch actual secrets. Combining both in one hook conflates two distinct problems and will eventually block a legitimate commit.
 **Agent**: security-reviewer

--- a/docs/LEARNINGS.md
+++ b/docs/LEARNINGS.md
@@ -188,7 +188,7 @@ This file is append-only. New entries are added by main Claude after each code r
 
 ---
 
-## Security
+## Security (2026-05-07 additions)
 
 ### [2026-05-07] Firebase verify_id_token() does NOT enforce email_verified — backend must gate explicitly
 

--- a/docs/LEARNINGS.md
+++ b/docs/LEARNINGS.md
@@ -3,6 +3,7 @@
 This file is append-only. New entries are added by main Claude after each code review session, based on `pattern-codifier` output. Never edit existing entries.
 
 ## Index
+
 - [Django/DRF](#djangodrf)
 - [Wagtail](#wagtail)
 - [React/TypeScript](#reacttypescript)
@@ -18,6 +19,7 @@ This file is append-only. New entries are added by main Claude after each code r
 ## Django/DRF
 
 ### [2025-11-06] ViewSet `get_permissions()` silently ignores `@action` permission_classes (Issue #131)
+
 **Mistake**: Custom `get_permissions()` override in a ViewSet returned blanket permission lists for all actions, silently overriding the `permission_classes` specified on individual `@action` decorators. NEW-trust users were able to bypass upload restrictions because the action-level `CanUploadImages` permission was never evaluated.
 **Fix**: Custom actions must be explicitly passed through to `super().get_permissions()` so their decorator-level permissions are respected.
 **Rule**: In any ViewSet with a custom `get_permissions()`, enumerate all custom `@action` names and delegate them to `super().get_permissions()` — never return a blanket list that covers custom actions.
@@ -28,12 +30,14 @@ This file is append-only. New entries are added by main Claude after each code r
 ## Wagtail
 
 ### [2026-05-06] Wagtail version mismatch between requirements.txt and requirements-dev.txt
+
 **Mistake**: `requirements.txt` referenced `wagtail==7.4` while `requirements-dev.txt` had `wagtail==7.1.2`, causing inconsistent behaviour between dev and production environments. Agents and pattern docs that referenced a single Wagtail version were silently wrong for one environment.
 **Fix**: Audited both files; agents and pattern docs now reference both versions with dev/prod context where behaviour differs.
 **Rule**: Any version reference in an agent checklist or pattern doc must specify dev vs. prod if they differ. Format: "dev (`requirements-dev.txt`): 7.1.2 · prod (`requirements.txt`): 7.4".
 **Agent**: wagtail-reviewer
 
 ### [2025-11-xx] Signal handlers must use `isinstance()` not `hasattr()` for page type checks
+
 **Mistake**: Signal handlers checking for Wagtail page subtypes used `hasattr(instance, 'blogpostpage')`. Multi-table inheritance makes this unreliable — the parent `Page` instance receives the signal, and the child table row may not be accessible at that point.
 **Fix**: Replaced all `hasattr` type checks with `isinstance(instance, BlogPostPage)`.
 **Rule**: Always use `isinstance()` for Wagtail page type checks in signal handlers. `hasattr()` on multi-table inheritance child attributes is unreliable.
@@ -44,12 +48,14 @@ This file is append-only. New entries are added by main Claude after each code r
 ## React/TypeScript
 
 ### [2025-11-08] React Router v7 imports must use `react-router-dom` not `react-router` (Issue #134)
+
 **Mistake**: 15+ files imported `useNavigate`, `useParams`, `useLocation` from `'react-router'` instead of `'react-router-dom'`. This caused a silent runtime crash: "Cannot read properties of undefined (reading 'navigate')".
 **Fix**: Global search-and-replace of the import source. Zero compilation errors after fix.
 **Rule**: All React Router v7 hooks must be imported from `'react-router-dom'`. The bare `'react-router'` package does not export these hooks in v7.
 **Agent**: react-typescript-reviewer
 
 ### [2025-11-xx] Debounce timers must use `useRef`, not `useState`
+
 **Mistake**: Timer IDs stored in `useState` triggered unnecessary re-renders and created stale closure bugs in the search page debounce handler. The `useCallback` dependency array needed to include the state setter, causing the callback to be recreated on each keystroke and defeating the debounce.
 **Fix**: Moved timer to `useRef` with cleanup in `useEffect` return.
 **Rule**: All timers (setTimeout, setInterval) in React components must be stored in `useRef`. Never store timer IDs in `useState`.
@@ -60,12 +66,14 @@ This file is append-only. New entries are added by main Claude after each code r
 ## Flutter/Firebase
 
 ### [2025-11-15] StreamSubscription memory leaks from Firebase auth state listener (PR #200)
+
 **Mistake**: The auth state `StreamSubscription<User?>` was not cancelled in `ref.onDispose()`. This caused a persistent Firebase connection after the provider was disposed, leading to memory leaks visible across hot restarts.
 **Fix**: Added `ref.onDispose(() { _authStateSubscription?.cancel(); })` to the `build()` method.
 **Rule**: Every `StreamSubscription` in a Riverpod provider MUST be cancelled in `ref.onDispose()`. This is non-negotiable — Firebase listeners are persistent connections that survive widget disposal.
 **Agent**: flutter-firebase-reviewer
 
 ### [2025-11-15] GDPR violation — unredacted email in Django backend logs (PR #200)
+
 **Mistake**: Backend Firebase token exchange endpoint logged the full email address from the decoded Firebase token.
 **Fix**: Added `redact_email()` helper that masks the local part: `william@example.com` → `wi***@example.com`.
 **Rule**: No backend log statement may contain a full email address. Always pass email values through `redact_email()` before logging.
@@ -76,12 +84,14 @@ This file is append-only. New entries are added by main Claude after each code r
 ## Security
 
 ### [2025-11-11] F-strings in raw SQL bypass Django ORM injection protection (Issue #012)
+
 **Mistake**: A migration used f-string interpolation to construct `ALTER TABLE` statements with dynamic table names. This bypassed Django ORM's SQL injection protection.
 **Fix**: Replaced f-strings with `psycopg2.sql.Identifier()` + a hardcoded whitelist of allowed table names.
 **Rule**: Never use f-strings or string concatenation to build raw SQL. Use `psycopg2.sql.Identifier()` for dynamic identifiers and validate against a hardcoded whitelist.
 **Agent**: security-reviewer
 
 ### [2025-11-xx] `icontains` queries must escape `%` and `_` SQL wildcards
+
 **Mistake**: Search endpoints used `icontains` queries without escaping SQL wildcard characters. A query containing `%` matched unintended records.
 **Fix**: Added `escape_search_query()` helper that escapes `%` → `\%` and `_` → `\_`.
 **Rule**: All user-supplied strings used in `icontains` (or any Django ORM filter that maps to SQL `LIKE`) must pass through `escape_search_query()` first.
@@ -92,6 +102,7 @@ This file is append-only. New entries are added by main Claude after each code r
 ## Performance
 
 ### [2025-11-xx] Lenient query count assertions hide N+1 regressions (Issue #117)
+
 **Mistake**: Performance tests used `assertLess(query_count, 10)` which allowed the query count to grow from 1 to 9 without any test failing. An N+1 regression went undetected until production load revealed it.
 **Fix**: Changed all performance test assertions to strict equality: `assertEqual(query_count, N)`.
 **Rule**: Performance tests must use `assertEqual(query_count, N)` with a docstring explaining why N is the expected count. `assertLess` is only acceptable when the count genuinely varies (document why).
@@ -102,6 +113,7 @@ This file is append-only. New entries are added by main Claude after each code r
 ## Testing
 
 ### [2025-11-xx] Django ORM mock tests passed while production migrations failed
+
 **Mistake**: Unit tests that mocked the Django ORM returned passing results for queries that assumed a schema that didn't match the actual migration state. After deploying a migration, the mocked tests continued to pass while production queries failed.
 **Fix**: Removed all ORM mocks; tests now hit a real PostgreSQL test database.
 **Rule**: Never mock Django ORM, QuerySets, or database connections in backend tests. Always use the real PostgreSQL test database with `--keepdb`.
@@ -118,12 +130,14 @@ This file is append-only. New entries are added by main Claude after each code r
 ## Security (2026-05-06 additions)
 
 ### [2026-05-06] ICS calendar export vulnerable to CRLF injection from user-supplied strings
+
 **Mistake**: `plant_name`, `reminder_type`, and `description` were embedded in ICS f-strings without stripping `\r` or `\n`. An attacker could inject arbitrary ICS fields by including CRLF sequences in a plant name.
 **Fix**: Added `_ics_safe = lambda s: str(s).replace('\r', '').replace('\n', ' ')` and applied it to every user-supplied field before embedding in the ICS template.
 **Rule**: Every user-supplied string embedded in an ICS (iCalendar) template MUST pass through a CRLF-stripping sanitizer. Strip both `\r` and `\n` — stripping only `\n` is insufficient.
 **Agent**: pattern-codifier
 
 ### [2026-05-06] Numeric API parameters accepted without `int()` conversion or range check
+
 **Mistake**: `snooze_hours` from `request.data` was passed directly to `mark_snoozed()`. Passing `"abc"` or `"-1"` caused a downstream `TypeError` or silently allowed unreasonable values (e.g., 100,000 hours).
 **Fix**: Added `int()` conversion inside `try/except` followed by `1 <= snooze_hours <= 8760` guard, returning HTTP 400 on failure.
 **Rule**: All numeric parameters from `request.data` or `query_params` MUST be explicitly converted with `int()` inside a `try/except`, then validated against named min/max constants before passing to service methods.
@@ -134,12 +148,14 @@ This file is append-only. New entries are added by main Claude after each code r
 ## Testing (2026-05-06 additions)
 
 ### [2026-05-06] Plant.id v2 mock responses silently pass tests while production uses v3 API
+
 **Mistake**: 3 test files still used v2 mock dicts (`suggestions[].plant_name`). Tests passed because the mock matched the test, but production already parsed v3 (`result.classification.suggestions[].name`).
 **Fix**: Updated all 3 mocks to v3 structure. Tests expecting a single API call now expect two (identify + health_assessment).
 **Rule**: Search for `"plant_name"` as the v2 canary in Plant.id test mocks. Any mock with a top-level `"suggestions"` key is v2 and must be migrated. See `backend/docs/patterns/domain/plant-identification.md` for the canonical v3 mock structure.
 **Agent**: pattern-codifier
 
 ### [2026-05-06] `on_commit` lambdas make target-function patches ineffective in tests
+
 **Mistake**: A test patched `BlogPostView.objects.create` to raise an exception, but the call was inside a `transaction.on_commit` lambda. Django tests wrap each test in a transaction that never commits, so the lambda was queued but never executed. The error-handling path was never tested.
 **Fix**: Patched `apps.blog.middleware.transaction.on_commit` with `side_effect=lambda fn: fn()` to execute the callback immediately.
 **Rule**: When testing code that wraps a call in `transaction.on_commit`, you must either (a) patch `transaction.on_commit` at the call site to execute immediately, or (b) use `self.captureOnCommitCallbacks(execute=True)`. The patch path must match the import in the module under test, not the canonical Django path.
@@ -150,12 +166,21 @@ This file is append-only. New entries are added by main Claude after each code r
 ## Tooling / Agents
 
 ### [2026-05-07] Bash `**` glob silently collapses to `*` without `shopt -s globstar`
+
 **Mistake**: The `full-review-orchestrator` `file:` filter spec relied on `**` for recursive path matching (`file:backend/apps/**`). Default Bash treats `**` as `*` — a single-component wildcard — so `backend/apps/**` matched only direct children of `apps/`, not nested files. The bug would have manifested as the repair phase silently skipping findings under nested paths (e.g., `backend/apps/forum/viewsets/foo.py`).
 **Fix**: Pinned the implementation recipe in `.claude/agents/full-review-orchestrator.md` to `shopt -s globstar nullglob` before glob expansion, with `find <root> -path '<pattern>'` as the alternative. Called out the default-bash trap explicitly.
 **Rule**: Any agent prompt or shell helper that uses `**` for recursive matching MUST set `shopt -s globstar` first, OR use `find -path` instead. Never assume `**` works in bash by default — globstar is an opt-in Bash 4+ feature, off by default. Same applies in zsh's emulated bash mode.
 **Agent**: full-review-orchestrator
 
+### [2026-05-08] `subosito/flutter-action@v2`: never combine `flutter-version` and `channel`
+
+**Mistake**: `security-scan.yml` Flutter setup specified both `flutter-version: '3.38.x'` and `channel: 'stable'`. The action attempts to satisfy both simultaneously, which causes ambiguous resolution — the pinned version may not match the latest stable, leading to either a failed lookup or divergence between the security-scan workflow and the mobile-ci workflow (which used `channel: stable` alone).
+**Fix**: Drop the `flutter-version` pin entirely; use `channel: stable` to always track the latest stable release. If a hard pin is ever needed for a specific reason, use `flutter-version` alone (no `channel`), and document why.
+**Rule**: In `subosito/flutter-action@v2`, choose exactly one resolution strategy: `channel: stable` (floating latest) OR `flutter-version: 'X.Y.Z'` (exact pin). Combining both is unsupported and produces silently ambiguous behaviour. Keep all jobs in a repo using the same strategy so Flutter versions stay in sync across workflows.
+**Agent**: flutter-dart-reviewer
+
 ### [2026-05-07] Full-review orchestrator at full-repo scale: rate-limit risk + main-context overflow
+
 **Mistake**: First end-to-end run of `full-review-orchestrator` over the entire repo (63 invocations across 8 waves of 8). Two operational failures emerged. (1) The 8th and final wave hit Anthropic per-account rate limits — all 7 sub-agents in that wave returned `You've hit your limit`, losing every web/* invocation. (2) Reviewer agents in waves 2-8 are dispatched via `subagent_type=general-purpose` (project-local agents in `.claude/agents/` are not auto-discovered as subagent types in this environment), and the original orchestrator template asked each agent to return findings as JSON in its message body — main Claude's context filled with ~700 KB of finding text after wave 1, threatening compaction.
 **Fix**: (a) Switched waves 2-8 dispatch prompt to a "disk-write" pattern: agent uses its own `Write` tool to save findings JSON to `/tmp/wave_results/<wave>__<agent>__<batch>.json`, then returns only a one-line summary (`Wrote ...json — N findings (X critical, ...)`) so main Claude never holds the full payload. Aggregation reads those files at Phase 3. (b) Recorded the 7 lost wave-8 invocations in `failed_invocations` so the resume flow can re-dispatch only those — the orchestrator's existing `.<review_id>-partial.json` checkpoint already supports this.
 **Rule**: For any orchestrator that dispatches > ~30 sub-agents in a single session, use the disk-write + summary-only return pattern; do not let agents return large JSON inline. Plan for rate-limit pauses at the 50-60 invocation mark per Anthropic account; the orchestrator's resume design (partial checkpoint + completed_waves array) handles this if every wave's results land on disk before the next wave starts. When a project-local reviewer agent isn't accepted as `subagent_type`, fall back to `general-purpose` and instruct it to read `.claude/agents/<name>.md` itself for persona — works equivalently.
@@ -166,6 +191,7 @@ This file is append-only. New entries are added by main Claude after each code r
 ## Security
 
 ### [2026-05-07] Firebase verify_id_token() does NOT enforce email_verified — backend must gate explicitly
+
 **Mistake**: `apps/users/firebase_auth_views.py` accepted any successfully-verified Firebase ID token and looked up / created the matching Django user purely on `email`. An attacker could sign up with Firebase email/password using a victim's email address, never click the verify link, and still log in as that user once a Django account with the same email existed (account takeover).
 **Fix**: After `decoded_token = firebase_auth.verify_id_token(...)`, explicitly check `decoded_token.get('email_verified')` and `decoded_token.get('firebase', {}).get('sign_in_provider')`. Reject with HTTP 403 unless the email is verified OR the provider is in a TRUSTED_PROVIDERS allowlist (`google.com`, `apple.com` self-verify emails). Confirmed via Context7 docs (`/websites/firebase_google_auth_admin`) that the SDK does not implicitly enforce verification — it returns the claim and leaves the policy to the caller.
 **Rule**: Any backend that exchanges a Firebase ID token for a session/JWT and matches users by email MUST gate on `email_verified == True` (or a federated-provider allowlist). `verify_id_token` only validates signature/expiry/audience — verification status of the email is the integrator's responsibility. See `backend/docs/patterns/security/authentication.md` for the full pattern.

--- a/docs/PRE_COMMIT_SETUP.md
+++ b/docs/PRE_COMMIT_SETUP.md
@@ -7,6 +7,7 @@
 ## What are Pre-commit Hooks?
 
 Pre-commit hooks are automated checks that run **before** you commit code to git. They catch issues like:
+
 - Exposed API keys and secrets (Issue #1 prevention)
 - CLAUDE.md being committed (local file only)
 - .env files being committed
@@ -106,20 +107,20 @@ pre-commit run --all-files
 
 ### Code Quality Checks
 
-7. **black** - Python code formatter
-8. **flake8** - Python linter
-9. **isort** - Python import sorter
-10. **eslint** - JavaScript/React linter
-11. **markdownlint** - Markdown formatter
+1. **black** - Python code formatter
+2. **flake8** - Python linter
+3. **isort** - Python import sorter
+4. **eslint** - JavaScript/React linter
+5. **markdownlint** - Markdown formatter
 
 ### Git Hygiene Checks
 
-12. **check-added-large-files** - Prevents files > 10MB
-13. **check-merge-conflict** - Detects merge conflict markers
-14. **no-commit-to-branch** - Prevents direct commits to main/master
-15. **trailing-whitespace** - Removes trailing whitespace
-16. **end-of-file-fixer** - Ensures files end with newline
-17. **detect-private-key** - Detects private key files
+1. **check-added-large-files** - Prevents files > 10MB
+2. **check-merge-conflict** - Detects merge conflict markers
+3. **no-commit-to-branch** - Prevents direct commits to main/master
+4. **trailing-whitespace** - Removes trailing whitespace
+5. **end-of-file-fixer** - Ensures files end with newline
+6. **detect-private-key** - Detects private key files
 
 ## How to Use
 
@@ -307,7 +308,7 @@ $ git commit -m "docs: add setup instructions"
 
 Running scan-api-keys hook...
 WARNING: Potential API key detected in README.md:45
-Pattern: PLANT_ID_API_KEY=W3YvEk2rx8g7Ko3fa8hKrlPJVqQeT2muIfikhKqvSBnaIUkXd4
+Pattern: PLANT_ID_API_KEY=your-plant-id-api-key-here
 ⚠️  Hook passed with warnings
 ```
 
@@ -324,7 +325,7 @@ Running detect-secrets hook...
   File: backend/settings.py
   Line: 67
   Type: Secret Keyword
-  Secret: GOOGLE_OAUTH2_CLIENT_SECRET = "abc123xyz..."
+  Secret: GOOGLE_OAUTH2_CLIENT_SECRET = "abc123xyz..."  # pragma: allowlist secret
 
 ❌ Hook failed
 ```
@@ -356,13 +357,15 @@ jobs:
 ```
 
 This ensures:
+
 - Hooks can't be bypassed with `--no-verify`
 - All commits are validated before merge
 - Team-wide enforcement of security standards
 
 ## Best Practices
 
-### DO:
+### DO
+
 ✅ Run `pre-commit run --all-files` before creating PR
 ✅ Update hooks monthly: `pre-commit autoupdate`
 ✅ Mark false positives in `.secrets.baseline`
@@ -370,7 +373,8 @@ This ensures:
 ✅ Keep .env.example updated with placeholders
 ✅ Fix hook failures immediately, don't skip
 
-### DON'T:
+### DON'T
+
 ❌ Use `--no-verify` except for emergencies
 ❌ Commit CLAUDE.md or .env files
 ❌ Ignore secret detection warnings
@@ -380,7 +384,7 @@ This ensures:
 
 ## Performance Optimization
 
-### Speed up hook execution:
+### Speed up hook execution
 
 ```bash
 # Only run hooks on changed files (default)
@@ -393,7 +397,7 @@ git commit -m "message"
 # Speeds up subsequent runs significantly
 ```
 
-### Typical execution times:
+### Typical execution times
 
 - **First run:** 30-60 seconds (installs hook environments)
 - **Subsequent runs:** 5-15 seconds (cached environments)
@@ -431,8 +435,8 @@ git commit -m "message"
 
 ### Resources
 
-- **Pre-commit docs:** https://pre-commit.com/
-- **detect-secrets:** https://github.com/Yelp/detect-secrets
+- **Pre-commit docs:** <https://pre-commit.com/>
+- **detect-secrets:** <https://github.com/Yelp/detect-secrets>
 - **Issue #1 analysis:** `backend/docs/development/SECURITY_PATTERNS_CODIFIED.md`
 - **Security incident:** `backend/docs/development/SECURITY_INCIDENT_2025_10_23_API_KEYS.md`
 

--- a/docs/SECURITY_QUICK_REFERENCE.md
+++ b/docs/SECURITY_QUICK_REFERENCE.md
@@ -7,18 +7,21 @@
 ## Files You Should NEVER Commit
 
 ### 1. CLAUDE.md (BLOCKER)
+
 ❌ **Never commit** - This is a local development file only
 ✅ **Instead:** Use CLAUDE.md.example as template
 **Why:** Contains real API keys and sensitive context
 **Check:** `git ls-files | grep CLAUDE.md` (should be empty)
 
 ### 2. .env Files (BLOCKER)
+
 ❌ **Never commit** - .env, .env.local, .env.production
 ✅ **Instead:** Use .env.example with placeholders
 **Why:** Contains production secrets and credentials
 **Check:** `grep "^.env$" .gitignore` (should exist)
 
 ### 3. config.local.* (WARNING)
+
 ❌ **Avoid committing** - Local configuration files
 ✅ **Instead:** Use config.example.* templates
 **Why:** May contain developer-specific credentials
@@ -26,13 +29,15 @@
 ## Placeholders vs Real Values
 
 ### ❌ WRONG - Real Values
+
 ```bash
 # DON'T DO THIS
-PLANT_ID_API_KEY=W3YvEk2rx8g7Ko3fa8hKrlPJVqQeT2muIfikhKqvSBnaIUkXd4
+PLANT_ID_API_KEY=your-plant-id-api-key-here
 SECRET_KEY=django-insecure-dev-key-change-in-production-2024
 ```
 
 ### ✅ CORRECT - Placeholders
+
 ```bash
 # DO THIS
 # Plant.id API Key - Get from: https://web.plant.id/
@@ -69,9 +74,11 @@ git commit -m "message"
 ## Common Mistakes and Fixes
 
 ### Mistake 1: "It's just documentation"
+
 **Problem:** Real API keys in README.md, SETUP.md
 **Fix:** Use placeholders with generation instructions
 **Example:**
+
 ```markdown
 ❌ export PLANT_ID_API_KEY=W3YvEk2rx...
 ✅ export PLANT_ID_API_KEY=your-api-key-here
@@ -79,27 +86,33 @@ git commit -m "message"
 ```
 
 ### Mistake 2: "It's just a dev key"
+
 **Problem:** Development keys committed because "not production"
 **Fix:** Use environment variables for ALL keys, even dev
 **Example:**
+
 ```python
-❌ SECRET_KEY = 'dev-key-123'
+❌ SECRET_KEY = 'dev-key-123'  # pragma: allowlist secret
 ✅ SECRET_KEY = os.environ.get('SECRET_KEY')
 ```
 
 ### Mistake 3: "Template with real value"
+
 **Problem:** .env.example has real key "as example"
 **Fix:** Always use obvious placeholders
 **Example:**
+
 ```bash
 ❌ PLANT_ID_API_KEY=test_W3YvEk2rx...
 ✅ PLANT_ID_API_KEY=your-plant-id-api-key-here
 ```
 
 ### Mistake 4: "Local file accidentally added"
+
 **Problem:** CLAUDE.md added with `git add .`
 **Fix:** Add to .gitignore immediately
 **Example:**
+
 ```bash
 # Check if CLAUDE.md in .gitignore
 grep "^CLAUDE.md$" .gitignore
@@ -111,7 +124,9 @@ echo "CLAUDE.md" >> .gitignore
 ## Emergency: I Committed a Secret
 
 ### Step 1: Don't Panic
+
 **If not pushed yet:**
+
 ```bash
 # Undo last commit, keep changes
 git reset --soft HEAD~1
@@ -127,12 +142,14 @@ git commit -m "fix: update configuration"
 ```
 
 **If already pushed:**
+
 1. **Immediately rotate the secret** (most important!)
 2. Report to security team
 3. Follow KEY_ROTATION_INSTRUCTIONS.md
 4. Consider git history rewrite (coordinate with team)
 
 ### Step 2: Rotate the Secret
+
 ```bash
 # For API keys: Visit provider website, revoke old key, generate new
 # For Django SECRET_KEY:
@@ -143,6 +160,7 @@ python -c 'import secrets; print(secrets.token_urlsafe(64))'
 ```
 
 ### Step 3: Update .env File
+
 ```bash
 # Update local .env file (NOT committed)
 vim backend/.env
@@ -171,6 +189,7 @@ pre-commit run --all-files
 ```
 
 **What gets blocked:**
+
 - ✅ CLAUDE.md commits
 - ✅ .env file commits
 - ✅ API key patterns
@@ -201,6 +220,7 @@ settings.local.py
 ```
 
 **Verify:**
+
 ```bash
 # Check critical patterns present
 grep -E "^(CLAUDE.md|\.env|\.env\.local)$" .gitignore
@@ -209,12 +229,14 @@ grep -E "^(CLAUDE.md|\.env|\.env\.local)$" .gitignore
 ## What to Do in Code Review
 
 **As Author:**
+
 - [ ] Verify no secrets in diff: `git diff main...HEAD | grep -i "api_key\|secret"`
 - [ ] Check .gitignore updated if new secret types added
 - [ ] Verify .env.example uses placeholders
 - [ ] Run pre-commit hooks: `pre-commit run --all-files`
 
 **As Reviewer:**
+
 - [ ] Scan for API_KEY, SECRET, PASSWORD in changes
 - [ ] Verify documentation uses placeholders
 - [ ] Check no CLAUDE.md or .env files in PR
@@ -223,17 +245,21 @@ grep -E "^(CLAUDE.md|\.env|\.env\.local)$" .gitignore
 ## Resources
 
 **Quick Setup:**
+
 - PRE_COMMIT_SETUP.md - Install hooks (5 minutes)
 
 **Comprehensive:**
+
 - SECURITY_PATTERNS_CODIFIED.md - Complete analysis
 - ISSUE_1_LESSONS_LEARNED_SUMMARY.md - Full summary
 
 **Incident Details:**
+
 - SECURITY_INCIDENT_2025_10_23_API_KEYS.md
 - KEY_ROTATION_INSTRUCTIONS.md
 
 **Code Review Agent:**
+
 - /.claude/agents/code-review-specialist.md - Now includes secret detection
 
 ## Quick Decision Tree
@@ -264,11 +290,13 @@ Are you about to commit a file?
 ## Remember
 
 **3 Simple Rules:**
+
 1. **NEVER commit CLAUDE.md** (local file only)
 2. **NEVER commit .env files** (use .env.example)
 3. **ALWAYS use placeholders** in documentation and examples
 
 **Before Every Commit:**
+
 - Check `git status` for CLAUDE.md, .env
 - Verify placeholders in changes
 - Let pre-commit hooks run (if installed)

--- a/docs/archive/2025-11/DEPENDENCY_UPDATE_PROGRESS.md
+++ b/docs/archive/2025-11/DEPENDENCY_UPDATE_PROGRESS.md
@@ -9,6 +9,7 @@
 ## ✅ Completed Updates (Phase 6 - Backend Wagtail/Treebeard, May 2026)
 
 ### 6. wagtail: 7.3.1 → 7.4 (LTS) ✅
+
 - **Status**: COMPLETE
 - **Migrations applied**: `wagtailadmin.0006_formstate`, `wagtailcore.0097_baselogentry_uuid_action_timestamp_indexes`, `wagtailsearch.0010_add_text_fields`
 - **Breaking Changes**: Removed Django 4.2 support (we use Django 5.2 — no impact). New StreamField `w-` CSS class prefix added alongside legacy classes (backwards compatible).
@@ -17,26 +18,32 @@
 - **Also upgraded**: `django-treebeard` 4.7.1 → 5.0.5 (auto-pulled as Wagtail 7.4 dependency), `modelsearch` 1.2.2 → 1.3.1
 
 ### 7. django-treebeard: 4.7.1 → 5.0.5 ✅
+
 - **Status**: COMPLETE (installed as part of wagtail 7.4 resolution above)
 - **Breaking Changes**: None for this project
 
 ### 8. CLAUDE.md: firebase-admin pin note updated ✅
+
 - Changed `>=6.6.0,<7.0.0` → `>=7.4.0`
 
 ### 9. Flutter SDK upgrade: 3.38.1 → 3.41.9 / Dart 3.10.0 → 3.11.5 ✅
+
 - **Status**: COMPLETE (May 5, 2026)
 - **Command**: `flutter upgrade`
 - **Tests**: 59 passing, 3 skipped — zero regressions
 
 ### 10. flutter_riverpod 3.3.1 ✅ (already resolved)
+
 - **Status**: CONFIRMED IN LOCKFILE — lockfile already had 3.3.1 (satisfies `^3.1.0`)
 - **No pubspec.yaml change needed**
 
 ### 11. riverpod_generator 4.0.3 ✅ (already resolved)
+
 - **Status**: CONFIRMED IN LOCKFILE — lockfile already had 4.0.3 (satisfies `^4.0.0+1`)
 - **No pubspec.yaml change needed**
 
 ### 12. drift / drift_dev: 2.31.0 → 2.33.0 ⏸️ STILL DEFERRED
+
 - **Blocker (updated)**: Flutter SDK 3.41.9 pins `meta: 1.17.0` exactly in its own pubspec
   - `drift 2.33.0` requires `sqlite3: ^3.1.5`
   - `sqlite3 3.x` + `drift_dev >= 2.32.1` (needs `analyzer >= 10.0.x`) + Flutter meta pin = unsolvable
@@ -49,12 +56,14 @@
 ## ✅ Completed Updates (Phase 1 - High Priority)
 
 ### 1. flutter_dotenv: 5.2.1 → 6.0.0 ✅
+
 - **Status**: COMPLETE
 - **Tests**: 15/15 passing (API service tests)
 - **Breaking Changes**: None detected
 - **Commit**: a79461d
 
 ### 2. permission_handler: 11.4.0 → 12.0.1 ✅ (CRITICAL)
+
 - **Status**: COMPLETE
 - **Transitive Updates**: permission_handler_android 12.1.0 → 13.0.1
 - **Tests**: No new compilation errors
@@ -63,6 +72,7 @@
 - **⚠️ Note**: Manual testing required for camera/gallery permissions on iOS and Android
 
 ### 3. geocoding: 3.0.0 → 4.0.0 ✅
+
 - **Status**: COMPLETE
 - **Transitive Updates**: geocoding_android 3.3.1 → 4.0.1
 - **Tests**: No geocoding-related errors
@@ -74,10 +84,12 @@
 ## ✅ Completed (Phase 3 - Integration Test Validation, May 5, 2026)
 
 ### 4. flutter_secure_storage: ✅ ALREADY AT v10
+
 - **Status**: pubspec.yaml already has `^10.0.0` (resolved from the Phase 1 blocked state)
 - **No action needed**
 
 ### 5. Integration Test Mock Service Fixes ✅ VALIDATED
+
 - **Status**: COMPLETE — validated May 5, 2026
 - **Command**: `flutter test test/integration/`
 - **Result**: `+12: All tests passed!` (12 tests across both files)
@@ -90,6 +102,7 @@
 ## ✅ Completed (Phase 4 - Transitive Upgrade Investigation, May 5, 2026)
 
 ### Transitive Dependency Upgrades: CONFIRMED BLOCKED
+
 **Result**: `flutter pub upgrade --major-versions --dry-run` → "No changes would be made to pubspec.yaml! / No dependencies would change."
 
 19 packages show newer versions in `flutter pub outdated` but none can be upgraded within the current dependency graph:
@@ -112,6 +125,7 @@
 ## ✅ Completed (Phase 5 - Final Validation, May 5, 2026)
 
 ### flutter analyze
+
 - **Result**: 4 `info`-level style warnings (pre-existing, unrelated to dependency changes)
   - `constant_identifier_names` in `care_task.dart` (2) and `garden_plant.dart` (1)
   - `unintended_html_in_doc_comment` in `garden_bed.dart` (1)
@@ -121,14 +135,16 @@
 
 ## 🚀 Deployment Notes
 
-### Manual Testing Required Before Merge:
+### Manual Testing Required Before Merge
+
 - [ ] Test camera permissions on iOS physical device
 - [ ] Test camera permissions on Android physical device
 - [ ] Test gallery/photo picker on both platforms
 - [ ] Verify environment variables load correctly (`flutter run -d macos`)
 - [ ] Verify authentication flow works (login/logout)
 
-### Merge Checklist:
+### Merge Checklist
+
 - [ ] All unit tests passing
 - [ ] All integration tests passing
 - [ ] Flutter analyze shows 0 errors
@@ -141,6 +157,7 @@
 ## 📊 Summary (Final — May 5, 2026)
 
 **Total Packages Updated**: 11
+
 - ✅ Phase 1: flutter_dotenv, permission_handler, geocoding (3 packages)
 - ✅ Phase 5 (Flutter secure storage): already at v10 in pubspec
 - ✅ Phase 5 (Integration tests): validated 12 tests passing
@@ -151,6 +168,7 @@
 - ❌ Phase 4 (Transitive): all blocked — upstream packages haven't released compatible versions
 
 **Test Status (Final)**:
+
 - Backend: ✅ 548 passed, 45 failed (pre-existing), 2 skipped
 - Flutter unit: ✅ 59 passing, 3 skipped
 - Flutter integration: ✅ 12 passing
@@ -169,6 +187,7 @@
 ---
 
 **Manual Testing Still Required Before Production**:
+
 - [ ] Test camera/gallery permissions on iOS physical device
 - [ ] Test camera/gallery permissions on Android physical device
 - [ ] Verify authentication flow (login/logout)

--- a/docs/archive/2025-11/FIREBASE_KEY_ROTATION_COMPLETE.md
+++ b/docs/archive/2025-11/FIREBASE_KEY_ROTATION_COMPLETE.md
@@ -9,6 +9,7 @@
 ## ✅ COMPLETED TASKS
 
 ### 1. New Firebase App Registrations ✅
+
 - **Android App ID**: `1:190351417275:android:53aa5e82b6e221ad69ae9e` (NEW)
 - **iOS App ID**: `1:190351417275:ios:41590963ad4f6bd969ae9e` (NEW)
 - **Old compromised apps**: DELETED from Firebase Console
@@ -16,22 +17,28 @@
   - iOS old: `cde2ebc37ca035de69ae9e` ❌ REVOKED
 
 ### 2. Configuration Files Updated ✅
+
 - ✅ `.env` file updated with new Firebase app IDs
 - ✅ `google-services.json` copied to `android/app/`
 - ✅ `GoogleService-Info.plist` copied to `ios/Runner/`
 - ✅ `.env` file properly gitignored (verified not tracked)
 
 ### 3. Firebase Security Rules Deployed ✅
+
 - ✅ **Firestore rules**: Deployed successfully
+
   ```
   ✔  firestore: released rules firebase/firestore.rules to cloud.firestore
   ```
+
 - ✅ **Storage rules**: Deployed successfully
+
   ```
   ✔  storage: released rules firebase/storage.rules to firebase.storage
   ```
 
 **Security Features Active:**
+
 - 🔐 Authentication required for all operations
 - 🔐 Ownership checks enforce user can only access their own data
 - 🔐 Deny-all default for unmatched paths
@@ -40,6 +47,7 @@
 ### 4. Important Security Note 📋
 
 **Why API keys are the same:**
+
 - Firebase API keys are **PROJECT-level**, not app-level
 - They're public identifiers (meant to be embedded in apps)
 - **Real security comes from Firebase Security Rules** (now deployed ✅)
@@ -52,6 +60,7 @@
 ### Task 1: Test Flutter App on iOS & Android
 
 **iOS Simulator Test:**
+
 ```bash
 cd /Users/williamtower/projects/plant_id_community/plant_community_mobile
 flutter emulators --launch apple_ios_simulator
@@ -59,12 +68,14 @@ flutter run -d ios
 ```
 
 **Android Emulator Test:**
+
 ```bash
 flutter emulators --launch Medium_Phone_API_36.1
 flutter run -d android
 ```
 
 **What to Verify:**
+
 - ✅ App launches without Firebase errors
 - ✅ No exceptions about missing Firebase configuration
 - ✅ Firebase services connect properly (if you have any Firebase features implemented)
@@ -76,7 +87,8 @@ flutter run -d android
 **🔍 Check for Unauthorized Access:**
 
 #### Firestore Activity
-1. Visit: https://console.firebase.google.com/project/plant-community-prod/firestore/usage
+
+1. Visit: <https://console.firebase.google.com/project/plant-community-prod/firestore/usage>
 2. Review graph for past 30 days
 3. **Look for red flags:**
    - ❌ Unusual spikes in document reads/writes
@@ -84,7 +96,8 @@ flutter run -d android
    - ❌ Operations from unexpected geographic locations
 
 #### Storage Activity
-1. Visit: https://console.firebase.google.com/project/plant-community-prod/storage/usage
+
+1. Visit: <https://console.firebase.google.com/project/plant-community-prod/storage/usage>
 2. Review bandwidth and storage usage
 3. **Look for red flags:**
    - ❌ Large unexpected file uploads
@@ -92,7 +105,8 @@ flutter run -d android
    - ❌ Unknown file names or paths
 
 #### Authentication Logs
-1. Visit: https://console.firebase.google.com/project/plant-community-prod/authentication/users
+
+1. Visit: <https://console.firebase.google.com/project/plant-community-prod/authentication/users>
 2. Review user creation dates
 3. **Look for red flags:**
    - ❌ Multiple accounts created in short time
@@ -157,12 +171,14 @@ gh issue close 142
 
 ## 🔐 What Changed vs. What Stayed the Same
 
-### ✅ Changed (Security Improved):
+### ✅ Changed (Security Improved)
+
 1. **App IDs rotated**: Old apps can no longer connect to Firebase
 2. **Security rules deployed**: Authentication and authorization now enforced
 3. **Configuration updated**: New app IDs in `.env` and config files
 
-### ℹ️ Stayed the Same (Expected):
+### ℹ️ Stayed the Same (Expected)
+
 1. **API keys**: PROJECT-level identifiers (same across all apps in project)
 2. **Project ID**: `plant-community-prod` (unchanged)
 3. **Storage bucket**: `plant-community-prod.firebasestorage.app` (unchanged)
@@ -203,11 +219,11 @@ gh issue close 142
 
 ## 🔗 Quick Links
 
-- **Firebase Console**: https://console.firebase.google.com/project/plant-community-prod
-- **GitHub Issue #142**: https://github.com/Xertox1234/plant_id_community/issues/142
-- **Firestore Usage**: https://console.firebase.google.com/project/plant-community-prod/firestore/usage
-- **Storage Usage**: https://console.firebase.google.com/project/plant-community-prod/storage/usage
-- **Authentication Users**: https://console.firebase.google.com/project/plant-community-prod/authentication/users
+- **Firebase Console**: <https://console.firebase.google.com/project/plant-community-prod>
+- **GitHub Issue #142**: <https://github.com/Xertox1234/plant_id_community/issues/142>
+- **Firestore Usage**: <https://console.firebase.google.com/project/plant-community-prod/firestore/usage>
+- **Storage Usage**: <https://console.firebase.google.com/project/plant-community-prod/storage/usage>
+- **Authentication Users**: <https://console.firebase.google.com/project/plant-community-prod/authentication/users>
 
 ---
 

--- a/docs/archive/2025-11/FIREBASE_ROTATION_STATUS.md
+++ b/docs/archive/2025-11/FIREBASE_ROTATION_STATUS.md
@@ -8,30 +8,36 @@
 ## ✅ COMPLETED TASKS
 
 ### 1. Firebase App Registration Rotation ✅
+
 - **New Android App ID**: `1:190351417275:android:53aa5e82b6e221ad69ae9e`
 - **New iOS App ID**: `1:190351417275:ios:41590963ad4f6bd969ae9e`
 - **Old compromised apps**: DELETED from Firebase Console
 
 ### 2. Configuration Files Updated ✅
+
 - `.env` file updated with new Firebase app IDs
 - `google-services.json` copied to `android/app/`
 - `GoogleService-Info.plist` copied to `ios/Runner/`
 - `.env` properly gitignored
 
 ### 3. Firebase Security Rules Deployed ✅
+
 ```
 ✔  firestore: released rules firebase/firestore.rules to cloud.firestore
 ✔  storage: released rules firebase/storage.rules to firebase.storage
 ```
 
 ### 4. Firebase Configuration Verification ✅
+
 **Build Log Analysis**:
+
 - ✅ Firebase plugins loaded successfully (cloud_firestore, firebase_auth, firebase_storage)
 - ✅ `.env` file read correctly (no missing Firebase key errors)
 - ✅ All Firebase SDK dependencies resolved (Firebase SDK 12.4.0)
 - ✅ No Firebase authentication or connection errors
 
 **iOS Platform Update**:
+
 - Updated `ios/Podfile` deployment target to iOS 15.0 (required for Firebase)
 - Installed CocoaPods successfully with all Firebase dependencies
 
@@ -44,25 +50,31 @@
 **Check these areas for unauthorized access (past 30 days)**:
 
 #### Firestore Activity
-URL: https://console.firebase.google.com/project/plant-community-prod/firestore/usage
+
+URL: <https://console.firebase.google.com/project/plant-community-prod/firestore/usage>
 
 **Look for**:
+
 - ❌ Unusual spikes in document reads/writes
 - ❌ Activity during off-hours
 - ❌ Operations from unexpected locations
 
 #### Storage Activity
-URL: https://console.firebase.google.com/project/plant-community-prod/storage/usage
+
+URL: <https://console.firebase.google.com/project/plant-community-prod/storage/usage>
 
 **Look for**:
+
 - ❌ Large unexpected file uploads
 - ❌ Bandwidth spikes
 - ❌ Unknown file paths
 
 #### Authentication
-URL: https://console.firebase.google.com/project/plant-community-prod/authentication/users
+
+URL: <https://console.firebase.google.com/project/plant-community-prod/authentication/users>
 
 **Look for**:
+
 - ❌ Mass account creation
 - ❌ Suspicious email patterns
 - ❌ Accounts created during odd hours
@@ -120,12 +132,15 @@ gh issue close 142
 ## 🔐 Important Security Notes
 
 ### Why API Keys Are the Same
+
 Firebase API keys are PROJECT-level identifiers (not app-level secrets):
+
 - Same keys are used across all apps in a Firebase project
 - They're public identifiers meant to be embedded in apps
 - **Security comes from Firebase Security Rules** (now deployed ✅)
 
 ### What Actually Changed
+
 - **App IDs changed**: Old apps can no longer connect
 - **Security rules deployed**: Authentication + authorization now enforced
 - **Old app registrations deleted**: Revoked access even with same API keys
@@ -150,5 +165,5 @@ Firebase API keys are PROJECT-level identifiers (not app-level secrets):
 ---
 
 **Generated**: November 14, 2025
-**Firebase Console**: https://console.firebase.google.com/project/plant-community-prod
-**GitHub Issue**: https://github.com/Xertox1234/plant_id_community/issues/142
+**Firebase Console**: <https://console.firebase.google.com/project/plant-community-prod>
+**GitHub Issue**: <https://github.com/Xertox1234/plant_id_community/issues/142>

--- a/docs/archive/2025-11/FIREBASE_SECURITY_REMEDIATION_PLAN.md
+++ b/docs/archive/2025-11/FIREBASE_SECURITY_REMEDIATION_PLAN.md
@@ -41,6 +41,7 @@ Firebase API keys were exposed in git commit history (commit `e43a7e1`). While t
 **Location**: Commit `e43a7e1` - Initial commit
 
 **Exposed Credentials**:
+
 ```
 Android API Key: AIzaSyDpRChSGfwYei1xfyjxcCNWjjnVJN2mBEA
 iOS API Key: AIzaSyBKJCbHFQ4fQihCWXbAV1aX50mkSxo4oQM
@@ -69,6 +70,7 @@ iOS Bundle ID: com.plantcommunity.plantCommunityMobile
 5. Click **"Regenerate Web API Key"** (or create new Android app)
 6. Copy the new `apiKey` value
 7. Update your local `.env` file:
+
    ```env
    FIREBASE_ANDROID_API_KEY=<new_key_here>
    ```
@@ -79,6 +81,7 @@ iOS Bundle ID: com.plantcommunity.plantCommunityMobile
 2. Click **"Regenerate Web API Key"** (or create new iOS app)
 3. Copy the new `apiKey` value
 4. Update your local `.env` file:
+
    ```env
    FIREBASE_IOS_API_KEY=<new_key_here>
    ```
@@ -86,6 +89,7 @@ iOS Bundle ID: com.plantcommunity.plantCommunityMobile
 #### Step 1.3: Delete Old Apps (Recommended)
 
 **Option A - Safer**: Create entirely new Android/iOS apps in Firebase:
+
 1. Click **"Add app"** button
 2. Register new Android app with same package name
 3. Register new iOS app with same bundle ID
@@ -140,6 +144,7 @@ firebase deploy --only storage
    - Document deletes
 
 **Red Flags**:
+
 - Unusual spikes in read/write activity
 - Activity during hours you weren't using the app
 - Reads from unexpected geographic locations
@@ -151,6 +156,7 @@ firebase deploy --only storage
 3. Look for unusual file uploads or downloads
 
 **Red Flags**:
+
 - Large unexpected file uploads
 - Bandwidth spikes
 - Unusual file access patterns
@@ -162,6 +168,7 @@ firebase deploy --only storage
 3. Check for suspicious accounts
 
 **Red Flags**:
+
 - Multiple accounts created in short time
 - Accounts with suspicious email patterns
 - Accounts created during odd hours
@@ -232,11 +239,13 @@ Firebase client API keys are **meant to be embedded in apps**. Security comes fr
 ### If You Want to Clean Git History
 
 **Step 1**: Backup repository:
+
 ```bash
 git clone https://github.com/Xertox1234/plant_id_community.git plant_id_backup
 ```
 
 **Step 2**: Use BFG Repo-Cleaner:
+
 ```bash
 # Install BFG
 brew install bfg
@@ -256,12 +265,14 @@ git push --force --all
 **Step 3**: Notify all contributors to re-clone repository
 
 **Risks**:
+
 - Breaks all forks
 - Requires all developers to re-clone
 - May not remove data from GitHub's cache immediately
 - Previous commits may still be accessible via direct links
 
 **Recommendation**: Given that:
+
 1. Security rules are properly configured
 2. Keys are rotated
 3. Firebase client keys are meant to be public anyway
@@ -273,16 +284,19 @@ git push --force --all
 ## 📊 Post-Remediation Monitoring
 
 ### Week 1: Daily Monitoring
+
 - Check Firebase usage dashboard daily
 - Review authentication logs
 - Monitor for unusual activity
 
 ### Week 2-4: Weekly Monitoring
+
 - Weekly Firebase usage review
 - Check for quota approaching limits
 - Review any new security alerts
 
 ### Ongoing: Monthly Audits
+
 - Monthly Firebase security audit
 - Review and update security rules as needed
 - Monitor Firebase SDK updates
@@ -306,9 +320,10 @@ git push --force --all
 From Firebase documentation:
 > "Unlike how API keys are typically used, API keys for Firebase services are not used to control access to backend resources; that can only be done with Firebase Security Rules. Usually, you need to fastidiously guard API keys (for example, by using a vault service or setting the keys as environment variables); however, API keys for Firebase services are ok to include in code or checked-in config files."
 
-**Source**: https://firebase.google.com/docs/projects/api-keys
+**Source**: <https://firebase.google.com/docs/projects/api-keys>
 
 The **real security** comes from:
+
 1. ✅ **Security Rules** (properly configured)
 2. ✅ **Authentication** (Firebase Auth)
 3. ✅ **Authorization** (ownership checks in rules)

--- a/docs/archive/2025-11/KEY_ROTATION_INSTRUCTIONS.md
+++ b/docs/archive/2025-11/KEY_ROTATION_INSTRUCTIONS.md
@@ -11,7 +11,7 @@ This PR removes exposed API keys from the repository, but you **MUST** rotate th
 
 ### 1. Rotate Plant.id API Key (5 minutes)
 
-1. Visit https://web.plant.id/account (or https://my.kindwise.com/)
+1. Visit <https://web.plant.id/account> (or <https://my.kindwise.com/>)
 2. Log in to your account
 3. Navigate to: **API Keys** or **Developer Settings**
 4. **Revoke the old key:** `W3YvEk2rx8g7Ko3fa8hKrlPJVqQeT2muIfikhKqvSBnaIUkXd4`
@@ -20,7 +20,7 @@ This PR removes exposed API keys from the repository, but you **MUST** rotate th
 
 ### 2. Rotate PlantNet API Key (5 minutes)
 
-1. Visit https://my.plantnet.org/
+1. Visit <https://my.plantnet.org/>
 2. Log in to your account
 3. Navigate to: **API Keys** or **Account Settings**
 4. **Revoke the old key:** `2b10XCJNMzrPYiojVsddjK0n`
@@ -71,10 +71,10 @@ cp .env.example .env
 
 ```bash
 # Update production environment variables
-heroku config:set PLANT_ID_API_KEY="new_plant_id_key_here"
-heroku config:set PLANTNET_API_KEY="new_plantnet_key_here"
-heroku config:set SECRET_KEY="new_django_secret_key_here"
-heroku config:set JWT_SECRET_KEY="new_jwt_secret_key_here"
+heroku config:set PLANT_ID_API_KEY="new_plant_id_key_here"  # pragma: allowlist secret
+heroku config:set PLANTNET_API_KEY="new_plantnet_key_here"  # pragma: allowlist secret
+heroku config:set SECRET_KEY="new_django_secret_key_here"  # pragma: allowlist secret
+heroku config:set JWT_SECRET_KEY="new_jwt_secret_key_here"  # pragma: allowlist secret
 
 # Verify
 heroku config:get PLANT_ID_API_KEY
@@ -130,12 +130,14 @@ curl -X POST http://localhost:8000/api/plant-identification/identify/ \
 ## Why This Matters
 
 ### Current Risk
+
 - **Plant.id key:** 100 IDs/month limit - can be exhausted quickly
 - **PlantNet key:** 500 IDs/day limit - can be exhausted rapidly
 - **Django SECRET_KEY:** Session hijacking, CSRF bypass
 - **JWT_SECRET_KEY:** Complete authentication bypass
 
 ### Impact if Not Rotated
+
 - Legitimate users unable to identify plants (quota exhausted)
 - Service disruption for development and production
 - Potential unauthorized access to user sessions
@@ -144,6 +146,7 @@ curl -X POST http://localhost:8000/api/plant-identification/identify/ \
 ## Timeline
 
 **Immediate (Today):**
+
 - [ ] Rotate Plant.id API key
 - [ ] Rotate PlantNet API key
 - [ ] Generate new Django SECRET_KEY
@@ -153,11 +156,13 @@ curl -X POST http://localhost:8000/api/plant-identification/identify/ \
 - [ ] Verify health endpoint works
 
 **Within 24 Hours:**
+
 - [ ] Test plant identification with new keys
 - [ ] Monitor API usage for next 7 days
 - [ ] Report completion on GitHub Issue #1
 
 **Within 7 Days:**
+
 - [ ] Decide on git history cleanup with team
 - [ ] Implement GitHub secret scanning
 - [ ] Add pre-commit hooks for secret detection
@@ -169,11 +174,13 @@ curl -X POST http://localhost:8000/api/plant-identification/identify/ \
 The exposed keys exist in git history (5 commits). Options:
 
 ### Option 1: Do Nothing (Recommended if low risk)
+
 - Keys are rotated, so old keys are useless
 - No disruption to team workflow
 - Simpler approach
 
 ### Option 2: Rewrite Git History (High coordination required)
+
 - Removes keys from all commits
 - **Requires all team members to delete and re-clone repo**
 - See `SECURITY_INCIDENT_2025_10_23_API_KEYS.md` for detailed instructions
@@ -185,9 +192,10 @@ The exposed keys exist in git history (5 commits). Options:
 **Questions?** Comment on GitHub Issue #1
 
 **Need Help?**
-- Plant.id support: https://web.plant.id/
-- PlantNet support: https://my.plantnet.org/contact
-- Django SECRET_KEY docs: https://docs.djangoproject.com/en/5.2/ref/settings/#secret-key
+
+- Plant.id support: <https://web.plant.id/>
+- PlantNet support: <https://my.plantnet.org/contact>
+- Django SECRET_KEY docs: <https://docs.djangoproject.com/en/5.2/ref/settings/#secret-key>
 
 ## Completion Checklist
 

--- a/docs/superpowers/plans/2026-05-07-completing-todos-skill.md
+++ b/docs/superpowers/plans/2026-05-07-completing-todos-skill.md
@@ -1,0 +1,1077 @@
+# Completing Todos Skill — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a project-local skill that drives `status: pending` todo files in `todos/` through implementation → verification → code review → archival, plus a frozen template that future audits use to create new todos.
+
+**Architecture:** One markdown skill at `.claude/skills/completing-todos/SKILL.md` orchestrates the workflow and reuses the existing `code-review-orchestrator` agent. A `todos/TEMPLATE.md` codifies the frontmatter + section structure so future todos stay consistent. Checkpoint files for resumability are git-ignored.
+
+**Tech Stack:** Markdown (skill prose, template, README), bash + grep + git for discovery and verification, Claude Code Skill tool for invocation, existing `.claude/agents/code-review-orchestrator.md` for the review step.
+
+**Spec:** [docs/superpowers/specs/2026-05-07-completing-todos-skill-design.md](../specs/2026-05-07-completing-todos-skill-design.md)
+
+---
+
+## Important Context (read before starting)
+
+**1. `.claude/*` is gitignored.** The repo has `.claude/*` in `.gitignore` (line 175) with an exception only for `.claude/agents/`. The new skill at `.claude/skills/…` will NOT be tracked unless you add `!.claude/skills/`. Task 1 handles this; do not skip it.
+
+**2. This skill is markdown prose, not code.** "Tests" are not unit tests — they are:
+
+- Reading the file back to confirm structure (grep, head, wc)
+- Running the discovery commands the skill embeds (`grep -l "^status: pending" todos/*.md`)
+- Invoking the skill via the Skill tool with `--dry-run` to confirm prompts/gates fire
+- A final live-run on one small todo to validate end-to-end
+
+**3. Filename convention** (from existing todos): `NNN-<status>-pX-<slug>.md` where `NNN` is zero-padded, `pX` is `p1|p2|p3|p4`, and the status segment must match the YAML frontmatter `status:` value.
+
+**4. Existing agents to reuse, not rewrite:**
+
+- [.claude/agents/code-review-orchestrator.md](../../../.claude/agents/code-review-orchestrator.md) — invoked at step 4 of Phase 1
+- Specialist agents (`Explore`, `frontend-developer`, `wagtail-cms-orchestrator`, `general-purpose`) — invoked from step 2 of Phase 1 when the todo's work needs them
+
+---
+
+## File Structure
+
+| File | Status | Responsibility |
+|---|---|---|
+| `.gitignore` | Modify | Carve out `!.claude/skills/` exception; ignore `todos/.completing-todos-run-*.json` |
+| `todos/TEMPLATE.md` | Create | Frozen template — YAML frontmatter + every required section, with a "do not edit in place" header comment |
+| `todos/README.md` | Modify | Add "Creating a New Todo" section pointing at the template |
+| `.claude/skills/completing-todos/SKILL.md` | Create | The skill itself: frontmatter + Phase 0 + Phase 1 + Phase 2 + Resumability + Safety Rails |
+
+---
+
+## Task 1: Carve out `.claude/skills/` and ignore checkpoint files
+
+**Files:**
+
+- Modify: `.gitignore` (lines 174–176 for the skills exception; lines 203–207 area for checkpoint pattern)
+
+- [ ] **Step 1: Inspect the current `.claude` exception block**
+
+Run: `sed -n '174,177p' .gitignore`
+Expected output:
+
+```
+# Claude Code configuration and tools (ignore contents, not dir itself, so agents/ exception works)
+.claude/*
+!.claude/agents/
+
+```
+
+- [ ] **Step 2: Add `!.claude/skills/` exception**
+
+Edit `.gitignore`. Find this exact block:
+
+```
+# Claude Code configuration and tools (ignore contents, not dir itself, so agents/ exception works)
+.claude/*
+!.claude/agents/
+```
+
+Replace with:
+
+```
+# Claude Code configuration and tools (ignore contents, not dir itself, so agents/ and skills/ exceptions work)
+.claude/*
+!.claude/agents/
+!.claude/skills/
+```
+
+- [ ] **Step 3: Add the checkpoint-file ignore pattern**
+
+Edit `.gitignore`. Find this exact block (near line 203):
+
+```
+# Full-review per-review artifacts (date-stamped, noisy). Index history committed.
+docs/reviews/*-full-review.md
+docs/reviews/*-full-review.json
+docs/reviews/.*-partial.json
+!docs/reviews/INDEX.md
+```
+
+Append after it (with one blank line of separation):
+
+```
+
+# Completing-todos run checkpoints (per-run, transient)
+todos/.completing-todos-run-*.json
+```
+
+- [ ] **Step 4: Verify both ignore rules work**
+
+Run:
+
+```bash
+mkdir -p .claude/skills/_probe && touch .claude/skills/_probe/x.md && \
+  touch todos/.completing-todos-run-2026-05-07-1200.json && \
+  git check-ignore -v .claude/skills/_probe/x.md todos/.completing-todos-run-2026-05-07-1200.json && \
+  echo OK_NOT_IGNORED || echo OK_IGNORED
+```
+
+Expected output: the skills probe path prints with `!.claude/skills/` as the matching rule (meaning it is NOT ignored), and the checkpoint path prints with the new `todos/.completing-todos-run-*.json` rule (meaning it IS ignored). The `git check-ignore` exit code will be mixed; what matters is each path's rule reference in the output.
+
+Then clean up:
+
+```bash
+rm -rf .claude/skills/_probe todos/.completing-todos-run-2026-05-07-1200.json
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .gitignore
+git commit -m "chore(gitignore): allow .claude/skills/ and ignore completing-todos checkpoints"
+```
+
+---
+
+## Task 2: Create `todos/TEMPLATE.md`
+
+**Files:**
+
+- Create: `todos/TEMPLATE.md`
+
+- [ ] **Step 1: Write the template file**
+
+Create `todos/TEMPLATE.md` with exactly this content:
+
+````markdown
+<!--
+COPY THIS FILE — do not edit in place.
+
+Filename: NNN-pending-pX-short-slug.md
+  NNN     = next zero-padded issue id (check `ls todos/*.md | tail -1`)
+  pX      = p1 | p2 | p3 | p4
+  slug    = lowercase-kebab-case, ≤ 6 words
+
+Status transitions: pending → in_progress → completed (or blocked).
+The filename status segment MUST match the frontmatter status value.
+
+Required sections: Problem, Findings, Recommended Action, Technical Details,
+Acceptance Criteria, Work Log. Optional sections (Proposed Solutions, Notes)
+may be deleted entirely if not used — never leave them blank.
+-->
+
+---
+status: pending
+priority: pX
+issue_id: "NNN"
+tags: []
+dependencies: []
+---
+
+# <Concise Issue Title>
+
+## Problem
+
+<1–3 sentences. What's broken or missing, and why it matters.>
+
+## Findings
+
+<Bullet list. Each bullet anchored to a file path, line number, command output,
+or commit. State the discovery source (audit run, agent, human).>
+
+## Proposed Solutions
+
+### Option 1: <Recommended>
+- **Implementation:** <how>
+- **Pros:** <list>
+- **Cons:** <list>
+- **Effort:** <minutes / hours>
+- **Risk:** <low / medium / high, with reason>
+
+### Option 2: <Alternative>
+<Same shape. Drop entire section if there is genuinely only one viable option.>
+
+## Recommended Action
+
+<Numbered list of concrete steps. Include code snippets, commands, file paths.>
+
+## Technical Details
+
+<File paths, line numbers, configuration examples, links to relevant patterns
+under backend/docs/patterns/, web/docs/patterns/, etc.>
+
+## Acceptance Criteria
+
+- [ ] <Verifiable criterion — passes a test, produces a build, etc.>
+- [ ] <Each criterion must be objectively checkable.>
+
+## Work Log
+
+### YYYY-MM-DD - <Event>
+
+- <What happened, by whom, with what outcome.>
+
+## Notes
+
+<Priority rationale, related issue ids, trade-offs, deferred decisions.>
+````
+
+- [ ] **Step 2: Verify required sections are present**
+
+Run:
+
+```bash
+grep -E '^## ' todos/TEMPLATE.md
+```
+
+Expected output (in this order):
+
+```
+## Problem
+## Findings
+## Proposed Solutions
+## Recommended Action
+## Technical Details
+## Acceptance Criteria
+## Work Log
+## Notes
+```
+
+- [ ] **Step 3: Verify frontmatter parses (matches existing todos)**
+
+Run:
+
+```bash
+sed -n '/^---$/,/^---$/p' todos/TEMPLATE.md | head -10
+```
+
+Expected output (between the `---` markers): five YAML keys — `status`, `priority`, `issue_id`, `tags`, `dependencies` — matching the schema documented in [todos/README.md](../../../todos/README.md#L168-L175).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add todos/TEMPLATE.md
+git commit -m "docs(todos): add TEMPLATE.md for new todo files"
+```
+
+---
+
+## Task 3: Add "Creating a New Todo" section to `todos/README.md`
+
+**Files:**
+
+- Modify: `todos/README.md` (insert after the "Quick Reference" header, before the existing "Current Stabilization Sweep" subsection)
+
+- [ ] **Step 1: Locate the insertion point**
+
+Run: `grep -n '^## Quick Reference' todos/README.md`
+Expected output: `9:## Quick Reference`
+
+Run: `sed -n '9,13p' todos/README.md`
+Expected output:
+
+```
+## Quick Reference
+
+### Current Stabilization Sweep (May 1, 2026)
+
+These todos were created after a fresh codebase assessment to make the repository safe to resume before new feature work:
+```
+
+- [ ] **Step 2: Insert the new section**
+
+Use Edit. Find this exact block:
+
+```
+## Quick Reference
+
+### Current Stabilization Sweep (May 1, 2026)
+```
+
+Replace with:
+
+```
+## Creating a New Todo
+
+1. Copy `TEMPLATE.md` to `NNN-pending-pX-slug.md` (next zero-padded id, lowercase kebab slug, ≤ 6 words).
+2. Fill every required section. Optional sections (Proposed Solutions, Notes) may be deleted, never left blank.
+3. Frontmatter `status:` must match the filename's status segment at all times.
+4. Commit the new file before referencing its `issue_id` from another todo's `dependencies`.
+
+To work through pending todos, invoke the `completing-todos` skill (`/completing-todos` or "complete the pending todos").
+
+## Quick Reference
+
+### Current Stabilization Sweep (May 1, 2026)
+```
+
+- [ ] **Step 3: Verify the section landed**
+
+Run: `grep -n '^## Creating a New Todo' todos/README.md`
+Expected output: `9:## Creating a New Todo`
+
+Run: `grep -n '^## Quick Reference' todos/README.md`
+Expected output: a line number greater than 9 (the section moved down).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add todos/README.md
+git commit -m "docs(todos): document template usage and completing-todos entry point"
+```
+
+---
+
+## Task 4: Scaffold the skill — frontmatter + overview only
+
+This task creates the file with just enough structure that the Skill tool can load it. Subsequent tasks fill in each phase.
+
+**Files:**
+
+- Create: `.claude/skills/completing-todos/SKILL.md`
+
+- [ ] **Step 1: Create the directory**
+
+Run:
+
+```bash
+mkdir -p .claude/skills/completing-todos
+```
+
+- [ ] **Step 2: Verify the directory is tracked (not git-ignored)**
+
+Run:
+
+```bash
+touch .claude/skills/completing-todos/.gitkeep && \
+  git check-ignore -v .claude/skills/completing-todos/.gitkeep; \
+  echo "exit=$?"
+```
+
+Expected: the path is NOT ignored. `git check-ignore` should print nothing and exit with code 1 (meaning "not ignored"), or print the `!.claude/skills/` exception rule if your git version reports the matching negative rule. Either way, `exit=1` confirms not-ignored.
+
+Then clean up: `rm .claude/skills/completing-todos/.gitkeep`
+
+- [ ] **Step 3: Write the SKILL.md scaffold**
+
+Create `.claude/skills/completing-todos/SKILL.md` with this content:
+
+````markdown
+---
+name: completing-todos
+description: Work through pending todo files in todos/ — one, many, or all. Drives each through implementation → verification → code review → archival. Use when the user says "complete the pending todos", "clear todos", "finish todo NNN", or invokes /completing-todos.
+---
+
+# Completing Todos
+
+Drive `status: pending` todo files in `todos/` through implementation, verification, code review, and archival. Reuse `code-review-orchestrator` for the review step; never reimplement its routing.
+
+**Announce at start:** "I'm using the completing-todos skill to work through pending todos."
+
+## Trigger phrases
+
+- `/completing-todos`
+- "complete the pending todos"
+- "work through the todos"
+- "clear all todos"
+- "finish todo NNN" (single-todo mode — parse `NNN` and treat as `--ids NNN`)
+
+## Filter flags
+
+Parsed from the user's invocation message:
+
+- `--priority p1` — restrict to one priority (default: all)
+- `--ids 050,052,056` — restrict to specific issue_ids
+- `--skip 053,054` — exclude specific issue_ids
+- `--dry-run` — print the plan and per-todo prompts; touch nothing
+
+Natural-language id references ("finish todo 050", "do 052 and 056") normalize to the equivalent `--ids` flag during Phase 0.
+
+## Workflow
+
+The skill runs in three phases. Phase 0 confirms scope. Phase 1 loops per todo. Phase 2 wraps up.
+
+(Phase sections appear below — populated in subsequent commits.)
+
+## Phases
+
+### Phase 0 — Scope Confirmation
+
+(populated in Task 5)
+
+### Phase 1 — Per-Todo Loop
+
+(populated in Tasks 6–7)
+
+### Phase 2 — Wrap-Up
+
+(populated in Task 5)
+
+## Resumability
+
+(populated in Task 5)
+
+## Safety Rails
+
+(populated in Task 8)
+````
+
+- [ ] **Step 4: Verify the skill loads (frontmatter is valid)**
+
+Run:
+
+```bash
+head -5 .claude/skills/completing-todos/SKILL.md
+```
+
+Expected output: opens with `---`, then `name: completing-todos`, then `description: Work through pending todo files…`, then `---`, then a blank line.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .claude/skills/completing-todos/SKILL.md
+git commit -m "feat(skill): scaffold completing-todos skill"
+```
+
+---
+
+## Task 5: Phase 0 (Scope Confirmation), Phase 2 (Wrap-Up), Resumability
+
+After this task, `--dry-run` is fully functional end-to-end (it never enters Phase 1).
+
+**Files:**
+
+- Modify: `.claude/skills/completing-todos/SKILL.md`
+
+- [ ] **Step 1: Replace Phase 0 placeholder**
+
+Use Edit. Find:
+
+```
+### Phase 0 — Scope Confirmation
+
+(populated in Task 5)
+```
+
+Replace with:
+
+````
+### Phase 0 — Scope Confirmation
+
+1. **Generate a `run_id`** for this invocation:
+   ```bash
+   date -u +"%Y-%m-%d-%H%M"
+   ```
+
+2. **Check for an interrupted run.** Glob:
+   ```bash
+   ls -1 todos/.completing-todos-run-*.json 2>/dev/null
+   ```
+   If one or more matches exist, read the most recent and follow the **Resumability** section below; do NOT continue with steps 3–8.
+
+3. **Discover candidates:**
+   ```bash
+   grep -l "^status: pending" todos/*.md | sort
+   ```
+
+4. **Parse each candidate's frontmatter** (`priority`, `issue_id`, `dependencies`) and title (the first `# ` line of the file).
+
+5. **Apply filter flags** parsed from the user's invocation message:
+   - `--priority pX` — keep only matching priority
+   - `--ids A,B,C` — keep only matching issue_ids (also accept natural-language: "finish todo 050" → `--ids 050`)
+   - `--skip A,B` — exclude matching issue_ids
+   - `--dry-run` — set a flag consulted in Phase 1 (no file mutations, no agent dispatches; just print what each step would do)
+
+6. **Order:** sort by priority ascending (p1 first), then dependency-respecting topological sort within each priority. If a dependency cycle is detected, **abort** with the cycle printed; do not silently break it.
+
+7. **Print the plan and prompt for confirmation:**
+   ```
+   Completing N todos sequentially [DRY-RUN]:
+     1. 050 [p1] Make Flutter App Buildable From a Fresh Checkout
+     2. 052 [p2] CI toolchain drift
+     ...
+   Skipped: 053 (--skip), 055 (--priority p2)
+   Run id: 2026-05-07-1430
+   Proceed? (yes / edit / cancel)
+   ```
+   On `edit`, accept a refined filter and re-plan from step 5. On `cancel`, exit without touching anything.
+
+8. **Write the initial checkpoint** (skip if `--dry-run`):
+   ```json
+   {
+     "run_id": "<id>",
+     "started_at": "<ISO>",
+     "plan": ["050", "052", "056"],
+     "completed": [],
+     "skipped": [],
+     "aborted_at": null,
+     "filter_flags": ["--skip", "053"]
+   }
+   ```
+   Path: `todos/.completing-todos-run-<run_id>.json`. Use Write.
+
+Proceed to Phase 1.
+````
+
+- [ ] **Step 2: Replace Phase 2 placeholder**
+
+Use Edit. Find:
+
+```
+### Phase 2 — Wrap-Up
+
+(populated in Task 5)
+```
+
+Replace with:
+
+````
+### Phase 2 — Wrap-Up
+
+After the per-todo loop ends (cleanly, by user `abort-run`, or by an unrecoverable error):
+
+1. **Print the run summary:**
+   ```
+   Run <run_id> finished.
+     Completed: 050, 052, 056
+     Skipped:   054 (verification failed: flutter analyze)
+     Aborted:   none
+   Files moved to todos/archive/. No commits made.
+   Suggested next step: review `git status`, then commit per todo or as a batch.
+   ```
+
+2. **Delete the checkpoint** if every planned id reached a terminal state (in `completed` or `skipped`). Keep it otherwise so the next invocation can resume.
+   ```bash
+   rm -f todos/.completing-todos-run-<run_id>.json
+   ```
+
+3. **Never run `git commit`.** The skill exits here.
+````
+
+- [ ] **Step 3: Replace Resumability placeholder**
+
+Use Edit. Find:
+
+```
+## Resumability
+
+(populated in Task 5)
+```
+
+Replace with:
+
+````
+## Resumability
+
+A `run_id` (`YYYY-MM-DD-HHMM`) is assigned in Phase 0. The checkpoint file `todos/.completing-todos-run-<run_id>.json` carries plan + progress so a long run can resume.
+
+Checkpoint shape:
+```json
+{
+  "run_id": "2026-05-07-1430",
+  "started_at": "2026-05-07T14:30:00Z",
+  "plan": ["050", "052", "056", "054"],
+  "completed": ["050", "052"],
+  "skipped": [],
+  "aborted_at": null,
+  "filter_flags": ["--skip", "053"]
+}
+```
+
+When Phase 0 detects an existing checkpoint:
+
+```
+Found in-progress run <run_id> (2/4 complete).
+Plan: 050 ✓, 052 ✓, 056 (next), 054
+Resume? (yes / restart / discard)
+```
+
+- `yes` → skip every id in `completed` and `skipped`; resume Phase 1 at the next planned id.
+- `restart` → delete the checkpoint, return to Phase 0 step 3.
+- `discard` → delete the checkpoint, exit immediately.
+
+Update the checkpoint after every per-todo terminal state (completed or skipped), using Write to overwrite (last writer wins; the checkpoint always reflects cumulative state).
+````
+
+- [ ] **Step 4: Verify all placeholders are replaced**
+
+Run:
+
+```bash
+grep -n '(populated in Task' .claude/skills/completing-todos/SKILL.md
+```
+
+Expected output: only Phase 1 placeholders remain (Tasks 6–7). Phase 0, Phase 2, and Resumability placeholders should be gone.
+
+- [ ] **Step 5: Smoke-test the discovery command**
+
+Run the exact command from Phase 0 step 3:
+
+```bash
+grep -l "^status: pending" todos/*.md | sort
+```
+
+Expected output: the 7 currently pending files (`050-…` through `056-…`).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add .claude/skills/completing-todos/SKILL.md
+git commit -m "feat(skill): add Phase 0, Phase 2, and resumability to completing-todos"
+```
+
+---
+
+## Task 6: Phase 1 — mark in-progress + verify-only fast path
+
+**Files:**
+
+- Modify: `.claude/skills/completing-todos/SKILL.md`
+
+- [ ] **Step 1: Replace Phase 1 placeholder with the loop scaffold + steps 1–2**
+
+Use Edit. Find:
+
+```
+### Phase 1 — Per-Todo Loop
+
+(populated in Tasks 6–7)
+```
+
+Replace with:
+
+````
+### Phase 1 — Per-Todo Loop
+
+For each todo in the planned order:
+
+#### Step 1 — Mark in-progress
+
+This step is atomic from the user's perspective: any failure leaves the file in `pending` state.
+
+1. Edit the file's frontmatter: `status: pending` → `status: in_progress`.
+2. Rename the file with `git mv`:
+   ```bash
+   git mv todos/050-pending-p1-flutter-fresh-checkout-build.md \
+          todos/050-in_progress-p1-flutter-fresh-checkout-build.md
+   ```
+3. Append a Work Log entry to the renamed file:
+   ```markdown
+   ### YYYY-MM-DD - Started by completing-todos skill (run <run_id>)
+
+   - Picked up by automated workflow.
+   ```
+4. If `--dry-run`: print what each of the above would do; do not execute.
+
+#### Step 2 — Implement or verify
+
+1. Read the **Recommended Action** and **Technical Details** sections.
+2. **Verify-only path:** if every `- [ ]` in Acceptance Criteria is already `- [x]` AND `git diff --quiet HEAD -- <paths-from-Technical-Details>` returns 0 (no diff), skip implementation and proceed to Step 3 to re-confirm. State this explicitly in the Work Log: `Detected verify-only state — no implementation work needed.`
+3. **Implementation path:** otherwise, perform the work described. Use TodoWrite to track sub-steps. Delegate substantial or specialized work to subagents:
+   - `Explore` for searching the codebase
+   - `frontend-developer` for React UI work
+   - `wagtail-cms-orchestrator` for CMS data flow / Wagtail page work
+   - `general-purpose` as a fallback for cross-cutting research or multi-step work
+
+   The skill itself owns orchestration; subagents do the actual implementation. Always read the relevant pattern docs under `backend/docs/patterns/`, `web/docs/patterns/`, or `plant_community_mobile/docs/patterns/` before writing new code in those areas.
+4. If `--dry-run`: do not invoke any subagent or write any file; print the planned subagent dispatches and pattern docs that would be consulted, then continue to Step 3.
+
+(Steps 3–5 below — populated in Task 7.)
+````
+
+- [ ] **Step 2: Verify the new scaffold landed and Phase 1 outline is complete through Step 2**
+
+Run:
+
+```bash
+grep -nE '^#### Step [0-9]' .claude/skills/completing-todos/SKILL.md
+```
+
+Expected output:
+
+```
+<line>:#### Step 1 — Mark in-progress
+<line>:#### Step 2 — Implement or verify
+```
+
+- [ ] **Step 3: Sanity-check the rename example**
+
+Run (this is a dry simulation — do not actually rename):
+
+```bash
+ls todos/050-pending-p1-flutter-fresh-checkout-build.md
+```
+
+Expected output: the file exists. (Confirms the example path in the skill matches reality.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .claude/skills/completing-todos/SKILL.md
+git commit -m "feat(skill): add Phase 1 steps 1-2 (mark in-progress, implement/verify) to completing-todos"
+```
+
+---
+
+## Task 7: Phase 1 — verification gate, code review, archive
+
+**Files:**
+
+- Modify: `.claude/skills/completing-todos/SKILL.md`
+
+- [ ] **Step 1: Replace the Phase 1 trailing placeholder**
+
+Use Edit. Find:
+
+```
+(Steps 3–5 below — populated in Task 7.)
+```
+
+Replace with:
+
+````
+#### Step 3 — Verification gate
+
+Per [verification-before-completion](https://github.com/anthropic-experimental/claude-superpowers): every `- [ ]` in Acceptance Criteria must flip to `- [x]` only when backed by quoted command output captured in the Work Log.
+
+1. For each unchecked item in Acceptance Criteria:
+   - Run the exact command implied by the criterion (test command, build command, type-check, etc.).
+   - Capture the output.
+   - If the output proves the criterion holds, flip `- [ ]` to `- [x]` and quote the relevant lines in the Work Log.
+   - If the output does NOT prove the criterion: do not flip the box. Continue to the failure handling below.
+2. **Failure handling:** if any criterion cannot be flipped, pause and ask:
+   ```
+   Acceptance criterion failed for todo NNN:
+     <criterion text>
+   Last command: <command>
+   Output:
+     <relevant lines>
+   Choose: (retry / skip-todo / abort-run)
+   ```
+   - `retry` — re-run after the user fixes the underlying issue.
+   - `skip-todo` — do NOT mark complete. Add this id to `skipped` in the checkpoint, append a Work Log entry explaining why, leave the file in `in_progress` state with its filename also `in_progress`. Continue to the next todo.
+   - `abort-run` — stop the loop, jump to Phase 2.
+3. If `--dry-run`: print the commands that would run, do not execute them, do not flip any boxes.
+
+#### Step 4 — Code review
+
+1. Compute the changed file list:
+   ```bash
+   git diff --name-only HEAD
+   ```
+2. Dispatch the `code-review-orchestrator` agent via the Task tool with this prompt:
+   ```
+   Review the following changes for todo NNN: <todo title>.
+   Changed files:
+     - <path 1>
+     - <path 2>
+   Return findings in your standard JSON shape.
+   ```
+3. **Severity policy:**
+   - `critical` or `high` — block. Print the findings and ask:
+     ```
+     Code review surfaced N blocking findings for todo NNN:
+       [critical] <file>:<line> — <description>
+       [high]     <file>:<line> — <description>
+     Choose: (repair / accept-and-continue / abort-run)
+     ```
+   - `medium` or below — list in the Work Log under a `Known issues` subsection; do not block.
+4. **On `repair`:** re-dispatch the *same domain reviewer that surfaced each blocking finding* via the Task tool, one invocation per file, with this prompt:
+   ```
+   Repair the following findings in this file:
+   File: <path>
+   Findings:
+     - line <N>: <description>  (suggested_fix: <text or "—">)
+     - line <M>: <description>
+   Return JSON: {"file": "...", "edits": [{"old_string": "...", "new_string": "..."}], "unrepaired": [...]}
+   ```
+   Apply each returned `edit` via the Edit tool. Re-run Step 3 (verification gate) on the repaired files. After repair completes, **exit the loop** so the user can review the diff before further todos run. Append a Work Log entry naming each finding repaired and any left in `unrepaired`.
+5. **On `accept-and-continue`:** record each unaddressed blocking finding in the Work Log under `Known issues — accepted at completion`. Do not silently drop them.
+6. **On `abort-run`:** stop the loop, jump to Phase 2.
+7. If `--dry-run`: print the orchestrator dispatch prompt and stop; do not actually invoke the orchestrator.
+
+#### Step 5 — Archive
+
+1. Edit the file's frontmatter: `status: in_progress` → `status: completed`.
+2. Append a Work Log entry:
+   ```markdown
+   ### YYYY-MM-DD - Completed by completing-todos skill (run <run_id>)
+
+   - Verification: <one-line summary, e.g., "all 5 acceptance criteria passed">.
+   - Review: <N findings total, M blocking — addressed via repair / accepted / none>.
+   ```
+3. Rename and move with `git mv`:
+   ```bash
+   git mv todos/050-in_progress-p1-flutter-fresh-checkout-build.md \
+          todos/archive/050-completed-p1-flutter-fresh-checkout-build.md
+   ```
+4. Update the checkpoint: append the issue_id to `completed[]`, write the file back.
+5. If `--dry-run`: print the planned frontmatter edit, Work Log entry, and `git mv` command; do not execute any of them.
+
+Proceed to the next todo in the plan, or to Phase 2 if this was the last.
+````
+
+- [ ] **Step 2: Verify all five steps of Phase 1 are present**
+
+Run:
+
+```bash
+grep -nE '^#### Step [0-9]' .claude/skills/completing-todos/SKILL.md
+```
+
+Expected output:
+
+```
+<line>:#### Step 1 — Mark in-progress
+<line>:#### Step 2 — Implement or verify
+<line>:#### Step 3 — Verification gate
+<line>:#### Step 4 — Code review
+<line>:#### Step 5 — Archive
+```
+
+- [ ] **Step 3: Verify there are no remaining placeholders**
+
+Run:
+
+```bash
+grep -n '(populated in Task' .claude/skills/completing-todos/SKILL.md || echo "NO_PLACEHOLDERS_REMAIN"
+```
+
+Expected output: `NO_PLACEHOLDERS_REMAIN`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .claude/skills/completing-todos/SKILL.md
+git commit -m "feat(skill): add Phase 1 steps 3-5 (verify, review, archive) to completing-todos"
+```
+
+---
+
+## Task 8: Add Safety Rails section
+
+**Files:**
+
+- Modify: `.claude/skills/completing-todos/SKILL.md`
+
+- [ ] **Step 1: Replace the Safety Rails placeholder**
+
+Use Edit. Find:
+
+```
+## Safety Rails
+
+(populated in Task 8)
+```
+
+Replace with:
+
+````
+## Safety Rails
+
+These are non-negotiable. They override any in-the-moment judgment to "just push through".
+
+1. **Never auto-commit.** The skill never runs `git commit`. Phase 2 explicitly tells the user to commit.
+2. **Sequential by default.** A `--parallel N` flag is reserved for future work; do NOT implement it in v1. Todos can collide on shared files; serialization is the safe default.
+3. **One-time confirmation before the first file move.** After Phase 0 confirmation, before the first `git mv` of the run, prompt once:
+   ```
+   About to rename + move N files via git mv across this run. Working directory: <pwd>. Continue? (yes / cancel)
+   ```
+   Skip this prompt if `--dry-run`.
+4. **Acceptance criteria are gospel.** A todo cannot be marked `completed` unless every `- [ ]` is flipped to `- [x]` with verification evidence quoted in the Work Log. There is no `--force-complete`.
+5. **No destructive recovery.** If `git mv` or any other step fails mid-todo, stop the loop and leave state as-is for the user to inspect. Do not roll back, do not delete, do not retry silently.
+6. **Stop on review block.** If `code-review-orchestrator` returns `critical`/`high` and the user chooses `repair`, exit the loop after that todo so the user can inspect the diff before the next todo starts.
+7. **Checkpoint integrity.** Update the checkpoint after every per-todo terminal state (completed or skipped), not at the end of the run. A killed process must be resumable from the last completed todo.
+````
+
+- [ ] **Step 2: Confirm no placeholders remain anywhere**
+
+Run:
+
+```bash
+grep -nE '\(populated in Task|TBD|TODO:|FIXME' .claude/skills/completing-todos/SKILL.md || echo "CLEAN"
+```
+
+Expected output: `CLEAN`
+
+- [ ] **Step 3: Confirm the skill renders top-to-bottom**
+
+Run:
+
+```bash
+wc -l .claude/skills/completing-todos/SKILL.md && \
+  grep -cE '^## ' .claude/skills/completing-todos/SKILL.md
+```
+
+Expected: a non-trivial line count (~250+) and at least 7 top-level `##` headings (`# Completing Todos`, then `Trigger phrases`, `Filter flags`, `Workflow`, `Phases`, `Resumability`, `Safety Rails`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .claude/skills/completing-todos/SKILL.md
+git commit -m "feat(skill): add safety rails to completing-todos"
+```
+
+---
+
+## Task 9: Dry-run validation against current pending todos
+
+**Files:** none modified.
+
+- [ ] **Step 1: Invoke the skill in dry-run mode**
+
+In a Claude Code session in this repo, run:
+
+```
+/completing-todos --dry-run
+```
+
+Or use natural language: "Dry-run completing-todos against all pending todos."
+
+- [ ] **Step 2: Confirm Phase 0 prints the expected plan**
+
+Expected: the skill prints a numbered plan with the 7 current pending todos, ordered p1 → p2 → p3:
+
+- 050 (p1) before 051, 052, 056 (all p2) before 053, 054 (p3) and 055 (p4).
+- Topological order within priority based on each file's `dependencies:` field.
+- A generated `run_id` of the form `YYYY-MM-DD-HHMM`.
+- `[DRY-RUN]` banner present.
+- A `Proceed? (yes / edit / cancel)` prompt.
+
+- [ ] **Step 3: Confirm Phase 1 walks each todo without mutating files**
+
+Respond `yes`. Expected: for each planned todo, the skill prints what it WOULD do at each of the five Phase 1 steps (mark in-progress, implement/verify, verify, review, archive) — but no `git mv` runs, no frontmatter edits land, no agents are dispatched.
+
+Verify after the run:
+
+```bash
+git status
+```
+
+Expected output: `nothing to commit, working tree clean` (or only changes you had before — none from the dry-run).
+
+```bash
+ls todos/.completing-todos-run-*.json 2>/dev/null || echo "NO_CHECKPOINT"
+```
+
+Expected: `NO_CHECKPOINT` (Phase 0 step 8 explicitly skips checkpoint write under `--dry-run`).
+
+- [ ] **Step 4: Fix any issues found**
+
+If the dry-run produces unexpected ordering, missing prompts, or written files, fix the SKILL.md prose and re-run from Step 1. Commit any fixes:
+
+```bash
+git add .claude/skills/completing-todos/SKILL.md
+git commit -m "fix(skill): <specific fix> in completing-todos"
+```
+
+---
+
+## Task 10: Live-run on one small pending todo
+
+Pick the smallest, lowest-risk pending todo to validate the full path including `git mv` and orchestrator dispatch. Today (2026-05-07) the candidates are:
+
+- `054-pending-p3-update-stale-documentation.md` — docs only, lowest blast radius. **Recommended.**
+- `053-pending-p3-repository-hygiene-generated-artifacts.md` — repo hygiene, also low risk.
+
+Avoid 050/051/052/056 for the live-run — those touch real code paths and deserve focused attention.
+
+- [ ] **Step 1: Confirm working tree is clean**
+
+Run:
+
+```bash
+git status --short
+```
+
+Expected: empty output (clean tree).
+
+- [ ] **Step 2: Invoke the skill scoped to the chosen todo**
+
+In a Claude Code session, run:
+
+```
+/completing-todos --ids 054
+```
+
+- [ ] **Step 3: Walk through Phase 0**
+
+Confirm the plan shows just todo 054, accept with `yes`, and accept the one-time file-move confirmation when it appears.
+
+- [ ] **Step 4: Walk through Phase 1**
+
+For Step 2 (Implement or verify), perform the actual documentation updates as the skill orchestrates. For Step 3 (verification), run any commands the acceptance criteria imply. For Step 4 (code review), let the `code-review-orchestrator` dispatch and resolve any findings per the severity policy.
+
+- [ ] **Step 5: Verify the file landed in archive**
+
+Run:
+
+```bash
+ls todos/archive/054-completed-p3-update-stale-documentation.md && \
+  ls todos/054-pending-p3-update-stale-documentation.md 2>/dev/null || echo "ORIGINAL_GONE"
+```
+
+Expected: the archived file exists, and `ORIGINAL_GONE` confirms the original is no longer in `todos/`.
+
+Run:
+
+```bash
+sed -n '1,8p' todos/archive/054-completed-p3-update-stale-documentation.md
+```
+
+Expected: frontmatter shows `status: completed`, plus the unchanged `priority`, `issue_id`, `tags`, `dependencies`.
+
+- [ ] **Step 6: Verify the checkpoint cleaned up**
+
+Run:
+
+```bash
+ls todos/.completing-todos-run-*.json 2>/dev/null || echo "CHECKPOINT_CLEAN"
+```
+
+Expected: `CHECKPOINT_CLEAN` (Phase 2 step 2 deletes the checkpoint when every planned id reached terminal state).
+
+- [ ] **Step 7: Inspect the diff and commit**
+
+Run:
+
+```bash
+git status
+git diff --stat HEAD
+```
+
+Expected: documentation file changes from the actual implementation, plus the moved + edited todo file.
+
+Commit per the user's preference (one commit for the todo + its implementation, or split). Suggested:
+
+```bash
+git add todos/archive/054-completed-p3-update-stale-documentation.md \
+        <files-implementation-touched>
+git commit -m "docs: update stale documentation (closes todo 054)"
+```
+
+- [ ] **Step 8: Note any rough edges**
+
+If the live-run surfaced friction (confusing prompts, missing edge case, off-by-one in ordering), file a tiny follow-up todo using `todos/TEMPLATE.md` to track the polish. The skill is now real and used; further refinement happens in subsequent commits.
+
+---
+
+## Self-Review (post-write)
+
+The plan was checked against the spec for:
+
+- **Spec coverage:** every section in the spec maps to a task.
+  - `todos/TEMPLATE.md` → Task 2
+  - README addition → Task 3
+  - `.gitignore` for checkpoint files → Task 1
+  - `.claude/*` exception (gotcha caught during file structure pass) → Task 1
+  - SKILL.md frontmatter + Phase 0 → Tasks 4–5
+  - Phase 1 (5 steps) → Tasks 6–7
+  - Phase 2 + Resumability → Task 5
+  - Safety Rails → Task 8
+  - Dry-run acceptance criterion → Task 9
+  - Live-run acceptance criterion → Task 10
+- **Placeholders:** none (`grep -n '(populated in Task'` is run inside Tasks 7 and 8 to enforce this).
+- **Type/identifier consistency:** trigger phrases, flag names (`--priority`, `--ids`, `--skip`, `--dry-run`), and the checkpoint JSON shape are identical across Task 5 (definition) and later tasks (consumption).
+
+---
+
+## Implementation Notes
+
+- **Commit cadence:** 8 commits across the 10 tasks (Tasks 9 and 10 only commit on demand if fixes are needed). This matches the spec's "frequent commits" guidance.
+- **Order rationale:** `.gitignore` first because the skill file is invisible to git without it. Template + README before the skill so the skill can reference them. Skill frontmatter before any phase content so the Skill tool can load it incrementally during development. Phase 0 / 2 / Resumability before Phase 1 so `--dry-run` is testable end-to-end before the loop body exists. Safety rails last because they apply to a fully-built workflow. Dry-run before live-run because dry-run cannot mutate state.

--- a/docs/superpowers/plans/2026-05-07-precommit-lint-prettier.md
+++ b/docs/superpowers/plans/2026-05-07-precommit-lint-prettier.md
@@ -1,0 +1,270 @@
+# Pre-commit Lint & Prettier Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add ESLint, Prettier (web), `flutter analyze`, and `dart format` (mobile) as pre-commit hooks, replacing the broken ESLint v8 mirror hook.
+
+**Architecture:** Three-task sequence — bootstrap Prettier in `web/` first (so existing files are formatted before the check hook goes live), then replace the broken ESLint mirror with two local hooks (ESLint + Prettier), then add two Flutter hooks. Each task ends with a commit.
+
+**Tech Stack:** pre-commit (Python), ESLint v10 (flat config), Prettier 3, Flutter SDK
+
+---
+
+## File Map
+
+| Action | File |
+|--------|------|
+| Modify | `web/package.json` — add `prettier` devDep, add `format` script |
+| Create | `web/.prettierrc` — Prettier config |
+| Modify | `.pre-commit-config.yaml` — replace mirrors-eslint, add 4 local hooks |
+
+---
+
+### Task 1: Bootstrap Prettier in web/
+
+**Files:**
+
+- Create: `web/.prettierrc`
+- Modify: `web/package.json`
+
+- [ ] **Step 1: Create `web/.prettierrc`**
+
+```json
+{
+  "printWidth": 100,
+  "singleQuote": true,
+  "semi": true,
+  "tabWidth": 2,
+  "trailingComma": "es5"
+}
+```
+
+- [ ] **Step 2: Add `prettier` devDependency and `format` script to `web/package.json`**
+
+In the `"scripts"` object, add after `"lint"`:
+
+```json
+"format": "prettier --write .",
+```
+
+In `"devDependencies"`, add (alphabetically after `"postcss"`):
+
+```json
+"prettier": "^3.4.0",
+```
+
+- [ ] **Step 3: Install the new dependency**
+
+```bash
+cd web && npm install
+```
+
+Expected: `package-lock.json` updated, no errors.
+
+- [ ] **Step 4: Format all existing files**
+
+This must happen before the Prettier check hook goes live, otherwise the hook fails on the first commit.
+
+```bash
+cd web && npm run format
+```
+
+Expected: Prettier rewrites any files that don't match the config. Review the diff — this is cosmetic whitespace/quote changes only.
+
+- [ ] **Step 5: Verify Prettier passes on the formatted files**
+
+```bash
+cd web && npx prettier --check .
+```
+
+Expected: `All matched files use Prettier code style!`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add web/package.json web/package-lock.json web/.prettierrc
+git add -u web/
+git commit -m "chore(web): install Prettier, format existing files"
+```
+
+(`git add -u web/` stages only already-tracked files modified by Prettier — `.gitignore` keeps `node_modules/` out.)
+
+---
+
+### Task 2: Replace broken ESLint mirror hook with local ESLint + Prettier hooks
+
+**Files:**
+
+- Modify: `.pre-commit-config.yaml`
+
+The existing `mirrors-eslint` block (lines ~155–168) uses ESLint v8 with `.eslintrc` config style. The project has ESLint v10 with flat config (`web/eslint.config.js`), so the mirror hook silently fails. Replace the entire block.
+
+- [ ] **Step 1: Replace the `mirrors-eslint` section in `.pre-commit-config.yaml`**
+
+Find and replace this block:
+
+```yaml
+  # ===================================
+  # JavaScript/TypeScript Code Quality
+  # ===================================
+  - repo: https://github.com/pre-commit/mirrors-eslint
+    rev: v8.56.0
+    hooks:
+      - id: eslint
+        name: Lint JavaScript/React with ESLint
+        files: ^web/src/.*\.(js|jsx|ts|tsx)$
+        types: [file]
+        additional_dependencies:
+          - eslint@8.56.0
+          - eslint-plugin-react@7.33.2
+          - eslint-plugin-react-hooks@4.6.0
+```
+
+Replace with:
+
+```yaml
+  # ===================================
+  # JavaScript/TypeScript Code Quality
+  # ===================================
+  - repo: local
+    hooks:
+      - id: eslint-web
+        name: Lint JS/TS with ESLint
+        entry: bash -c 'cd web && npm run lint'
+        language: system
+        files: ^web/.*\.(js|jsx|ts|tsx)$
+        pass_filenames: false
+
+      - id: prettier-web
+        name: Check JS/TS formatting with Prettier
+        entry: bash -c 'cd web && npx prettier --check .'
+        language: system
+        files: ^web/.*\.(js|jsx|ts|tsx)$
+        pass_filenames: false
+```
+
+- [ ] **Step 2: Verify ESLint hook passes**
+
+```bash
+pre-commit run eslint-web --all-files
+```
+
+Expected: `Lint JS/TS with ESLint..........Passed`
+
+If it fails: run `cd web && npm run lint` directly to see the ESLint errors, fix them, re-run.
+
+- [ ] **Step 3: Verify Prettier hook passes**
+
+```bash
+pre-commit run prettier-web --all-files
+```
+
+Expected: `Check JS/TS formatting with Prettier..........Passed`
+
+If it fails: run `cd web && npm run format` to auto-fix, then re-run the check.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .pre-commit-config.yaml
+git commit -m "chore: replace broken mirrors-eslint hook with local ESLint + Prettier hooks"
+```
+
+---
+
+### Task 3: Add Flutter analyze and dart format hooks
+
+**Files:**
+
+- Modify: `.pre-commit-config.yaml`
+
+**Prerequisites:** `flutter` and `dart` must be in your `PATH`. Verify with `flutter --version` before starting.
+
+- [ ] **Step 1: Add Flutter hooks to `.pre-commit-config.yaml`**
+
+Find the Markdown Linting section header:
+
+```yaml
+  # ===================================
+  # Markdown Linting
+  # ===================================
+```
+
+Insert a new block immediately before it:
+
+```yaml
+  # ===================================
+  # Flutter/Dart Code Quality
+  # ===================================
+  - repo: local
+    hooks:
+      - id: flutter-analyze
+        name: Analyze Flutter with flutter analyze
+        entry: bash -c 'flutter analyze plant_community_mobile/'
+        language: system
+        files: ^plant_community_mobile/.*\.dart$
+        pass_filenames: false
+
+      - id: dart-format
+        name: Check Dart formatting with dart format
+        entry: bash -c 'dart format --output=none --set-exit-if-changed plant_community_mobile/lib/'
+        language: system
+        files: ^plant_community_mobile/.*\.dart$
+        pass_filenames: false
+
+```
+
+- [ ] **Step 2: Verify `flutter analyze` hook passes**
+
+```bash
+pre-commit run flutter-analyze --all-files
+```
+
+Expected: `Analyze Flutter with flutter analyze..........Passed`
+
+If it fails: run `flutter analyze plant_community_mobile/` directly, fix reported issues, re-run.
+
+- [ ] **Step 3: Check if existing Dart files need formatting**
+
+```bash
+dart format --output=none --set-exit-if-changed plant_community_mobile/lib/
+```
+
+If it exits non-zero, files need formatting:
+
+```bash
+dart format plant_community_mobile/lib/
+```
+
+Then verify the hook passes:
+
+```bash
+pre-commit run dart-format --all-files
+```
+
+Expected: `Check Dart formatting with dart format..........Passed`
+
+- [ ] **Step 4: If Dart files were reformatted, commit them first**
+
+```bash
+git add plant_community_mobile/lib/
+git commit -m "chore(mobile): format Dart files with dart format"
+```
+
+- [ ] **Step 5: Commit the hook config**
+
+```bash
+git add .pre-commit-config.yaml
+git commit -m "chore: add flutter analyze and dart format pre-commit hooks"
+```
+
+---
+
+## Developer Cheat Sheet
+
+| Hook fails | Fix command |
+|------------|-------------|
+| `eslint-web` | `cd web && npm run lint -- --fix` |
+| `prettier-web` | `cd web && npm run format` |
+| `flutter-analyze` | Fix the reported Dart issue |
+| `dart-format` | `dart format plant_community_mobile/lib/` |

--- a/docs/superpowers/plans/2026-05-08-kimi-delegation.md
+++ b/docs/superpowers/plans/2026-05-08-kimi-delegation.md
@@ -1,12 +1,12 @@
-# Kimi K2.5 Bulk I/O Delegation Implementation Plan
+# Kimi K2.6 Bulk I/O Delegation Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Install and configure three CLI tools that delegate bulk file reading and boilerplate generation to Kimi K2.5, reducing Claude token consumption by 60-70% on I/O-heavy tasks.
+**Goal:** Install and configure three CLI tools that delegate bulk file reading and boilerplate generation to Kimi K2.6, reducing Claude token consumption by 60-70% on I/O-heavy tasks.
 
 **Architecture:** Clone `claude-coworker-model` to `~/.local/share/claude-coworker/`, run its `setup.sh` to install tools to `~/.local/bin/`, then wire env vars into `~/.claude/settings.json` (for Claude sessions) and `~/.zshrc` (for direct terminal use). Add delegation rules to the project `CLAUDE.md` so Claude auto-delegates without being prompted.
 
-**Tech Stack:** Python 3, `openai>=1.0` (OpenAI-compatible client), Moonshot AI API (`https://api.moonshot.ai/v1`), zsh, Claude Code settings.json
+**Tech Stack:** Python 3, `openai>=1.0` (OpenAI-compatible client), OpenRouter API (`https://openrouter.ai/api/v1`), zsh, Claude Code settings.json
 
 ---
 
@@ -86,7 +86,7 @@
 
 - Modify: `~/.claude/settings.json`
 
-> **Before running Step 1:** You need your Moonshot API key. If you don't have it set as `$MOONSHOT_API_KEY` in your current shell, ask the user: "What is your Moonshot API key?" and substitute it for `<YOUR_MOONSHOT_API_KEY>` in the script below.
+> **Before running Step 1:** You need your OpenRouter API key. If you don't have it set as `$WORKER_API_KEY` in your current shell, ask the user: "What is your OpenRouter API key?" and substitute it for `<YOUR_OPENROUTER_API_KEY>` in the script below.
 
 - [ ] **Step 1: Confirm env vars are not yet set in Claude sessions**
 
@@ -103,7 +103,7 @@
 
 - [ ] **Step 2: Add env vars and permissions to `~/.claude/settings.json`**
 
-  Replace `<YOUR_MOONSHOT_API_KEY>` with the actual key before running:
+  Replace `<YOUR_OPENROUTER_API_KEY>` with the actual key before running:
 
   ```bash
   python3 - <<'PYEOF'
@@ -115,9 +115,9 @@
 
   # Add worker env vars
   s.setdefault('env', {})
-  s['env']['WORKER_API_KEY'] = '<YOUR_MOONSHOT_API_KEY>'
-  s['env']['WORKER_BASE_URL'] = 'https://api.moonshot.ai/v1'
-  s['env']['WORKER_MODEL'] = 'kimi-k2.5'
+  s['env']['WORKER_API_KEY'] = '<YOUR_OPENROUTER_API_KEY>'
+  s['env']['WORKER_BASE_URL'] = 'https://openrouter.ai/api/v1'
+  s['env']['WORKER_MODEL'] = 'moonshotai/kimi-k2.6'
 
   # Add bash permissions
   new_perms = ['Bash(ask-kimi:*)', 'Bash(kimi-write:*)', 'Bash(extract-chat:*)']
@@ -156,8 +156,8 @@
 
   ```text
   WORKER_API_KEY present: True
-  WORKER_BASE_URL: https://api.moonshot.ai/v1
-  WORKER_MODEL: kimi-k2.5
+  WORKER_BASE_URL: https://openrouter.ai/api/v1
+  WORKER_MODEL: moonshotai/kimi-k2.6
   ask-kimi permitted: True
   kimi-write permitted: True
   extract-chat permitted: True
@@ -181,15 +181,15 @@
 
 - [ ] **Step 2: Append exports to `~/.zshrc`**
 
-  Replace `<YOUR_MOONSHOT_API_KEY>` with the actual key (same value used in Task 2):
+  Replace `<YOUR_OPENROUTER_API_KEY>` with the actual key (same value used in Task 2):
 
   ```bash
   cat >> ~/.zshrc << 'EOF'
 
-  # Kimi K2.5 worker delegation (claude-coworker-model)
-  export WORKER_API_KEY="<YOUR_MOONSHOT_API_KEY>"
-  export WORKER_BASE_URL="https://api.moonshot.ai/v1"
-  export WORKER_MODEL="kimi-k2.5"
+  # Kimi K2.6 worker delegation (claude-coworker-model)
+  export WORKER_API_KEY="<YOUR_OPENROUTER_API_KEY>"
+  export WORKER_BASE_URL="https://openrouter.ai/api/v1"
+  export WORKER_MODEL="moonshotai/kimi-k2.6"
   EOF
   ```
 
@@ -199,7 +199,7 @@
   zsh -c 'source ~/.zshrc && echo "KEY=${WORKER_API_KEY:0:8}... URL=$WORKER_BASE_URL MODEL=$WORKER_MODEL"'
   ```
 
-  Expected: prints the first 8 chars of the key (confirming it loaded), the URL, and `kimi-k2.5`. If `KEY=...` shows blank, the export line was not appended correctly — re-check Step 2.
+  Expected: prints the first 8 chars of the key (confirming it loaded), the URL, and `moonshotai/kimi-k2.6`. If `KEY=...` shows blank, the export line was not appended correctly — re-check Step 2.
 
 ---
 
@@ -225,9 +225,9 @@
   ````bash
   python3 - << 'PYEOF'
   section = """
-  ## Cheap-Worker Delegation (Kimi K2.5)
+  ## Cheap-Worker Delegation (Kimi K2.6)
 
-  Three CLI tools delegate bulk I/O to a cheap worker model (Kimi K2.5 via Moonshot AI).
+  Three CLI tools delegate bulk I/O to a cheap worker model (Kimi K2.6 via OpenRouter).
   Claude handles reasoning and architecture; the worker handles token-heavy reading/writing.
 
   ### ask-kimi — bulk file reading
@@ -299,7 +299,7 @@
   grep -n 'Cheap-Worker Delegation' CLAUDE.md
   ```
 
-  Expected: prints a line number followed by `## Cheap-Worker Delegation (Kimi K2.5)`.
+  Expected: prints a line number followed by `## Cheap-Worker Delegation (Kimi K2.6)`.
 
 - [ ] **Step 4: Lint the markdown**
 
@@ -313,7 +313,7 @@
 
   ```bash
   git add CLAUDE.md
-  git commit -m "feat(claude): add Kimi K2.5 bulk I/O delegation rules"
+  git commit -m "feat(claude): add Kimi K2.6 bulk I/O delegation rules"
   ```
 
   Expected: commit succeeds (pre-commit hooks pass).
@@ -330,7 +330,7 @@ All tests run from the project root. Tasks 1–4 must be complete and a **new Cl
   echo "KEY=${WORKER_API_KEY:0:8}... MODEL=$WORKER_MODEL"
   ```
 
-  Expected: prints the first 8 chars of your key and `kimi-k2.5`. If blank, the session was not restarted after Task 2 — restart and retry.
+  Expected: prints the first 8 chars of your key and `moonshotai/kimi-k2.6`. If blank, the session was not restarted after Task 2 — restart and retry.
 
 - [ ] **Step 2: ask-kimi smoke test**
 

--- a/docs/superpowers/plans/2026-05-08-kimi-delegation.md
+++ b/docs/superpowers/plans/2026-05-08-kimi-delegation.md
@@ -1,0 +1,399 @@
+# Kimi K2.5 Bulk I/O Delegation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Install and configure three CLI tools that delegate bulk file reading and boilerplate generation to Kimi K2.5, reducing Claude token consumption by 60-70% on I/O-heavy tasks.
+
+**Architecture:** Clone `claude-coworker-model` to `~/.local/share/claude-coworker/`, run its `setup.sh` to install tools to `~/.local/bin/`, then wire env vars into `~/.claude/settings.json` (for Claude sessions) and `~/.zshrc` (for direct terminal use). Add delegation rules to the project `CLAUDE.md` so Claude auto-delegates without being prompted.
+
+**Tech Stack:** Python 3, `openai>=1.0` (OpenAI-compatible client), Moonshot AI API (`https://api.moonshot.ai/v1`), zsh, Claude Code settings.json
+
+---
+
+## File Map
+
+| File | Action | Notes |
+| ---- | ------ | ----- |
+| `~/.local/share/claude-coworker/` | Create (git clone) | Repo root + venv live here |
+| `~/.local/bin/ask-kimi` | Create (by setup.sh) | Already on PATH |
+| `~/.local/bin/kimi-write` | Create (by setup.sh) | Already on PATH |
+| `~/.local/bin/extract-chat` | Create (by setup.sh) | Symlink, stdlib only |
+| `~/.claude/settings.json` | Modify | Add `env` keys + 3 allow-list entries |
+| `~/.zshrc` | Modify | Append 3 `export` lines |
+| `CLAUDE.md` | Modify | Append delegation rules section |
+
+---
+
+## Task 1: Clone repo and install coworker tools
+
+**Files:**
+
+- Create: `~/.local/share/claude-coworker/` (repo + venv)
+- Create: `~/.local/bin/ask-kimi`, `~/.local/bin/kimi-write`, `~/.local/bin/extract-chat`
+
+- [ ] **Step 1: Confirm tools are not yet installed**
+
+  ```bash
+  which ask-kimi 2>/dev/null || echo "NOT FOUND"
+  which kimi-write 2>/dev/null || echo "NOT FOUND"
+  which extract-chat 2>/dev/null || echo "NOT FOUND"
+  ```
+
+  Expected: all three print `NOT FOUND`. If any tool already exists, skip to Task 2.
+
+- [ ] **Step 2: Clone the repo**
+
+  ```bash
+  git clone https://github.com/imkunal007219/claude-coworker-model.git \
+    ~/.local/share/claude-coworker
+  ```
+
+  Expected: directory `~/.local/share/claude-coworker` exists with `setup.sh`, `tools/`, `requirements.txt`.
+
+  Verify:
+
+  ```bash
+  ls ~/.local/share/claude-coworker/
+  ```
+
+  Expected output contains: `setup.sh  tools  requirements.txt  CLAUDE.md.template  README.md`
+
+- [ ] **Step 3: Run setup.sh**
+
+  ```bash
+  cd ~/.local/share/claude-coworker && ./setup.sh
+  ```
+
+  Expected: prints `=== Done! ===` with no errors. A Python venv is created at `~/.local/share/claude-coworker/venv/`. Tools are written to `~/.local/bin/`.
+
+  If setup.sh prints `⚠  No API key found` — that is expected at this stage (key gets added in Task 2). Continue.
+
+- [ ] **Step 4: Verify tools are on PATH and executable**
+
+  ```bash
+  which ask-kimi && ask-kimi --help 2>&1 | head -5
+  which kimi-write && kimi-write --help 2>&1 | head -5
+  which extract-chat && extract-chat --help 2>&1 | head -5
+  ```
+
+  Expected: each `which` prints a path under `~/.local/bin/`. The `--help` output shows usage instructions without a Python traceback.
+
+---
+
+## Task 2: Configure env vars and permissions in `~/.claude/settings.json`
+
+**Files:**
+
+- Modify: `~/.claude/settings.json`
+
+> **Before running Step 1:** You need your Moonshot API key. If you don't have it set as `$MOONSHOT_API_KEY` in your current shell, ask the user: "What is your Moonshot API key?" and substitute it for `<YOUR_MOONSHOT_API_KEY>` in the script below.
+
+- [ ] **Step 1: Confirm env vars are not yet set in Claude sessions**
+
+  ```bash
+  python3 -c "
+  import json
+  with open('/Users/williamtower/.claude/settings.json') as f:
+      s = json.load(f)
+  print('WORKER_API_KEY' in s.get('env', {}))
+  "
+  ```
+
+  Expected: `False`. If `True`, skip to Task 3.
+
+- [ ] **Step 2: Add env vars and permissions to `~/.claude/settings.json`**
+
+  Replace `<YOUR_MOONSHOT_API_KEY>` with the actual key before running:
+
+  ```bash
+  python3 - <<'PYEOF'
+  import json
+
+  path = '/Users/williamtower/.claude/settings.json'
+  with open(path) as f:
+      s = json.load(f)
+
+  # Add worker env vars
+  s.setdefault('env', {})
+  s['env']['WORKER_API_KEY'] = '<YOUR_MOONSHOT_API_KEY>'
+  s['env']['WORKER_BASE_URL'] = 'https://api.moonshot.ai/v1'
+  s['env']['WORKER_MODEL'] = 'kimi-k2.5'
+
+  # Add bash permissions
+  new_perms = ['Bash(ask-kimi:*)', 'Bash(kimi-write:*)', 'Bash(extract-chat:*)']
+  allow = s.setdefault('permissions', {}).setdefault('allow', [])
+  for p in new_perms:
+      if p not in allow:
+          allow.append(p)
+
+  with open(path, 'w') as f:
+      json.dump(s, f, indent=2)
+  print('Done')
+  PYEOF
+  ```
+
+  Expected: prints `Done` with no errors.
+
+- [ ] **Step 3: Verify the changes are present**
+
+  ```bash
+  python3 -c "
+  import json
+  with open('/Users/williamtower/.claude/settings.json') as f:
+      s = json.load(f)
+  env = s.get('env', {})
+  allow = s.get('permissions', {}).get('allow', [])
+  print('WORKER_API_KEY present:', 'WORKER_API_KEY' in env)
+  print('WORKER_BASE_URL:', env.get('WORKER_BASE_URL'))
+  print('WORKER_MODEL:', env.get('WORKER_MODEL'))
+  print('ask-kimi permitted:', 'Bash(ask-kimi:*)' in allow)
+  print('kimi-write permitted:', 'Bash(kimi-write:*)' in allow)
+  print('extract-chat permitted:', 'Bash(extract-chat:*)' in allow)
+  "
+  ```
+
+  Expected output:
+
+  ```text
+  WORKER_API_KEY present: True
+  WORKER_BASE_URL: https://api.moonshot.ai/v1
+  WORKER_MODEL: kimi-k2.5
+  ask-kimi permitted: True
+  kimi-write permitted: True
+  extract-chat permitted: True
+  ```
+
+---
+
+## Task 3: Add WORKER_* exports to `~/.zshrc`
+
+**Files:**
+
+- Modify: `~/.zshrc`
+
+- [ ] **Step 1: Check that exports are not already present**
+
+  ```bash
+  grep -c 'WORKER_API_KEY' ~/.zshrc 2>/dev/null || echo "0"
+  ```
+
+  Expected: `0`. If non-zero, skip this task.
+
+- [ ] **Step 2: Append exports to `~/.zshrc`**
+
+  Replace `<YOUR_MOONSHOT_API_KEY>` with the actual key (same value used in Task 2):
+
+  ```bash
+  cat >> ~/.zshrc << 'EOF'
+
+  # Kimi K2.5 worker delegation (claude-coworker-model)
+  export WORKER_API_KEY="<YOUR_MOONSHOT_API_KEY>"
+  export WORKER_BASE_URL="https://api.moonshot.ai/v1"
+  export WORKER_MODEL="kimi-k2.5"
+  EOF
+  ```
+
+- [ ] **Step 3: Verify exports load in a new shell**
+
+  ```bash
+  zsh -c 'source ~/.zshrc && echo "KEY=${WORKER_API_KEY:0:8}... URL=$WORKER_BASE_URL MODEL=$WORKER_MODEL"'
+  ```
+
+  Expected: prints the first 8 chars of the key (confirming it loaded), the URL, and `kimi-k2.5`. If `KEY=...` shows blank, the export line was not appended correctly — re-check Step 2.
+
+---
+
+## Task 4: Append delegation rules to `CLAUDE.md`
+
+**Files:**
+
+- Modify: `CLAUDE.md` (project root, line 138 is current end)
+
+- [ ] **Step 1: Confirm the section does not already exist**
+
+  ```bash
+  grep -c 'Cheap-Worker Delegation' CLAUDE.md
+  ```
+
+  Expected: `0`. If non-zero, skip this task.
+
+- [ ] **Step 2: Append the delegation rules section**
+
+  Run from the project root (`/Users/williamtower/projects/plant_id_community`).
+  This uses Python to write the content so that inner code-fence markers are preserved correctly:
+
+  ````bash
+  python3 - << 'PYEOF'
+  section = """
+  ## Cheap-Worker Delegation (Kimi K2.5)
+
+  Three CLI tools delegate bulk I/O to a cheap worker model (Kimi K2.5 via Moonshot AI).
+  Claude handles reasoning and architecture; the worker handles token-heavy reading/writing.
+
+  ### ask-kimi — bulk file reading
+
+  Use when reading 3+ files for context, or any single file >400 lines when the goal is
+  understanding (not editing):
+
+  ```bash
+  ask-kimi --paths <file1> <file2>... --question "<specific question>"
+  ```
+
+  Returns structured bullets. Read the summary instead of the raw files.
+  Only use Read directly when you need exact line numbers for editing.
+
+  ### kimi-write — boilerplate generation
+
+  Use for pytest tests, DRF viewsets/serializers, Flutter widgets, Riverpod providers —
+  anything that follows an existing pattern:
+
+  ```bash
+  kimi-write --spec "<what to write>" --context <existing-similar-file> --target <output-path>
+  ```
+
+  Then review the output and edit only what needs fixing.
+
+  ### extract-chat — session transcript extraction
+
+  Converts Claude Code JSONL session logs to readable text (no API call, stdlib only):
+
+  ```bash
+  extract-chat <session.jsonl> -o /tmp/chat.txt
+  ```
+
+  Use before post-session doc updates: extract → ask-kimi to suggest changes → apply with Edit.
+
+  ### Delegation rules
+
+  **AUTO-delegate (no prompt needed):**
+
+  - Reading 3+ files for exploration or context
+  - Single file >400 lines when goal is understanding (not editing)
+  - Boilerplate: pytest tests, DRF viewsets/serializers, Flutter widgets, Riverpod providers
+  - Post-session documentation updates
+
+  **NEVER delegate:**
+
+  - Architecture decisions, refactoring plans, feature design
+  - Debugging (requires reasoning about error state)
+  - Security-sensitive code: auth, permissions, input validation, migrations
+  - Tasks requiring exact line numbers for editing — use Read directly
+  - Tasks under ~2000 tokens (overhead not worth it)
+
+  **Ask first (ambiguous):**
+
+  - "Summarize what changed in this PR"
+  - Anything touching auth or permissions even if it seems mechanical
+  """
+  with open("CLAUDE.md", "a") as f:
+      f.write(section)
+  print("Done")
+  PYEOF
+  ````
+
+  Expected: prints `Done` with no errors.
+
+- [ ] **Step 3: Verify section was appended**
+
+  ```bash
+  grep -n 'Cheap-Worker Delegation' CLAUDE.md
+  ```
+
+  Expected: prints a line number followed by `## Cheap-Worker Delegation (Kimi K2.5)`.
+
+- [ ] **Step 4: Lint the markdown**
+
+  ```bash
+  npx markdownlint CLAUDE.md
+  ```
+
+  Expected: no output (clean). If errors appear, fix them using the Edit tool before committing.
+
+- [ ] **Step 5: Commit**
+
+  ```bash
+  git add CLAUDE.md
+  git commit -m "feat(claude): add Kimi K2.5 bulk I/O delegation rules"
+  ```
+
+  Expected: commit succeeds (pre-commit hooks pass).
+
+---
+
+## Task 5: Run smoke tests
+
+All tests run from the project root. Tasks 1–4 must be complete and a **new Claude Code session must be started** (so the `settings.json` env vars are injected).
+
+- [ ] **Step 1: Confirm env vars are visible inside the Claude session**
+
+  ```bash
+  echo "KEY=${WORKER_API_KEY:0:8}... MODEL=$WORKER_MODEL"
+  ```
+
+  Expected: prints the first 8 chars of your key and `kimi-k2.5`. If blank, the session was not restarted after Task 2 — restart and retry.
+
+- [ ] **Step 2: ask-kimi smoke test**
+
+  ```bash
+  ask-kimi \
+    --paths backend/apps/plant_identification/models.py \
+    --question "list the models defined in this file and their primary fields"
+  ```
+
+  Expected: structured bullet output naming models (e.g. `PlantIdentification`, `Diagnosis`) with field names. No Python traceback. No `AuthenticationError` (would indicate bad API key).
+
+  If you see `AuthenticationError` or `401`: the API key in `~/.claude/settings.json` is incorrect. Re-run Task 2 Step 2 with the correct key.
+
+- [ ] **Step 3: kimi-write smoke test**
+
+  ```bash
+  kimi-write \
+    --spec "write a stub pytest test class for PlantIdentificationViewSet with one placeholder test" \
+    --context backend/apps/plant_identification/tests.py \
+    --target /tmp/test_stub.py
+  ```
+
+  Then verify:
+
+  ```bash
+  python3 -c "
+  import ast, sys
+  try:
+      ast.parse(open('/tmp/test_stub.py').read())
+      print('PASS: valid Python')
+  except SyntaxError as e:
+      print('FAIL:', e)
+      sys.exit(1)
+  "
+  ```
+
+  Expected: `PASS: valid Python`
+
+- [ ] **Step 4: extract-chat smoke test**
+
+  ```bash
+  LATEST=$(ls -t ~/.claude/projects/*/sessions/*.jsonl 2>/dev/null | head -1)
+  if [ -z "$LATEST" ]; then
+    echo "No session JSONL found — skip this step"
+  else
+    extract-chat "$LATEST" -o /tmp/chat.txt
+    wc -l /tmp/chat.txt
+    head -3 /tmp/chat.txt
+  fi
+  ```
+
+  Expected: prints a line count and the first 3 lines of human-readable conversation text. If no JSONL files exist, the step is skipped (that's fine — `extract-chat` is used for post-session doc updates once more sessions accumulate).
+
+- [ ] **Step 5: Delegation behavior verification**
+
+  Ask Claude (in the same session) to explain a large file without using the Read tool:
+
+  > "What models are defined in `backend/apps/plant_identification/models.py` and what are their key fields?"
+
+  Expected: Claude issues a Bash call to `ask-kimi --paths backend/apps/plant_identification/models.py --question "..."` rather than calling the Read tool. If Claude uses Read instead, check that the CLAUDE.md section was appended correctly in Task 4 and that the session was started after that commit.
+
+- [ ] **Step 6: Clean up temp files**
+
+  ```bash
+  rm -f /tmp/test_stub.py /tmp/chat.txt
+  ```

--- a/docs/superpowers/specs/2026-05-07-completing-todos-skill-design.md
+++ b/docs/superpowers/specs/2026-05-07-completing-todos-skill-design.md
@@ -1,0 +1,308 @@
+# Completing Todos Skill — Design
+
+**Date:** 2026-05-07
+**Status:** Approved (Approach A)
+**Author:** Brainstormed with Claude Code
+
+## Goal
+
+Provide a repeatable, reviewable workflow for working through `status: pending` todo files in `todos/` and a frozen template that future audits use to create new todos. The workflow drives one or many todos through implementation → verification → code review → archival, reusing the existing `code-review-orchestrator` rather than duplicating its routing logic.
+
+## Non-Goals
+
+- **Auto-creating todos.** New todos are added by audits or humans; the template enforces structure but the skill does not generate todos.
+- **Auto-committing.** The skill never runs `git commit`. The user controls commit boundaries (often one PR per todo, sometimes one PR per batch).
+- **PR creation.** Out of scope. Use `commit-commands:commit-push-pr` after.
+- **Backfill of the existing `archive/`.** Existing archived files are left alone; the template applies going forward.
+- **Reimplementing review routing.** All file-pattern → reviewer mapping lives in `code-review-orchestrator`; this skill calls that orchestrator and consumes its findings.
+
+## User-Visible Surface
+
+### Trigger phrases
+
+The skill activates on any of:
+
+- `/completing-todos` (slash invocation)
+- "complete the pending todos"
+- "work through the todos"
+- "clear all todos"
+- "finish todo NNN" (single-todo mode — skill parses `NNN` and treats it as `--ids NNN`)
+
+### Filter flags (parsed from the user's invocation message)
+
+- `--priority p1` — restrict to one priority (default: all)
+- `--ids 050,052,056` — restrict to specific issue_ids
+- `--skip 053,054` — exclude specific issue_ids
+- `--dry-run` — print what would be done; touch nothing
+
+Natural-language id references (e.g., "finish todo 050", "do 052 and 056") are normalized to the equivalent `--ids` flag during Phase 0 plan construction.
+
+Defaults: process all `status: pending` todos, sequentially, in priority then dependency order.
+
+## Components
+
+### 1. `todos/TEMPLATE.md` — frozen template
+
+A single template file at the root of `todos/`. Codifies the structure already documented in [todos/README.md](../../../todos/README.md) (lines 164–213) so future authors and AI audits emit consistent files.
+
+**Header comment** (markdown comment at top, removed when copied):
+
+```markdown
+<!--
+COPY THIS FILE — do not edit in place.
+Filename: NNN-pending-pX-short-slug.md
+  NNN     = next zero-padded issue id (check `ls todos/*.md | tail -1`)
+  pX      = p1 | p2 | p3 | p4
+  slug    = lowercase-kebab-case, ≤ 6 words
+
+Status transitions: pending → in_progress → completed (or blocked).
+Filename status segment must match frontmatter status.
+-->
+```
+
+**Body** (the template proper, identical structure to existing todos):
+
+```markdown
+---
+status: pending
+priority: pX
+issue_id: "NNN"
+tags: []
+dependencies: []
+---
+
+# <Concise Issue Title>
+
+## Problem
+
+<1–3 sentences. What's broken or missing, and why it matters.>
+
+## Findings
+
+<Bullet list. Each bullet anchored to a file path, line number, command output,
+or commit. State the discovery source (audit run, agent, human).>
+
+## Proposed Solutions
+
+### Option 1: <Recommended>
+- **Implementation:** <how>
+- **Pros:** <list>
+- **Cons:** <list>
+- **Effort:** <minutes / hours>
+- **Risk:** <low / medium / high, with reason>
+
+### Option 2: <Alternative>
+<Same shape. Drop entire section if there is genuinely only one viable option.>
+
+## Recommended Action
+
+<Numbered list of concrete steps. Include code snippets, commands, file paths.>
+
+## Technical Details
+
+<File paths, line numbers, configuration examples, links to relevant patterns
+under backend/docs/patterns/, web/docs/patterns/, etc.>
+
+## Acceptance Criteria
+
+- [ ] <Verifiable criterion — passes a test, produces a build, etc.>
+- [ ] <Each criterion must be objectively checkable.>
+
+## Work Log
+
+### YYYY-MM-DD - <Event>
+
+- <What happened, by whom, with what outcome.>
+
+## Notes
+
+<Priority rationale, related issue ids, trade-offs, deferred decisions.>
+```
+
+### 2. `todos/README.md` — small addition
+
+Add one section near the top of [todos/README.md](../../../todos/README.md), immediately after the "Quick Reference" header:
+
+```markdown
+## Creating a New Todo
+
+1. Copy `TEMPLATE.md` to `NNN-pending-pX-slug.md` (next id, lowercase kebab slug).
+2. Fill every section. Empty Optional sections may be deleted, not left blank.
+3. Frontmatter `status` must match the filename status segment.
+4. Commit the new file before referencing its issue_id from another todo's `dependencies`.
+```
+
+The existing "Todo File Structure" section (lines 164–213) stays — it documents the schema. The new section points authors at the template.
+
+### 3. `.claude/skills/completing-todos/SKILL.md` — the workflow skill
+
+Project-local skill (lives in this repo, ships with the codebase).
+
+**Frontmatter:**
+
+```yaml
+---
+name: completing-todos
+description: Work through pending todo files in todos/ — one, many, or all. Drives each through implementation → verification → code review → archival. Use when the user says "complete the pending todos", "clear todos", "finish todo NNN", or invokes /completing-todos.
+---
+```
+
+**Body sections** (full prose lives in the skill file; this spec describes shape):
+
+#### Section: Phase 0 — Scope Confirmation
+
+1. Discover candidates:
+
+   ```bash
+   grep -l "^status: pending" todos/*.md | sort
+   ```
+
+2. Parse each candidate's frontmatter (`priority`, `issue_id`, `dependencies`) and title (first `#` line).
+3. Apply filter flags from the user's message (`--priority`, `--ids`, `--skip`).
+4. Order: **priority asc** (p1 first), then **dependency-respecting topo sort** within priority. If a cycle is detected, abort with the cycle printed; do not silently break it.
+5. Print the proposed run plan:
+
+   ```
+   Completing 4 todos sequentially:
+     1. 050 [p1] Make Flutter App Buildable From a Fresh Checkout
+     2. 052 [p2] CI toolchain drift
+     3. 056 [p2] Backend Python vulnerabilities
+     4. 054 [p3] Update stale documentation
+   Skipped: 053 (--skip), 055 (--priority p2)
+   Proceed? (yes / edit / cancel)
+   ```
+
+6. Wait for user confirmation. On `edit`, accept a refined filter and re-plan. On `cancel`, exit.
+
+#### Section: Phase 1 — Per-Todo Loop
+
+For each todo in order:
+
+1. **Mark in-progress** (atomic):
+   - Edit frontmatter `status: pending` → `in_progress`.
+   - `git mv` filename `…-pending-…` → `…-in_progress-…`.
+   - Append Work Log entry: `YYYY-MM-DD - Started by completing-todos skill`.
+
+2. **Implement / verify**:
+   - Read **Recommended Action** and **Technical Details** sections.
+   - If acceptance criteria are already all-checked and the file paths in Technical Details show no diff vs. `HEAD` (`git diff --quiet HEAD -- <paths>`), treat as **verify-only**: skip to step 3 to re-confirm the criteria still hold.
+   - Otherwise, perform the work. Use TodoWrite to track sub-steps. Delegate large or specialized work to subagents (Explore for searches, frontend-developer for UI, wagtail-cms-orchestrator for CMS data flow). The skill itself owns the orchestration; subagents own the doing.
+
+3. **Verification gate** (per [verification-before-completion](../../../.claude/skills/superpowers/verification-before-completion/SKILL.md)):
+   - Run every command implied by the Acceptance Criteria. Capture output.
+   - For each `- [ ]` item: confirm with evidence, then flip to `- [x]`. Never flip without command output you can quote.
+   - If any criterion fails: pause, print the failure, ask `(retry / skip-todo / abort-run)`. Do not proceed.
+
+4. **Code review**:
+   - Dispatch `code-review-orchestrator` via the Task tool with the changed file list.
+   - Severity policy:
+     - `critical` or `high` → block. Print the findings, ask `(repair / accept-and-continue / abort-run)`.
+     - `medium` or below → list in the Work Log entry, do not block.
+   - On `repair`: the skill re-dispatches the *same domain reviewer that surfaced the finding* via the Task tool with a repair prompt (file path + finding description + suggested_fix). It then applies the reviewer's returned edits via Edit, re-runs the verification gate, and exits the loop after this todo so the user can inspect the diff before continuing. (Repair does NOT use `full-review-orchestrator`'s Phase 4 machinery — that's a different surface; this skill keeps repair scoped to a single file.)
+   - On `accept-and-continue`: record the unaddressed finding in the Work Log under a `Known issues` subsection so it is not silently lost.
+
+5. **Archive**:
+   - Edit frontmatter `status: in_progress` → `completed`.
+   - Append Work Log entry: `YYYY-MM-DD - Completed by completing-todos skill. Verification: <one-line summary>. Review: <N findings, N blocking>.`
+   - `git mv` `…-in_progress-…` → `…-completed-…` AND move into `todos/archive/`.
+
+6. **Checkpoint**:
+   - Append the completed `issue_id` to `todos/.completing-todos-run-<run_id>.json` (see Resumability below).
+
+7. **Continue** to the next todo.
+
+#### Section: Phase 2 — Wrap-Up
+
+After the loop (or after `abort-run`):
+
+1. Print the run summary:
+
+   ```
+   Run <run_id> finished.
+     Completed: 050, 052, 056
+     Skipped:   054 (verification failed: flutter analyze)
+     Aborted:   none
+   Files moved to todos/archive/. No commits made.
+   Suggested next step: review `git status`, then commit per todo or as a batch.
+   ```
+
+2. Delete the checkpoint file if all planned todos reached a terminal state (completed or skipped). Keep it if the run was aborted, so a re-invocation can resume.
+
+#### Section: Resumability
+
+A `run_id` is generated at Phase 0 (`date -u +"%Y-%m-%d-%H%M"`).
+
+The checkpoint file `todos/.completing-todos-run-<run_id>.json` shape:
+
+```json
+{
+  "run_id": "2026-05-07-1430",
+  "started_at": "2026-05-07T14:30:00Z",
+  "plan": ["050", "052", "056", "054"],
+  "completed": ["050", "052"],
+  "skipped": [],
+  "aborted_at": null,
+  "filter_flags": ["--skip", "053"]
+}
+```
+
+On re-invocation, if any `todos/.completing-todos-run-*.json` exists:
+
+- Phase 0 detects it, prints `Found in-progress run <run_id> (2/4 complete). Resume? (yes / restart / discard)`.
+- `yes` → skip everything in `completed`/`skipped`; resume at the next planned id.
+- `restart` → delete the checkpoint, re-plan from scratch.
+- `discard` → delete the checkpoint, exit.
+
+#### Section: Safety Rails
+
+- **Never auto-commit.** Phase 2 explicitly tells the user to commit.
+- **Sequential by default.** A `--parallel N` flag is reserved but not implemented in v1; document it as future work in the skill body.
+- **Confirmation before the first file move.** Once per run, the skill prompts `About to rename + move 4 files via git mv. Continue? (yes / cancel)` so a misclick or wrong working directory bails out cheaply.
+- **Acceptance criteria are gospel.** The skill cannot mark a todo complete unless every `- [ ]` has been flipped to `- [x]` with verification evidence captured in the Work Log.
+- **No destructive recovery.** If the workflow fails mid-todo (e.g., `git mv` fails), the skill stops and leaves state as-is for the user to inspect. It does not roll back.
+- **Stop on review block.** If `code-review-orchestrator` returns critical/high findings and the user picks `repair`, the skill exits the loop after repair so the user can review the diff before any further todos run.
+
+### 4. Reuse, not rebuild
+
+- **Routing:** `code-review-orchestrator` already maps changed files to domain reviewers. This skill calls it; it does not maintain its own routing table.
+- **Verification rigor:** [verification-before-completion](../../../.claude/skills/superpowers/verification-before-completion/SKILL.md) defines what "verified" means. This skill cites and follows it; it does not redefine.
+- **Subagents:** For implementation work, the skill dispatches existing agents (`Explore`, `frontend-developer`, `wagtail-cms-orchestrator`, `general-purpose`) chosen by what the todo touches.
+
+## Out of Scope (explicit)
+
+- Generating todos from review findings (separate workflow).
+- Synchronizing todos with GitHub Issues (covered by existing `GITHUB_ISSUE_*.md` docs in `todos/`).
+- Time tracking or effort-estimate reconciliation.
+- Stale-todo detection / cleanup.
+
+## Risks & Mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Skill marks a todo complete with un-met acceptance criteria | Hard rule: every `- [ ]` must flip to `- [x]` with quoted command output in the Work Log. Skill code path has no "force complete". |
+| Sequential runs are slow for many small todos | v1 ships sequential only. Document `--parallel` as future work; do not implement until shared-file collision detection exists. |
+| `git mv` fails mid-rename leaves orphan | Skill stops on first error; does not attempt recovery. User inspects `git status` and resolves. |
+| User runs skill in wrong directory | One-time confirmation prompt before the first file move. |
+| Review orchestrator returns findings the user disagrees with | Skill offers `repair / accept-and-continue / abort-run` — user is in the loop, never overridden. |
+| Checkpoint file leaks if process is killed | Checkpoint lives under `todos/.completing-todos-run-*.json`; pattern is git-ignored (add to `.gitignore` as part of implementation). Stale ones can be inspected and deleted by hand. |
+
+## Acceptance Criteria for the Skill Itself
+
+- [ ] `todos/TEMPLATE.md` exists, contains the documented structure, and includes the "do not edit in place" header comment.
+- [ ] `todos/README.md` has a "Creating a New Todo" section pointing at the template.
+- [ ] `todos/.gitignore` (or root `.gitignore` entry) excludes `todos/.completing-todos-run-*.json`.
+- [ ] `.claude/skills/completing-todos/SKILL.md` exists with frontmatter triggering on the documented phrases and `/completing-todos`.
+- [ ] Skill body covers all four phases (Scope, Per-Todo Loop, Wrap-Up, Resumability) and the Safety Rails section.
+- [ ] Skill explicitly delegates code review to `code-review-orchestrator` via the Task tool — no domain-routing logic in the skill itself.
+- [ ] Skill cites `verification-before-completion` as the standard for marking acceptance criteria done.
+- [ ] Dry-run a single completed todo from the existing archive (e.g., 046) end-to-end and confirm the prompts and gates fire as designed (no actual file changes — `--dry-run` flag).
+
+## Implementation Order (preview for writing-plans)
+
+1. Write `todos/TEMPLATE.md` and the README addition. Cheapest, smallest blast radius.
+2. Add the `todos/.completing-todos-run-*.json` exclusion to `.gitignore`.
+3. Write `.claude/skills/completing-todos/SKILL.md` — Phase 0 + Phase 2 + Resumability first (the wrapper), then Phase 1 (the loop body). This lets the skill be invoked end-to-end with `--dry-run` before the loop is fully fleshed out.
+4. Dry-run against the current 7 pending todos. Refine prompts based on real output.
+5. Live-run on one truly small pending todo (a P3 or P4) to validate the full path including `git mv` and the review dispatch.
+
+`writing-plans` will turn these into a numbered, dependency-aware implementation plan.

--- a/docs/superpowers/specs/2026-05-07-precommit-lint-prettier-design.md
+++ b/docs/superpowers/specs/2026-05-07-precommit-lint-prettier-design.md
@@ -1,0 +1,89 @@
+# Pre-commit Lint & Prettier Hooks Design
+
+**Date:** 2026-05-07  
+**Status:** Approved
+
+## Summary
+
+Add ESLint, Prettier (web), `flutter analyze`, and `dart format` (mobile) as pre-commit hooks. Fix the existing broken `mirrors-eslint` v8 hook, which is incompatible with the project's ESLint v9 flat config.
+
+## Scope
+
+- `web/` — React/TypeScript frontend
+- `plant_community_mobile/` — Flutter mobile app
+
+Python checks (Black, Flake8, isort) are already working and are out of scope.
+
+## Approach
+
+Option A: local hooks running project CLI tools directly. No new hook systems (no husky/lint-staged). All hooks live in `.pre-commit-config.yaml` alongside existing checks. Runs on all project files (not just staged), which is acceptable at this codebase size.
+
+## Changes Required
+
+### 1. `web/` — Bootstrap Prettier
+
+- Install `prettier` as a devDependency in `web/package.json`
+- Add `web/.prettierrc` with:
+  - `printWidth: 100`
+  - `singleQuote: true`
+  - `semi: true`
+  - `tabWidth: 2`
+  - `trailingComma: "es5"`
+- Add `"format": "prettier --write ."` script to `web/package.json`
+
+### 2. `.pre-commit-config.yaml` — Web hooks
+
+Remove the existing broken `pre-commit/mirrors-eslint` v8 hook.
+
+Add two local hooks under a new `# JavaScript/TypeScript` section:
+
+**ESLint hook**
+
+- `name`: Lint JS/TS with ESLint
+- `entry`: `bash -c 'cd web && npm run lint'`
+- `language`: system
+- `files`: `^web/.*\.(js|jsx|ts|tsx)$`
+- `pass_filenames`: false
+
+**Prettier hook**
+
+- `name`: Check JS/TS formatting with Prettier
+- `entry`: `bash -c 'cd web && npx prettier --check .'`
+- `language`: system
+- `files`: `^web/.*\.(js|jsx|ts|tsx)$`
+- `pass_filenames`: false
+
+### 3. `.pre-commit-config.yaml` — Flutter hooks
+
+Add two local hooks under a new `# Flutter/Dart` section:
+
+**flutter analyze hook**
+
+- `name`: Analyze Flutter with flutter analyze
+- `entry`: `bash -c 'flutter analyze plant_community_mobile/'`
+- `language`: system
+- `files`: `^plant_community_mobile/.*\.dart$`
+- `pass_filenames`: false
+
+**dart format hook**
+
+- `name`: Check Dart formatting with dart format
+- `entry`: `bash -c 'dart format --output=none --set-exit-if-changed plant_community_mobile/lib/'`
+- `language`: system
+- `files`: `^plant_community_mobile/.*\.dart$`
+- `pass_filenames`: false
+
+## Developer Workflow
+
+| Problem | Fix command |
+|---------|-------------|
+| ESLint errors | `cd web && npm run lint -- --fix` |
+| Prettier failures | `cd web && npm run format` |
+| flutter analyze failures | Fix the reported Dart issues |
+| dart format failures | `dart format plant_community_mobile/lib/` |
+
+## Out of Scope
+
+- Adding ESLint/Prettier to GitHub Actions CI (separate task)
+- Changing existing Python (Black/Flake8/isort) hooks
+- Changing `analysis_options.yaml` lint rules

--- a/docs/superpowers/specs/2026-05-08-kimi-delegation-design.md
+++ b/docs/superpowers/specs/2026-05-08-kimi-delegation-design.md
@@ -1,0 +1,134 @@
+# Kimi K2.5 Bulk I/O Delegation — Design
+
+**Date:** 2026-05-08
+**Status:** Approved, pending implementation
+
+## Goal
+
+Reduce Claude Code token consumption by delegating bulk file reading and boilerplate generation to a cheap worker model (Kimi K2.5 via Moonshot AI). Claude handles architecture and reasoning; the worker handles token-heavy I/O.
+
+## Source Repo
+
+`https://github.com/imkunal007219/claude-coworker-model`
+MIT license. Python, uses `openai>=1.0` against any OpenAI-compatible provider.
+
+## Architecture
+
+### Installation
+
+- Clone repo to `~/.local/share/claude-coworker/`
+- Run `setup.sh` — creates a Python venv, installs `openai` package, copies/symlinks three tools to `~/.local/bin/` (already on PATH)
+
+### Tools
+
+| Tool | Purpose |
+|------|---------|
+| `ask-kimi` | Reads N files, returns structured bullet summary |
+| `kimi-write` | Generates boilerplate to a target file using an existing file as style reference |
+| `extract-chat` | Converts `.jsonl` session logs to readable text (stdlib only, no API call) |
+
+### Environment Variables
+
+Set in two places:
+
+**`~/.claude/settings.json` `env` block** — injected into every Claude Code session automatically:
+
+```json
+"WORKER_API_KEY": "<moonshot key>",
+"WORKER_BASE_URL": "https://api.moonshot.ai/v1",
+"WORKER_MODEL": "kimi-k2.5"
+```
+
+**`~/.zshrc`** — same three exports for manual terminal use.
+
+### Permissions
+
+Add to `~/.claude/settings.json` allow list so Claude never prompts:
+
+```text
+Bash(ask-kimi:*)
+Bash(kimi-write:*)
+Bash(extract-chat:*)
+```
+
+## Delegation Rules (CLAUDE.md)
+
+A new section `## Cheap-Worker Delegation (Kimi K2.5)` is appended to the project `CLAUDE.md`. Nothing existing is removed.
+
+### AUTO-delegate (no prompt)
+
+- Reading 3+ files for exploration/context → `ask-kimi --paths <files> --question "<question>"`
+- Single file over ~400 lines when the goal is understanding (not editing) — e.g. `backend/apps/*/models.py`, serializers, large Flutter screens
+- Generating boilerplate that follows an existing pattern: pytest tests, DRF viewsets/serializers, Flutter widgets, Riverpod providers → `kimi-write --spec "<what>" --context <existing-similar-file> --target <output>`
+- Post-session documentation updates → `extract-chat <session.jsonl>` then `ask-kimi` to suggest doc changes
+
+### NEVER delegate
+
+- Architecture decisions, refactoring plans, feature design
+- Debugging (requires reasoning about error state)
+- Security-sensitive code: auth, permissions, input validation, migrations
+- Any task requiring exact line numbers for editing — read the file directly
+- Tasks under ~2000 tokens (delegation overhead not worth it)
+
+### AMBIGUOUS — ask first
+
+- "Summarize what changed in this PR" (may need reasoning)
+- Anything touching auth or permissions even if mechanical
+
+## Data Flow
+
+```text
+Claude encounters bulk work
+  → checks CLAUDE.md rules
+  → Bash: ask-kimi --paths <files> --question "<specific question>"
+  → worker calls Moonshot API, returns structured bullets
+  → Claude reads ~200-token summary instead of ~4000+ token raw files
+  → Claude reasons/edits using the summary
+
+Claude identifies boilerplate task
+  → Bash: kimi-write --spec "<what>" --context <existing-file> --target <output>
+  → worker writes the file
+  → Claude reviews and edits only what needs fixing
+```
+
+## Test Plan
+
+All four steps runnable via Bash in a Claude Code session:
+
+1. **Tool smoke test**
+
+   ```bash
+   ask-kimi --paths backend/apps/plant_identification/models.py \
+     --question "list the models and their key fields"
+   ```
+
+   Expected: structured bullet list, no errors.
+
+2. **Write smoke test**
+
+   ```bash
+   kimi-write \
+     --spec "stub pytest test class for PlantIdentificationViewSet" \
+     --context backend/apps/plant_identification/tests.py \
+     --target /tmp/test_stub.py
+   ```
+
+   Expected: `/tmp/test_stub.py` created with valid Python.
+
+3. **Extract smoke test**
+
+   ```bash
+   extract-chat $(ls -t ~/.claude/projects/*/sessions/*.jsonl 2>/dev/null | head -1) \
+     -o /tmp/chat.txt
+   ```
+
+   Expected: `/tmp/chat.txt` contains human-readable conversation text.
+
+4. **Delegation in-session**
+   Ask Claude a question about a 500+ line file. Confirm it calls `ask-kimi` rather than using the Read tool.
+
+## Out of Scope
+
+- mcp-memory-service (existing file-based memory at `~/.claude/projects/.../memory/` is sufficient and already loading)
+- SessionEnd auto-harvest hooks (not needed; memory is curated manually)
+- Additional worker providers (DeepSeek, Ollama) — can be added later by changing env vars

--- a/docs/superpowers/specs/2026-05-08-kimi-delegation-design.md
+++ b/docs/superpowers/specs/2026-05-08-kimi-delegation-design.md
@@ -1,11 +1,11 @@
-# Kimi K2.5 Bulk I/O Delegation — Design
+# Kimi K2.6 Bulk I/O Delegation — Design
 
 **Date:** 2026-05-08
 **Status:** Approved, pending implementation
 
 ## Goal
 
-Reduce Claude Code token consumption by delegating bulk file reading and boilerplate generation to a cheap worker model (Kimi K2.5 via Moonshot AI). Claude handles architecture and reasoning; the worker handles token-heavy I/O.
+Reduce Claude Code token consumption by delegating bulk file reading and boilerplate generation to a cheap worker model (Kimi K2.6 via OpenRouter). Claude handles architecture and reasoning; the worker handles token-heavy I/O.
 
 ## Source Repo
 
@@ -34,9 +34,9 @@ Set in two places:
 **`~/.claude/settings.json` `env` block** — injected into every Claude Code session automatically:
 
 ```json
-"WORKER_API_KEY": "<moonshot key>",
-"WORKER_BASE_URL": "https://api.moonshot.ai/v1",
-"WORKER_MODEL": "kimi-k2.5"
+"WORKER_API_KEY": "<openrouter key>",
+"WORKER_BASE_URL": "https://openrouter.ai/api/v1",
+"WORKER_MODEL": "moonshotai/kimi-k2.6"
 ```
 
 **`~/.zshrc`** — same three exports for manual terminal use.
@@ -53,7 +53,7 @@ Bash(extract-chat:*)
 
 ## Delegation Rules (CLAUDE.md)
 
-A new section `## Cheap-Worker Delegation (Kimi K2.5)` is appended to the project `CLAUDE.md`. Nothing existing is removed.
+A new section `## Cheap-Worker Delegation (Kimi K2.6)` is appended to the project `CLAUDE.md`. Nothing existing is removed.
 
 ### AUTO-delegate (no prompt)
 
@@ -81,7 +81,7 @@ A new section `## Cheap-Worker Delegation (Kimi K2.5)` is appended to the projec
 Claude encounters bulk work
   → checks CLAUDE.md rules
   → Bash: ask-kimi --paths <files> --question "<specific question>"
-  → worker calls Moonshot API, returns structured bullets
+  → worker calls OpenRouter API, returns structured bullets
   → Claude reads ~200-token summary instead of ~4000+ token raw files
   → Claude reasons/edits using the summary
 

--- a/plant_community_mobile/ios/Flutter/AppFrameworkInfo.plist
+++ b/plant_community_mobile/ios/Flutter/AppFrameworkInfo.plist
@@ -20,7 +20,5 @@
   <string>????</string>
   <key>CFBundleVersion</key>
   <string>1.0</string>
-  <key>MinimumOSVersion</key>
-  <string>13.0</string>
 </dict>
 </plist>

--- a/plant_community_mobile/ios/Podfile
+++ b/plant_community_mobile/ios/Podfile
@@ -1,5 +1,5 @@
 # Uncomment this line to define a global platform for your project
-platform :ios, '15.0'
+platform :ios, '16.0'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'
@@ -39,5 +39,8 @@ end
 post_install do |installer|
   installer.pods_project.targets.each do |target|
     flutter_additional_ios_build_settings(target)
+    target.build_configurations.each do |config|
+      config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '16.0'
+    end
   end
 end

--- a/plant_community_mobile/ios/Podfile.lock
+++ b/plant_community_mobile/ios/Podfile.lock
@@ -1194,57 +1194,64 @@ PODS:
   - BoringSSL-GRPC/Implementation (0.0.37):
     - BoringSSL-GRPC/Interface (= 0.0.37)
   - BoringSSL-GRPC/Interface (0.0.37)
-  - cloud_firestore (6.1.0):
-    - Firebase/Firestore (= 12.4.0)
+  - cloud_firestore (6.3.0):
+    - Firebase/Firestore (= 12.12.0)
     - firebase_core
     - Flutter
-  - Firebase/Auth (12.4.0):
+  - Firebase/Auth (12.12.0):
     - Firebase/CoreOnly
-    - FirebaseAuth (~> 12.4.0)
-  - Firebase/CoreOnly (12.4.0):
-    - FirebaseCore (~> 12.4.0)
-  - Firebase/Firestore (12.4.0):
+    - FirebaseAuth (~> 12.12.0)
+  - Firebase/CoreOnly (12.12.0):
+    - FirebaseCore (~> 12.12.0)
+  - Firebase/Firestore (12.12.0):
     - Firebase/CoreOnly
-    - FirebaseFirestore (~> 12.4.0)
-  - Firebase/Storage (12.4.0):
+    - FirebaseFirestore (~> 12.12.0)
+  - Firebase/Messaging (12.12.0):
     - Firebase/CoreOnly
-    - FirebaseStorage (~> 12.4.0)
-  - firebase_auth (6.1.2):
-    - Firebase/Auth (= 12.4.0)
+    - FirebaseMessaging (~> 12.12.0)
+  - Firebase/Storage (12.12.0):
+    - Firebase/CoreOnly
+    - FirebaseStorage (~> 12.12.0)
+  - firebase_auth (6.4.0):
+    - Firebase/Auth (= 12.12.0)
     - firebase_core
     - Flutter
-  - firebase_core (4.2.1):
-    - Firebase/CoreOnly (= 12.4.0)
+  - firebase_core (4.7.0):
+    - Firebase/CoreOnly (= 12.12.0)
     - Flutter
-  - firebase_storage (13.0.4):
-    - Firebase/Storage (= 12.4.0)
+  - firebase_messaging (16.2.0):
+    - Firebase/Messaging (= 12.12.0)
     - firebase_core
     - Flutter
-  - FirebaseAppCheckInterop (12.4.0)
-  - FirebaseAuth (12.4.0):
-    - FirebaseAppCheckInterop (~> 12.4.0)
-    - FirebaseAuthInterop (~> 12.4.0)
-    - FirebaseCore (~> 12.4.0)
-    - FirebaseCoreExtension (~> 12.4.0)
+  - firebase_storage (13.3.0):
+    - Firebase/Storage (= 12.12.0)
+    - firebase_core
+    - Flutter
+  - FirebaseAppCheckInterop (12.12.0)
+  - FirebaseAuth (12.12.0):
+    - FirebaseAppCheckInterop (~> 12.12.0)
+    - FirebaseAuthInterop (~> 12.12.0)
+    - FirebaseCore (~> 12.12.0)
+    - FirebaseCoreExtension (~> 12.12.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 8.1)
     - GoogleUtilities/Environment (~> 8.1)
     - GTMSessionFetcher/Core (< 6.0, >= 3.4)
     - RecaptchaInterop (~> 101.0)
-  - FirebaseAuthInterop (12.4.0)
-  - FirebaseCore (12.4.0):
-    - FirebaseCoreInternal (~> 12.4.0)
+  - FirebaseAuthInterop (12.12.0)
+  - FirebaseCore (12.12.1):
+    - FirebaseCoreInternal (~> 12.12.0)
     - GoogleUtilities/Environment (~> 8.1)
     - GoogleUtilities/Logger (~> 8.1)
-  - FirebaseCoreExtension (12.4.0):
-    - FirebaseCore (~> 12.4.0)
-  - FirebaseCoreInternal (12.4.0):
+  - FirebaseCoreExtension (12.12.0):
+    - FirebaseCore (~> 12.12.0)
+  - FirebaseCoreInternal (12.12.0):
     - "GoogleUtilities/NSData+zlib (~> 8.1)"
-  - FirebaseFirestore (12.4.0):
-    - FirebaseCore (~> 12.4.0)
-    - FirebaseCoreExtension (~> 12.4.0)
-    - FirebaseFirestoreInternal (~> 12.4.0)
-    - FirebaseSharedSwift (~> 12.4.0)
-  - FirebaseFirestoreInternal (12.4.0):
+  - FirebaseFirestore (12.12.0):
+    - FirebaseCore (~> 12.12.0)
+    - FirebaseCoreExtension (~> 12.12.0)
+    - FirebaseFirestoreInternal (~> 12.12.0)
+    - FirebaseSharedSwift (~> 12.12.0)
+  - FirebaseFirestoreInternal (12.12.0):
     - abseil/algorithm (~> 1.20240722.0)
     - abseil/base (~> 1.20240722.0)
     - abseil/container/flat_hash_map (~> 1.20240722.0)
@@ -1253,21 +1260,48 @@ PODS:
     - abseil/strings/strings (~> 1.20240722.0)
     - abseil/time (~> 1.20240722.0)
     - abseil/types (~> 1.20240722.0)
-    - FirebaseAppCheckInterop (~> 12.4.0)
-    - FirebaseCore (~> 12.4.0)
+    - FirebaseAppCheckInterop (~> 12.12.0)
+    - FirebaseCore (~> 12.12.0)
     - "gRPC-C++ (~> 1.69.0)"
     - gRPC-Core (~> 1.69.0)
     - leveldb-library (~> 1.22)
     - nanopb (~> 3.30910.0)
-  - FirebaseSharedSwift (12.4.0)
-  - FirebaseStorage (12.4.0):
-    - FirebaseAppCheckInterop (~> 12.4.0)
-    - FirebaseAuthInterop (~> 12.4.0)
-    - FirebaseCore (~> 12.4.0)
-    - FirebaseCoreExtension (~> 12.4.0)
+  - FirebaseInstallations (12.12.0):
+    - FirebaseCore (~> 12.12.0)
+    - GoogleUtilities/Environment (~> 8.1)
+    - GoogleUtilities/UserDefaults (~> 8.1)
+    - PromisesObjC (~> 2.4)
+  - FirebaseMessaging (12.12.0):
+    - FirebaseCore (~> 12.12.0)
+    - FirebaseInstallations (~> 12.12.0)
+    - GoogleDataTransport (~> 10.1)
+    - GoogleUtilities/AppDelegateSwizzler (~> 8.1)
+    - GoogleUtilities/Environment (~> 8.1)
+    - GoogleUtilities/Reachability (~> 8.1)
+    - GoogleUtilities/UserDefaults (~> 8.1)
+    - nanopb (~> 3.30910.0)
+  - FirebaseSharedSwift (12.12.0)
+  - FirebaseStorage (12.12.1):
+    - FirebaseAppCheckInterop (~> 12.12.0)
+    - FirebaseAuthInterop (~> 12.12.0)
+    - FirebaseCore (~> 12.12.0)
+    - FirebaseCoreExtension (~> 12.12.0)
     - GoogleUtilities/Environment (~> 8.1)
     - GTMSessionFetcher/Core (< 6.0, >= 3.4)
   - Flutter (1.0.0)
+  - flutter_local_notifications (0.0.1):
+    - Flutter
+  - flutter_secure_storage_darwin (10.0.0):
+    - Flutter
+    - FlutterMacOS
+  - geocoding_ios (1.0.5):
+    - Flutter
+  - geolocator_apple (1.2.0):
+    - Flutter
+    - FlutterMacOS
+  - GoogleDataTransport (10.1.0):
+    - nanopb (~> 3.30910.0)
+    - PromisesObjC (~> 2.4)
   - GoogleUtilities/AppDelegateSwizzler (8.1.0):
     - GoogleUtilities/Environment
     - GoogleUtilities/Logger
@@ -1287,6 +1321,9 @@ PODS:
     - GoogleUtilities/Privacy
   - GoogleUtilities/Privacy (8.1.0)
   - GoogleUtilities/Reachability (8.1.0):
+    - GoogleUtilities/Logger
+    - GoogleUtilities/Privacy
+  - GoogleUtilities/UserDefaults (8.1.0):
     - GoogleUtilities/Logger
     - GoogleUtilities/Privacy
   - "gRPC-C++ (1.69.0)":
@@ -1381,7 +1418,7 @@ PODS:
     - gRPC-Core/Privacy (= 1.69.0)
   - gRPC-Core/Interface (1.69.0)
   - gRPC-Core/Privacy (1.69.0)
-  - GTMSessionFetcher/Core (5.0.0)
+  - GTMSessionFetcher/Core (5.2.0)
   - image_picker_ios (0.0.1):
     - Flutter
   - leveldb-library (1.22.6)
@@ -1390,9 +1427,11 @@ PODS:
     - nanopb/encode (= 3.30910.0)
   - nanopb/decode (3.30910.0)
   - nanopb/encode (3.30910.0)
-  - path_provider_foundation (0.0.1):
+  - package_info_plus (0.4.5):
     - Flutter
-    - FlutterMacOS
+  - permission_handler_apple (9.3.0):
+    - Flutter
+  - PromisesObjC (2.4.0)
   - RecaptchaInterop (101.0.0)
   - sqflite_darwin (0.0.4):
     - Flutter
@@ -1402,10 +1441,16 @@ DEPENDENCIES:
   - cloud_firestore (from `.symlinks/plugins/cloud_firestore/ios`)
   - firebase_auth (from `.symlinks/plugins/firebase_auth/ios`)
   - firebase_core (from `.symlinks/plugins/firebase_core/ios`)
+  - firebase_messaging (from `.symlinks/plugins/firebase_messaging/ios`)
   - firebase_storage (from `.symlinks/plugins/firebase_storage/ios`)
   - Flutter (from `Flutter`)
+  - flutter_local_notifications (from `.symlinks/plugins/flutter_local_notifications/ios`)
+  - flutter_secure_storage_darwin (from `.symlinks/plugins/flutter_secure_storage_darwin/darwin`)
+  - geocoding_ios (from `.symlinks/plugins/geocoding_ios/ios`)
+  - geolocator_apple (from `.symlinks/plugins/geolocator_apple/darwin`)
   - image_picker_ios (from `.symlinks/plugins/image_picker_ios/ios`)
-  - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/darwin`)
+  - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
+  - permission_handler_apple (from `.symlinks/plugins/permission_handler_apple/ios`)
   - sqflite_darwin (from `.symlinks/plugins/sqflite_darwin/darwin`)
 
 SPEC REPOS:
@@ -1421,14 +1466,18 @@ SPEC REPOS:
     - FirebaseCoreInternal
     - FirebaseFirestore
     - FirebaseFirestoreInternal
+    - FirebaseInstallations
+    - FirebaseMessaging
     - FirebaseSharedSwift
     - FirebaseStorage
+    - GoogleDataTransport
     - GoogleUtilities
     - "gRPC-C++"
     - gRPC-Core
     - GTMSessionFetcher
     - leveldb-library
     - nanopb
+    - PromisesObjC
     - RecaptchaInterop
 
 EXTERNAL SOURCES:
@@ -1438,47 +1487,69 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/firebase_auth/ios"
   firebase_core:
     :path: ".symlinks/plugins/firebase_core/ios"
+  firebase_messaging:
+    :path: ".symlinks/plugins/firebase_messaging/ios"
   firebase_storage:
     :path: ".symlinks/plugins/firebase_storage/ios"
   Flutter:
     :path: Flutter
+  flutter_local_notifications:
+    :path: ".symlinks/plugins/flutter_local_notifications/ios"
+  flutter_secure_storage_darwin:
+    :path: ".symlinks/plugins/flutter_secure_storage_darwin/darwin"
+  geocoding_ios:
+    :path: ".symlinks/plugins/geocoding_ios/ios"
+  geolocator_apple:
+    :path: ".symlinks/plugins/geolocator_apple/darwin"
   image_picker_ios:
     :path: ".symlinks/plugins/image_picker_ios/ios"
-  path_provider_foundation:
-    :path: ".symlinks/plugins/path_provider_foundation/darwin"
+  package_info_plus:
+    :path: ".symlinks/plugins/package_info_plus/ios"
+  permission_handler_apple:
+    :path: ".symlinks/plugins/permission_handler_apple/ios"
   sqflite_darwin:
     :path: ".symlinks/plugins/sqflite_darwin/darwin"
 
 SPEC CHECKSUMS:
   abseil: a05cc83bf02079535e17169a73c5be5ba47f714b
   BoringSSL-GRPC: dded2a44897e45f28f08ae87a55ee4bcd19bc508
-  cloud_firestore: 7a6d8a533ec7418a7fe46b3a5dabf55661a5b298
-  Firebase: f07b15ae5a6ec0f93713e30b923d9970d144af3e
-  firebase_auth: 9225db04db5d8e3b46dc8940e04bc6aec6833e27
-  firebase_core: f1aafb21c14f497e5498f7ffc4dc63cbb52b2594
-  firebase_storage: d558bbfa99449fff39352db83c466c8515fa1afa
-  FirebaseAppCheckInterop: f734c802f21fe1da0837708f0f9a27218c8a4ed0
-  FirebaseAuth: 4a2aed737c84114a9d9b33d11ae1b147d6b94889
-  FirebaseAuthInterop: 858e6b754966e70740a4370dd1503dfffe6dbb49
-  FirebaseCore: bb595f3114953664e3c1dc032f008a244147cfd3
-  FirebaseCoreExtension: 7e1f7118ee970e001a8013719fb90950ee5e0018
-  FirebaseCoreInternal: d7f5a043c2cd01a08103ab586587c1468047bca6
-  FirebaseFirestore: 2a6183381cf7679b1bb000eb76a8e3178e25dee2
-  FirebaseFirestoreInternal: 6577a27cd5dc3722b900042527f86d4ea1626134
-  FirebaseSharedSwift: 93426a1de92f19e1199fac5295a4f8df16458daa
-  FirebaseStorage: 20d6b56fb8a40ebaa03d6a2889fe33dac64adb73
+  cloud_firestore: 51d1815d5406b0122715a861bb4eaa0f3ad850a9
+  Firebase: aa154fee4e9b8eac17aa42344988865b3e857d33
+  firebase_auth: b0aa0a5964e23fba1bf7f32603437edc33b889c4
+  firebase_core: 9156a152117c843440b0b990c785aa0259bc5447
+  firebase_messaging: 0d962ab44ff24ed36deb8fa2ee043c4671858269
+  firebase_storage: ef547439afc96fe8ee856de3878ed28e1c5a88e8
+  FirebaseAppCheckInterop: c63ae0d003274f145174849c545ab861593beaf9
+  FirebaseAuth: bcfebbc0ca055a6335f2252a90e57363d7ea5e65
+  FirebaseAuthInterop: 917aa3a17ecf144d5f1823b51ef372da06909a4b
+  FirebaseCore: 86241206e656f5c80c995e370e6c975913b9b284
+  FirebaseCoreExtension: ff6fd42eb5287e71d3e160450de6509733d9ead7
+  FirebaseCoreInternal: 7c12fc3011d889085e765e317d7b9fd1cef97af9
+  FirebaseFirestore: 01e964d312cf17e56925c955b19798848775a7fd
+  FirebaseFirestoreInternal: 9d9fd7eadbe0f19310fd7df06470a04baeaf3f36
+  FirebaseInstallations: 4e6e162aa4abaaeeeb01dd00179dfc5ad9c2194e
+  FirebaseMessaging: 341004946fa7ffc741344b20f1b667514fc93e31
+  FirebaseSharedSwift: bccaff90721d14bafc14be34f28b77fdd7c91dc9
+  FirebaseStorage: b3682c96ae7016420c1f6eb43d45057a0e909c9f
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
+  flutter_local_notifications: 643a3eda1ce1c0599413ca31672536d423dee214
+  flutter_secure_storage_darwin: acdb3f316ed05a3e68f856e0353b133eec373a23
+  geocoding_ios: 33776c9ebb98d037b5e025bb0e7537f6dd19646e
+  geolocator_apple: ab36aa0e8b7d7a2d7639b3b4e48308394e8cef5e
+  GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleUtilities: 00c88b9a86066ef77f0da2fab05f65d7768ed8e1
   "gRPC-C++": cc207623316fb041a7a3e774c252cf68a058b9e8
   gRPC-Core: 860978b7db482de8b4f5e10677216309b5ff6330
-  GTMSessionFetcher: 02d6e866e90bc236f48a703a041dfe43e6221a29
+  GTMSessionFetcher: 904bdd2a82c635bcd6f44edf94cc8775c5d1d6e6
   image_picker_ios: e0ece4aa2a75771a7de3fa735d26d90817041326
   leveldb-library: cc8b8f8e013647a295ad3f8cd2ddf49a6f19be19
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
-  path_provider_foundation: bb55f6dbba17d0dccd6737fe6f7f34fbd0376880
+  package_info_plus: af8e2ca6888548050f16fa2f1938db7b5a5df499
+  permission_handler_apple: 4ed2196e43d0651e8ff7ca3483a069d469701f2d
+  PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   RecaptchaInterop: 11e0b637842dfb48308d242afc3f448062325aba
   sqflite_darwin: 20b2a3a3b70e43edae938624ce550a3cbf66a3d0
 
-PODFILE CHECKSUM: 53a6aebc29ccee84c41f92f409fc20cd4ca011f1
+PODFILE CHECKSUM: 1857a7cdb7dfafe45f2b0e9a9af44644190f7506
 
 COCOAPODS: 1.16.2

--- a/plant_community_mobile/ios/Runner.xcodeproj/project.pbxproj
+++ b/plant_community_mobile/ios/Runner.xcodeproj/project.pbxproj
@@ -202,6 +202,7 @@
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
 				51B04073CBA4FC368F2CB94B /* [CP] Embed Pods Frameworks */,
+				6DDDBA8BD4842EA04CC16924 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -327,6 +328,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		6DDDBA8BD4842EA04CC16924 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		84E8F8E17AB262E9049D3BC8 /* [CP] Check Pods Manifest.lock */ = {
@@ -459,7 +477,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = iphoneos;
@@ -588,7 +606,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -639,7 +657,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = iphoneos;

--- a/plant_community_mobile/ios/Runner/AppDelegate.swift
+++ b/plant_community_mobile/ios/Runner/AppDelegate.swift
@@ -2,12 +2,15 @@ import Flutter
 import UIKit
 
 @main
-@objc class AppDelegate: FlutterAppDelegate {
+@objc class AppDelegate: FlutterAppDelegate, FlutterImplicitEngineDelegate {
   override func application(
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
-    GeneratedPluginRegistrant.register(with: self)
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+  }
+
+  func didInitializeImplicitFlutterEngine(_ engineBridge: FlutterImplicitEngineBridge) {
+    GeneratedPluginRegistrant.register(with: engineBridge.pluginRegistry)
   }
 }

--- a/plant_community_mobile/ios/Runner/Info.plist
+++ b/plant_community_mobile/ios/Runner/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
@@ -24,6 +26,29 @@
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneClassName</key>
+					<string>UIWindowScene</string>
+					<key>UISceneConfigurationName</key>
+					<string>flutter</string>
+					<key>UISceneDelegateClassName</key>
+					<string>FlutterSceneDelegate</string>
+					<key>UISceneStoryboardFile</key>
+					<string>Main</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
@@ -41,9 +66,5 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-	<key>CADisableMinimumFrameDurationOnPhone</key>
-	<true/>
-	<key>UIApplicationSupportsIndirectInputEvents</key>
-	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary

- **Kimi K2.6 delegation**: installs `claude-coworker-model` tools (`ask-kimi`, `kimi-write`, `extract-chat`) and adds auto-delegation rules to `CLAUDE.md` — Claude now delegates bulk file reading and boilerplate generation to Kimi K2.6 via OpenRouter, targeting 60-70% token savings
- **CLAUDE.md unblocked**: removes the overly-broad `block-claude-md` pre-commit hook (added post-security-incident but redundant — `scan-api-keys` already catches real credentials); `CLAUDE.md` is intentional project documentation
- **Docs housekeeping**: reorganised root-level docs, added superpowers specs/plans for completing-todos and pre-commit hooks, fixed duplicate Security heading, re-enabled MD024/MD040 linting, bumped iOS minimum deployment target to 16.0

## System-level config (outside this repo)

The following one-time setup lives outside the repository and is not captured in this diff:

1. **Tool installation**: `claude-coworker-model` cloned to `~/.local/share/claude-coworker/`, `setup.sh` run to install tools to `~/.local/bin/`
2. **API key**: `WORKER_API_KEY` (OpenRouter `sk-or-v1-...`) set in `~/.claude/settings.json` `env` block and `~/.zshrc`
3. **Permissions**: `Bash(ask-kimi:*)`, `Bash(kimi-write:*)`, `Bash(extract-chat:*)` added to `~/.claude/settings.json` allow list

The spec and plan docs in this PR describe this setup for reproducibility.

## Design

Spec: `docs/superpowers/specs/2026-05-08-kimi-delegation-design.md`
Plan: `docs/superpowers/plans/2026-05-08-kimi-delegation.md`

Delegation rules (in `CLAUDE.md`):
- **AUTO-delegate**: reading 3+ files or any file >400 lines for understanding; generating boilerplate (tests, serializers, widgets, providers)
- **NEVER delegate**: architecture decisions, debugging, security-sensitive code, tasks needing exact line numbers
- **Ask first**: ambiguous cases (PR summaries, auth-adjacent work)

## Test Plan

- [x] Django system check passes (0 issues)
- [x] `ask-kimi` smoke test: returned 19 models with fields from `plant_identification/models.py`
- [x] `kimi-write` smoke test: generated valid Python test stub
- [x] Pre-commit hooks all pass on changed files
- [ ] `extract-chat` smoke test: skipped — no session JSONL files yet; verify after a few sessions accumulate

🤖 Generated with [Claude Code](https://claude.com/claude-code)