### PR TITLE
chore: add review-doc tracking convention + close May-6 review

### DIFF
--- a/.claude/skills/completing-todos/SKILL.md
+++ b/.claude/skills/completing-todos/SKILL.md
@@ -37,22 +37,26 @@ The skill runs in three phases. Phase 0 confirms scope. Phase 1 loops per todo. 
 ### Phase 0 — Scope Confirmation
 
 1. **Generate a `run_id`** for this invocation:
+
    ```bash
    date -u +"%Y-%m-%d-%H%M"
    ```
 
 2. **Check for an interrupted run.** Glob:
+
    ```bash
    ls -1 todos/.completing-todos-run-*.json 2>/dev/null
    ```
+
    If one or more matches exist, read the most recent and follow the **Resumability** section below; do NOT continue with steps 3–8.
 
 3. **Discover candidates:**
+
    ```bash
    grep -l "^status: pending" todos/*.md | grep -v -E '/(TEMPLATE|README)\.md$' | sort
    ```
 
-4. **Parse each candidate's frontmatter** (`priority`, `issue_id`, `dependencies`) and title (the first `# ` line of the file).
+4. **Parse each candidate's frontmatter** (`priority`, `issue_id`, `dependencies`) and title (the first `#` line of the file).
 
 5. **Apply filter flags** parsed from the user's invocation message:
    - `--priority pX` — keep only matching priority
@@ -63,7 +67,8 @@ The skill runs in three phases. Phase 0 confirms scope. Phase 1 loops per todo. 
 6. **Order:** sort by priority ascending (p1 first), then dependency-respecting topological sort within each priority. If a dependency cycle is detected, **abort** with the cycle printed; do not silently break it.
 
 7. **Print the plan and prompt for confirmation:**
-   ```
+
+   ```text
    Completing N todos sequentially [DRY-RUN]:
      1. 050 [p1] Make Flutter App Buildable From a Fresh Checkout
      2. 052 [p2] CI toolchain drift
@@ -72,9 +77,11 @@ The skill runs in three phases. Phase 0 confirms scope. Phase 1 loops per todo. 
    Run id: 2026-05-07-1430
    Proceed? (yes / edit / cancel)
    ```
+
    On `edit`, accept a refined filter and re-plan from step 5. On `cancel`, exit without touching anything.
 
 8. **Write the initial checkpoint** (skip if `--dry-run`):
+
    ```json
    {
      "run_id": "<id>",
@@ -86,6 +93,7 @@ The skill runs in three phases. Phase 0 confirms scope. Phase 1 loops per todo. 
      "filter_flags": ["--skip", "053"]
    }
    ```
+
    Path: `todos/.completing-todos-run-<run_id>.json`. Use Write.
 
 Proceed to Phase 1.
@@ -100,16 +108,20 @@ This step is atomic from the user's perspective: any failure leaves the file in 
 
 1. Edit the file's frontmatter: `status: pending` → `status: in_progress`.
 2. Rename the file with `git mv`:
+
    ```bash
    git mv todos/050-pending-p1-flutter-fresh-checkout-build.md \
           todos/050-in_progress-p1-flutter-fresh-checkout-build.md
    ```
+
 3. Append a Work Log entry to the renamed file:
+
    ```markdown
    ### YYYY-MM-DD - Started by completing-todos skill (run <run_id>)
 
    - Picked up by automated workflow.
    ```
+
 4. If `--dry-run`: print what each of the above would do; do not execute.
 
 #### Step 2 — Implement or verify
@@ -135,7 +147,8 @@ Per [verification-before-completion](https://github.com/anthropic-experimental/c
    - If the output proves the criterion holds, flip `- [ ]` to `- [x]` and quote the relevant lines in the Work Log.
    - If the output does NOT prove the criterion: do not flip the box. Continue to the failure handling below.
 2. **Failure handling:** if any criterion cannot be flipped, pause and ask:
-   ```
+
+   ```text
    Acceptance criterion failed for todo NNN:
      <criterion text>
    Last command: <command>
@@ -143,6 +156,7 @@ Per [verification-before-completion](https://github.com/anthropic-experimental/c
      <relevant lines>
    Choose: (retry / skip-todo / abort-run)
    ```
+
    - `retry` — re-run after the user fixes the underlying issue.
    - `skip-todo` — do NOT mark complete. Add this id to `skipped` in the checkpoint, append a Work Log entry explaining why, leave the file in `in_progress` state with its filename also `in_progress`. Continue to the next todo.
    - `abort-run` — stop the loop, jump to Phase 2.
@@ -151,28 +165,35 @@ Per [verification-before-completion](https://github.com/anthropic-experimental/c
 #### Step 4 — Code review
 
 1. Compute the changed file list:
+
    ```bash
    git diff --name-only HEAD
    ```
+
 2. Dispatch the `code-review-orchestrator` agent via the Task tool with this prompt:
-   ```
+
+   ```text
    Review the following changes for todo NNN: <todo title>.
    Changed files:
      - <path 1>
      - <path 2>
    Return findings in your standard JSON shape.
    ```
+
 3. **Severity policy:**
    - `critical` or `high` — block. Print the findings and ask:
-     ```
+
+     ```text
      Code review surfaced N blocking findings for todo NNN:
        [critical] <file>:<line> — <description>
        [high]     <file>:<line> — <description>
      Choose: (repair / accept-and-continue / abort-run)
      ```
+
    - `medium` or below — list in the Work Log under a `Known issues` subsection; do not block.
 4. **On `repair`:** re-dispatch the *same domain reviewer that surfaced each blocking finding* via the Task tool, one invocation per file, with this prompt:
-   ```
+
+   ```text
    Repair the following findings in this file:
    File: <path>
    Findings:
@@ -180,6 +201,7 @@ Per [verification-before-completion](https://github.com/anthropic-experimental/c
      - line <M>: <description>
    Return JSON: {"file": "...", "edits": [{"old_string": "...", "new_string": "..."}], "unrepaired": [...]}
    ```
+
    Apply each returned `edit` via the Edit tool. Re-run Step 3 (verification gate) on the repaired files. After repair completes, **exit the loop** so the user can review the diff before further todos run. Append a Work Log entry naming each finding repaired and any left in `unrepaired`.
 5. **On `accept-and-continue`:** record each unaddressed blocking finding in the Work Log under `Known issues — accepted at completion`. Do not silently drop them.
 6. **On `abort-run`:** stop the loop, jump to Phase 2.
@@ -189,19 +211,36 @@ Per [verification-before-completion](https://github.com/anthropic-experimental/c
 
 1. Edit the file's frontmatter: `status: in_progress` → `status: completed`.
 2. Append a Work Log entry:
+
    ```markdown
    ### YYYY-MM-DD - Completed by completing-todos skill (run <run_id>)
 
    - Verification: <one-line summary, e.g., "all 5 acceptance criteria passed">.
    - Review: <N findings total, M blocking — addressed via repair / accepted / none>.
    ```
+
 3. Rename and move with `git mv`:
+
    ```bash
    git mv todos/050-in_progress-p1-flutter-fresh-checkout-build.md \
           todos/archive/050-completed-p1-flutter-fresh-checkout-build.md
    ```
-4. Update the checkpoint: append the issue_id to `completed[]`, write the file back.
-5. If `--dry-run`: print the planned frontmatter edit, Work Log entry, and `git mv` command; do not execute any of them.
+
+4. **Check off the source review finding** (if `source_review` and `source_finding` are in the todo's frontmatter):
+   - Read the file at `source_review`.
+   - In the `## Finding Status` section, find the line matching `- [ ] #<source_finding>`.
+   - Replace it with `- [x] #<source_finding> (completed YYYY-MM-DD)` using Edit.
+   - Count remaining `- [ ]` lines in the `## Finding Status` section.
+   - If **zero remain**, rename the review doc:
+
+     ```bash
+     git mv <source_review_path> <source_review_path_without_.md>-COMPLETED.md
+     ```
+
+     Append to the Work Log: "Source review doc `<path>` renamed to COMPLETED — all findings resolved."
+   - If `--dry-run`: print the planned Edit and optional `git mv`; do not execute.
+5. Update the checkpoint: append the issue_id to `completed[]`, write the file back.
+6. If `--dry-run`: print the planned frontmatter edit, Work Log entry, and `git mv` command; do not execute any of them.
 
 Proceed to the next todo in the plan, or to Phase 2 if this was the last.
 
@@ -210,7 +249,8 @@ Proceed to the next todo in the plan, or to Phase 2 if this was the last.
 After the per-todo loop ends (cleanly, by user `abort-run`, or by an unrecoverable error):
 
 1. **Print the run summary:**
-   ```
+
+   ```text
    Run <run_id> finished.
      Completed: 050, 052, 056
      Skipped:   054 (verification failed: flutter analyze)
@@ -220,6 +260,7 @@ After the per-todo loop ends (cleanly, by user `abort-run`, or by an unrecoverab
    ```
 
 2. **Delete the checkpoint** if every planned id reached a terminal state (in `completed` or `skipped`). Keep it otherwise so the next invocation can resume.
+
    ```bash
    rm -f todos/.completing-todos-run-<run_id>.json
    ```
@@ -231,6 +272,7 @@ After the per-todo loop ends (cleanly, by user `abort-run`, or by an unrecoverab
 A `run_id` (`YYYY-MM-DD-HHMM`) is assigned in Phase 0. The checkpoint file `todos/.completing-todos-run-<run_id>.json` carries plan + progress so a long run can resume.
 
 Checkpoint shape:
+
 ```json
 {
   "run_id": "2026-05-07-1430",
@@ -245,7 +287,7 @@ Checkpoint shape:
 
 When Phase 0 detects an existing checkpoint:
 
-```
+```text
 Found in-progress run <run_id> (2/4 complete).
 Plan: 050 ✓, 052 ✓, 056 (next), 054
 Resume? (yes / restart / discard)
@@ -264,9 +306,11 @@ These are non-negotiable. They override any in-the-moment judgment to "just push
 1. **Never auto-commit.** The skill never runs `git commit`. Phase 2 explicitly tells the user to commit.
 2. **Sequential by default.** A `--parallel N` flag is reserved for future work; do NOT implement it in v1. Todos can collide on shared files; serialization is the safe default.
 3. **One-time confirmation before the first file move.** After Phase 0 confirmation, before the first `git mv` of the run, prompt once:
-   ```
+
+   ```text
    About to rename + move N files via git mv across this run. Working directory: <pwd>. Continue? (yes / cancel)
    ```
+
    Skip this prompt if `--dry-run`.
 4. **Acceptance criteria are gospel.** A todo cannot be marked `completed` unless every `- [ ]` is flipped to `- [x]` with verification evidence quoted in the Work Log. There is no `--force-complete`.
 5. **No destructive recovery.** If `git mv` or any other step fails mid-todo, stop the loop and leave state as-is for the user to inspect. Do not roll back, do not delete, do not retry silently.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,6 +101,38 @@ The pattern library is the primary reference for implementation decisions. Read 
 
 Append-only log of bugs, incidents, and hard-won patterns. Read before starting a new feature area.
 
+## Review Doc Tracking
+
+When a finding from a review doc is converted to an individual todo file, link them so completion is visible.
+
+### Convention
+
+**1. Add `source_review` fields to the todo frontmatter:**
+
+```yaml
+source_review: "docs/reviews/2026-05-07-1641-full-review.md"
+source_finding: "42"
+```
+
+**2. Add/update a `## Finding Status` section in the review doc** (create if absent, append if present):
+
+```markdown
+## Finding Status
+- [ ] #42 short-description → todo 064
+- [ ] #43 another-description → todo 065
+```
+
+One line per converted finding, in finding-number order.
+
+**3. The `completing-todos` skill handles the rest automatically** on archive:
+
+- Checks off `- [ ] #42` → `- [x] #42 (completed YYYY-MM-DD)`
+- When **all** `## Finding Status` lines are `- [x]`, renames the review doc to `…-COMPLETED.md` via `git mv`
+
+### Why
+
+Previously, findings were converted to todos and completed without any trace in the source review doc, making it impossible to tell at a glance which findings were still open. This broke down in the May 6 review — 7 items looked open but were already done as todos 057–063.
+
 ## Code Review Agents
 
 Trigger a review: ask Claude to invoke `.claude/agents/code-review-orchestrator.md`. It reads `git diff`, dispatches only the agents relevant to changed files in parallel, deduplicates findings, and returns results by severity.

--- a/docs/todos/2026-05-06-review-COMPLETED.md
+++ b/docs/todos/2026-05-06-review-COMPLETED.md
@@ -3,11 +3,22 @@
 Source: Phase 3 self-improving agent review on commit `99bd7b3`
 Status: CRITICAL/HIGH/MEDIUM repaired in commit `4d8b9de`. LOW/INFO below.
 
+## Finding Status
+
+- [x] #14 disease-vote-dedup → todo 057 (completed 2026-05-07)
+- [x] #16 popular-posts-n1 → todo 058 (completed 2026-05-07)
+- [x] #17 disease-db-viewset-queryset → todo 059 (completed 2026-05-07)
+- [x] #18 users-views-import-order → todo 060 (completed 2026-05-07)
+- [x] #19 ics-safe-lambda-scope → todo 061 (completed 2026-05-07)
+- [x] #20 blog-middleware-patch-path → todo 062 (completed 2026-05-07)
+- [x] #21 celery-task-idempotency → todo 063 (completed 2026-05-07)
+
 ---
 
 ## LOW Priority
 
 ### Finding 14 — Disease vote deduplication (PlantDiseaseResultViewSet)
+
 **File**: `backend/apps/plant_identification/views.py:873`
 **Issue**: `PlantDiseaseResultViewSet.vote` increments upvotes/downvotes atomically with F() but has a TODO for preventing duplicate votes. Unlike `PlantIdentificationResultViewSet.vote` which uses a `PlantIdentificationVote` model, the disease vote endpoint has no per-user tracking.
 **Impact**: Users can vote multiple times on disease diagnosis results.
@@ -19,39 +30,47 @@ Status: CRITICAL/HIGH/MEDIUM repaired in commit `4d8b9de`. LOW/INFO below.
 ## INFO / Technical Debt
 
 ### Finding 16 — Popular posts endpoint N+1 still unresolved
+
 **File**: `backend/apps/blog/tests/test_analytics.py`
 **Issue**: Popular posts endpoint executes ~26 queries for 5 posts (4 queries/post N+1 pattern: author, categories, tags, comment count). The `assertLessEqual(30)` assertion in the test is a temporary ceiling.
 **Fix needed**: Add `select_related('author')` + `prefetch_related('categories', 'tags')` to the popular posts queryset, and convert comment count to an annotation. Should bring to ≤6 queries total.
 **Related**: Issue #117 (performance test assertion patterns)
 
 ### Finding 17 — PlantDiseaseDatabaseViewSet queryset not memoized
+
 **File**: `backend/apps/plant_identification/views.py:1014`
 **Issue**: The class-level `queryset = PlantDiseaseDatabase.objects.filter(...)` is evaluated at class definition time (Django behaviour), but filters in `get_queryset()` recreate the queryset on every request. Minor — not a bug, just a style inconsistency.
 **Fix needed**: Either move everything to `get_queryset()` (preferred) or document why the class-level queryset is intentionally there.
 
 ### Finding 18 — users/views.py import order
+
 **File**: `backend/apps/users/views.py:26`
 **Issue**: `from .constants import RATE_LIMIT_DEMO_DATA_CREATE, RATE_LIMIT_ONBOARDING_EVENT` was added after `from apps.plant_identification.constants import RATE_LIMITS`. PEP 8 local imports should be grouped. Low impact.
 **Fix needed**: Reorder so `from .constants import ...` precedes the `from apps.plant_identification.constants import ...` line.
 
 ### Finding 19 — `_ics_safe` lambda defined inside loop scope
+
 **File**: `backend/apps/users/views.py` (export_care_reminders_calendar)
 **Issue**: The `_ics_safe` lambda is defined before the `for reminder in reminders` loop, which is correct, but it would be cleaner as a module-level helper or at least named clearly.
 **Fix needed**: Promote to a module-level `_sanitize_ics_field()` function for testability. Low priority.
 
 ### Finding 20 — blog/middleware.py transaction.on_commit import path
+
 **File**: `backend/apps/blog/tests/test_analytics.py`
 **Issue**: The test now patches `apps.blog.middleware.transaction.on_commit` — this requires the middleware to import `transaction` from `django.db` at module scope (i.e., `from django.db import transaction`). Verify this is how the middleware imports it; if it uses `import django.db.transaction` the patch path would differ.
 **Fix needed**: Confirm middleware import style matches the patch path. If not, update the patch string.
 
 ### Finding 21 — Celery tasks lack idempotency guards
+
 **File**: `backend/apps/plant_identification/tasks.py`
 **Issue**: The `run_identification` Celery task (called via `run_identification.delay(str(request_obj.request_id))`) does not have an explicit idempotency guard. If Celery retries the task (e.g., on a transient failure), the identification could run twice.
 **Fix needed**: Add a guard at the start of the task:
+
 ```python
 request_obj = PlantIdentificationRequest.objects.get(request_id=task_request_id)
 if request_obj.status != 'pending':
     logger.info("[CELERY] Skipping duplicate task for %s (status=%s)", task_request_id, request_obj.status)
     return
 ```
+
 See `backend/docs/patterns/domain/celery.md` for idempotency pattern.


### PR DESCRIPTION
## Summary

- **CLAUDE.md**: New "Review Doc Tracking" section establishes the convention: when a finding is converted to a todo, add `source_review`/`source_finding` frontmatter to the todo and a `## Finding Status` checklist entry to the review doc; rename the review doc to `…-COMPLETED.md` when all items are checked.
- **completing-todos skill**: Step 5 (Archive) now automatically checks off the source finding and renames the review doc when the last finding resolves. Also fixes pre-existing MD040 markdownlint violations (bare code fences lacked language tags).
- **docs/todos/2026-05-06-review.md**: Retroactively added `## Finding Status` with all 7 findings marked done (todos 057–063 completed them in #255); file renamed to `…-COMPLETED.md`.

**Why:** After completing todos 057–063, the source review doc still showed all 7 findings as open text — no checkboxes, no link back to the resolved todos. This caused confusion in the next session, where the items appeared to still need work.

## Test plan

- [x] Verify `docs/todos/2026-05-06-review-COMPLETED.md` exists and all 7 `## Finding Status` lines are `- [x]`
- [x] Verify CLAUDE.md "Review Doc Tracking" section is present with correct convention
- [x] Verify completing-todos SKILL.md Step 5 contains the source_review check-off logic
- [x] Confirm markdownlint passes on SKILL.md (all fenced code blocks have language tags)

🤖 Generated with [Claude Code](https://claude.com/claude-code)