### PR TITLE
chore: codify 4 new patterns from PR #259 review session

### DIFF
--- a/.claude/agents/django-drf-reviewer.md
+++ b/.claude/agents/django-drf-reviewer.md
@@ -16,6 +16,8 @@ color: blue
 tools: Read, Glob, Grep, Bash
 ---
 
+# Django/DRF Reviewer
+
 You are the Django/DRF domain reviewer for the plant_id_community project. Review only the files you are given. Do not read the full repository.
 
 ## Scope
@@ -29,6 +31,7 @@ You do NOT review: Wagtail page models or blog app files (those go to wagtail-re
 Work through each item for every changed file. Find the exact line number for each issue (Grep can help). Emit findings in the structured format defined in "## Output Format (Review Mode)" below — do not write prose.
 
 **Permissions & Security**
+
 - [ ] ViewSet.get_permissions() must call `super().get_permissions()` for any `@action` decorator — never override action-specific permission_classes silently (Issue #131)
 - [ ] No f-strings in raw SQL queries — use `psycopg2.sql.Identifier` + whitelist validation
 - [ ] Search queries using `icontains` must call `escape_search_query()` to escape `%` and `_` wildcards
@@ -37,6 +40,7 @@ Work through each item for every changed file. Find the exact line number for ea
 - [ ] Authentication: DEBUG=True allows anonymous access; DEBUG=False requires authentication (environment-aware)
 
 **Code Quality**
+
 - [ ] All service methods must have type hints on parameters and return types
 - [ ] No magic numbers — all configuration values imported from app-specific `constants.py`
 - [ ] Logging must use bracketed prefixes: `[CACHE]`, `[PERF]`, `[ERROR]`, `[CIRCUIT]`, `[SERVICE_NAME]`
@@ -44,11 +48,13 @@ Work through each item for every changed file. Find the exact line number for ea
 - [ ] New apps must register models in `auditlog.py` for GDPR compliance
 
 **Migrations**
+
 - [ ] New migrations must not contain f-strings in raw SQL
 - [ ] PostgreSQL-specific operations (GIN indexes, trigrams) must check `connection.vendor == 'postgresql'` and skip gracefully on SQLite
 - [ ] Migrations that add NOT NULL columns to large tables must include a backfill default
 
 **Models & Queries**
+
 - [ ] ForeignKey access in serializers or views must use `select_related()` — no lazy loading
 - [ ] Reverse FK / M2M access must use `prefetch_related()`, not Python-side iteration
 - [ ] `SerializerMethodField` that queries the DB is a BLOCKER N+1 — use conditional annotations instead
@@ -78,6 +84,7 @@ Return ONLY this JSON structure (no surrounding prose, no markdown fences in the
 Each `"line"` value must be the actual 1-based line number in the source file — never copy the example value.
 
 Severity rules:
+
 - `critical`: security hole, data loss risk, or production-breaking bug
 - `high`: real bug or pattern violation that will cause issues
 - `medium`: maintainability or correctness concern
@@ -116,9 +123,14 @@ When invoked with a list of findings to repair in a single file:
 ```
 
 Rules:
+
 - Each `old_string` must be unique enough in the file that an exact match replaces only the intended span.
 - Do not apply edits yourself — return them; the orchestrator will apply via the Edit tool.
 - If a finding cannot be repaired safely (ambiguous, requires architectural change), include it in an extra field `"unrepaired": [{"line": N, "reason": "..."}]`.
 - The `edits` array may be empty if all findings land in `unrepaired`.
+
+**Serializer Code Quality**
+
+- [ ] Serializer helper methods defined identically in two or more serializer classes must be extracted into a shared mixin or module-level function before merging — duplicate bodies diverge silently when one copy is updated (e.g. `_normalize_rich_content` in both `CreateTopicSerializer` and `CreatePostSerializer`)
 
 The single-finding case is just `edits` of length 1.

--- a/.claude/agents/performance-reviewer.md
+++ b/.claude/agents/performance-reviewer.md
@@ -16,6 +16,8 @@ color: yellow
 tools: Read, Glob, Grep, Bash
 ---
 
+# Performance Reviewer
+
 You are the performance domain reviewer for the plant_id_community project.
 
 ## Scope
@@ -25,23 +27,29 @@ Review only the files passed to you. Do not read the full repo.
 ## Review Mode — Checklist
 
 **N+1 Queries (BLOCKER)**
+
 - [ ] `SerializerMethodField` methods that access `obj.related_set.all()` or `obj.related_set.filter()` are BLOCKERS — these execute a query per object in list views
 - [ ] Fix: add conditional annotation in `ViewSet.get_queryset()` and read from annotation in serializer
 - [ ] `prefetch_related()` prevents object loading but NOT Python-side counting — counting must be done via `Count()` annotation in the database
 - [ ] Foreign key access (`obj.author`, `obj.category`) without `select_related` is an N+1 — add `select_related`
+- [ ] Reverse OneToOne accessor (e.g. `obj.rich_content`) accessed more than once across separate `SerializerMethodField` methods is an N+1 per extra access — add the relation to `select_related()` in the ViewSet queryset and consolidate all field reads into a single `to_representation()` local variable
+- [ ] Instance-level attribute cache set on a model instance inside a serializer (e.g. `obj._foo_cache = ...`) risks stale data when the same instance is mutated and re-serialized in the same request (e.g. after a related `.create()`); cache on the serializer instance keyed by pk, or eliminate caching entirely with `select_related()`
 
 **Query Optimisation**
+
 - [ ] List views must use `select_related()` for all accessed foreign keys
 - [ ] List views must use `prefetch_related()` for all accessed reverse FKs and M2M
 - [ ] Aggregations must use `Count()`, `Sum()`, `Avg()` with `annotate()` — not Python loops
 - [ ] Large querysets must use `.iterator()` or `.only()` / `.defer()` to reduce memory
 
 **Performance Test Assertions (IMPORTANT)**
+
 - [ ] Performance tests must use `assertEqual(query_count, N)` not `assertLess(query_count, 10)` — strict equality catches regressions immediately
 - [ ] Test docstrings must explain WHY the expected query count is N
 - [ ] Include clear error messages in assertions that cite the issue number
 
 **Redis Caching**
+
 - [ ] Frequently-accessed, rarely-changed data must have a Redis cache layer
 - [ ] Cache hit rate targets: Plant ID 40%, AI generation 80-95%
 - [ ] Cache warming must be triggered on deployment for cold-start prevention
@@ -70,6 +78,7 @@ Return ONLY this JSON structure (no surrounding prose, no markdown fences in the
 Each `"line"` value must be the actual 1-based line number in the source file — never copy the example value.
 
 Severity rules:
+
 - `critical`: security hole, data loss risk, or production-breaking bug
 - `high`: real bug or pattern violation that will cause issues
 - `medium`: maintainability or correctness concern
@@ -104,6 +113,7 @@ When invoked with a list of findings to repair in a single file:
 ```
 
 Rules:
+
 - Each `old_string` must be unique enough in the file that an exact match replaces only the intended span.
 - Do not apply edits yourself — return them; the orchestrator will apply via the Edit tool.
 - If a finding cannot be repaired safely (ambiguous, requires architectural change), include it in an extra field `"unrepaired": [{"line": N, "reason": "..."}]`.

--- a/.claude/agents/test-quality-reviewer.md
+++ b/.claude/agents/test-quality-reviewer.md
@@ -16,6 +16,8 @@ color: green
 tools: Read, Glob, Grep, Bash
 ---
 
+# Test Quality Reviewer
+
 You are the test quality domain reviewer for the plant_id_community project.
 
 ## Scope
@@ -31,31 +33,37 @@ E2E: Playwright, 107 tests
 ## Review Mode — Checklist
 
 **Database Usage (BLOCKER)**
+
 - [ ] Tests MUST hit the real PostgreSQL database — NO mocking of Django ORM, QuerySets, or database connections
 - [ ] Reason: mocked DB tests passed while prod migrations failed (prior incident — do not repeat)
 - [ ] `--keepdb` flag used in test commands to preserve test DB across runs
 
 **External API Mocking**
+
 - [ ] External APIs (Plant.id, PlantNet, Firebase, OpenAI) MUST be mocked in tests
 - [ ] Mock responses must reflect current API response shape (v3 for Plant.id as of Nov 2025)
 - [ ] Plant.id tests expect 2 API calls: identification + `/health_assessment`
 
 **Assertion Quality (IMPORTANT)**
+
 - [ ] Performance tests: use `assertEqual(query_count, N)` not `assertLess(query_count, 10)` — strict equality catches regressions
 - [ ] Test docstrings must explain WHY the expected count is N
 - [ ] Assertions must have descriptive failure messages: `self.assertEqual(count, 1, "Expected 1 query but got N+1 — check select_related in Issue #X")`
 
 **Test Naming & Structure**
+
 - [ ] Test methods named: `test_{feature}_{condition}_{expected_result}`
 - [ ] One assertion concept per test — don't bundle unrelated assertions
 - [ ] Setup in `setUp()` or fixtures — no test-to-test dependency
 
 **Coverage**
+
 - [ ] New service methods require at least one happy-path and one error-path test
 - [ ] New API endpoints require: authenticated success, unauthenticated 401, invalid input 400
 - [ ] New permission classes require: allowed and denied test cases
 
 **Frontend Tests**
+
 - [ ] React component tests must not test implementation details (internal state) — test behaviour
 - [ ] No `act()` warnings left unresolved — they indicate async state update issues
 - [ ] E2E tests for any new user-facing flow added to `web/E2E_TESTING_GUIDE.md`
@@ -84,6 +92,7 @@ Return ONLY this JSON structure (no surrounding prose, no markdown fences in the
 Each `"line"` value must be the actual 1-based line number in the source file — never copy the example value.
 
 Severity rules:
+
 - `critical`: security hole, data loss risk, or production-breaking bug
 - `high`: real bug or pattern violation that will cause issues
 - `medium`: maintainability or correctness concern
@@ -118,9 +127,14 @@ When invoked with a list of findings to repair in a single file:
 ```
 
 Rules:
+
 - Each `old_string` must be unique enough in the file that an exact match replaces only the intended span.
 - Do not apply edits yourself — return them; the orchestrator will apply via the Edit tool.
 - If a finding cannot be repaired safely (ambiguous, requires architectural change), include it in an extra field `"unrepaired": [{"line": N, "reason": "..."}]`.
 - The `edits` array may be empty if all findings land in `unrepaired`.
+
+**Third-Party App Loaders**
+
+- [ ] Test modules that import from django-machina (or any app with a dynamic class loader) require the full app subtree in `INSTALLED_APPS` — Machina's `machina.core.loading.get_class()` raises `AppNotFoundError` at import time if any `machina.apps.*` entry is missing, causing all tests in the module to fail before `setUp` runs
 
 The single-finding case is just `edits` of length 1.

--- a/.gitignore
+++ b/.gitignore
@@ -209,3 +209,6 @@ docs/reviews/.*-partial.json
 
 # Completing-todos run checkpoints (per-run, transient)
 todos/.completing-todos-run-*.json
+
+# Local coworking notes (not tracked)
+docs/cowork/

--- a/backend/docs/patterns/performance/query-optimization.md
+++ b/backend/docs/patterns/performance/query-optimization.md
@@ -2,6 +2,7 @@
 
 **Last Updated**: November 13, 2025
 **Consolidated From**:
+
 - `docs/development/PERFORMANCE_PATTERNS_CODIFIED.md` (6 patterns)
 - `docs/performance/n-plus-one-elimination.md` (4 implementations)
 - Week 4 Performance Optimization (2025-10-23)
@@ -28,6 +29,7 @@
 **Problem**: Accessing foreign key relationships in loops triggers one query per iteration (N+1 pattern). For 10 items, this creates 11 queries (1 main + 10 for each foreign key).
 
 **Performance Impact**:
+
 - **Before**: 10-12 queries, 200ms
 - **After**: 1 query with JOIN, 30ms (85% faster)
 - **Reduction**: 91% fewer queries
@@ -37,6 +39,7 @@
 ### Pattern: Single-Level Foreign Key
 
 **Anti-Pattern** ❌:
+
 ```python
 # BAD - Triggers N+1 queries
 recent_topics = Topic.objects.filter(
@@ -52,6 +55,7 @@ for topic in recent_topics:
 ```
 
 **Correct Pattern** ✅:
+
 ```python
 # GOOD - Single query with JOIN
 recent_topics = Topic.objects.filter(
@@ -67,6 +71,7 @@ for topic in recent_topics:
 ```
 
 **SQL Generated**:
+
 ```sql
 -- With select_related()
 SELECT
@@ -88,6 +93,7 @@ LIMIT 10;
 **Problem**: Nested foreign keys (e.g., `post.topic.forum.name`) require multiple select_related() calls.
 
 **Anti-Pattern** ❌:
+
 ```python
 # BAD - Queries for each level
 recent_posts = Post.objects.filter(
@@ -105,6 +111,7 @@ for post in recent_posts:
 ```
 
 **Correct Pattern** ✅:
+
 ```python
 # GOOD - Chain select_related for nested relationships
 recent_posts = Post.objects.filter(
@@ -130,6 +137,7 @@ for post in recent_posts:
 **Problem**: ManyToMany relationships cannot use select_related() (which only works for ForeignKey and OneToOne). Must use prefetch_related() instead.
 
 **Anti-Pattern** ❌:
+
 ```python
 # BAD - N+1 queries for tags
 blog_posts = BlogPostPage.objects.filter(
@@ -144,6 +152,7 @@ for post in blog_posts:
 ```
 
 **Correct Pattern** ✅:
+
 ```python
 # GOOD - Prefetch ManyToMany relationships
 blog_posts = BlogPostPage.objects.filter(
@@ -158,6 +167,7 @@ for post in blog_posts:
 ```
 
 **SQL Generated**:
+
 ```sql
 -- Query 1: Get blog posts
 SELECT * FROM blog_blogpostpage WHERE live = TRUE LIMIT 10;
@@ -175,6 +185,7 @@ WHERE blog_post_tags.post_id IN (1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
 **Use Case**: When you have both ForeignKey and ManyToMany relationships.
 
 **Implementation**:
+
 ```python
 # Combine both for optimal performance
 blog_posts = BlogPostPage.objects.filter(
@@ -206,6 +217,7 @@ for post in blog_posts:
 **Use Case**: When you only need a subset of related objects (e.g., only published comments, only active users).
 
 **Implementation**:
+
 ```python
 from django.db.models import Prefetch
 
@@ -232,6 +244,7 @@ for post in blog_posts:
 **Problem**: Multiple separate `.count()` queries on the same model waste database round-trips. Each `.count()` is a separate query.
 
 **Performance Impact**:
+
 - **Before**: 15-20 queries, 500-800ms
 - **After**: 3-4 queries, 10-20ms (97% faster)
 - **Reduction**: 75-80% fewer queries
@@ -241,6 +254,7 @@ for post in blog_posts:
 ### Pattern: Dashboard Stats Aggregation
 
 **Anti-Pattern** ❌:
+
 ```python
 # BAD - 4 separate COUNT queries
 plant_stats = {
@@ -267,6 +281,7 @@ plant_stats = {
 ```
 
 **Correct Pattern** ✅:
+
 ```python
 from django.db.models import Count, Q
 
@@ -291,6 +306,7 @@ plant_stats = {
 ```
 
 **SQL Generated**:
+
 ```sql
 -- Single query with conditional counting
 SELECT
@@ -306,6 +322,7 @@ WHERE user_id = 123;
 ### Pattern: Forum Stats Aggregation
 
 **Implementation** (from dashboard_stats endpoint):
+
 ```python
 from django.db.models import Count, Q
 
@@ -343,11 +360,13 @@ forum_stats = {
 ### Pattern: Conditional Aggregation with Q Objects
 
 **Use Cases**:
+
 - Date-based filtering (this week, this month, this year)
 - Status-based filtering (published, draft, archived)
 - User-based filtering (own posts, favorited posts)
 
 **Implementation**:
+
 ```python
 from django.db.models import Count, Q, Sum, Avg
 from datetime import timedelta
@@ -385,11 +404,13 @@ stats = Model.objects.filter(user=user).aggregate(
 **Problem**: Fetching the same object multiple times in a single request. Common in token refresh, user profile updates, and object detail views.
 
 **Performance Impact**:
+
 - **Before**: 3-4 queries, 150ms
 - **After**: 1 query, 10ms (93% faster)
 - **Reduction**: 75% fewer queries
 
 **Anti-Pattern** ❌:
+
 ```python
 # BAD - Multiple user queries in token refresh
 used_refresh = RefreshToken(refresh_token)  # Query 1: Validates token
@@ -407,6 +428,7 @@ new_refresh = RefreshToken.for_user(user)  # Query 4: Might query user again
 ```
 
 **Correct Pattern** ✅:
+
 ```python
 # GOOD - Fetch user once with only() for selective loading
 used_refresh = RefreshToken(refresh_token)
@@ -438,16 +460,19 @@ response = set_jwt_cookies(response, user)  # Uses cached user object
 ### Pattern: Selective Field Loading with only()
 
 **Use Cases**:
+
 - Token refresh (only need id, username, email)
 - List views (only need id, title, created_at)
 - Count operations (only need id)
 
 **Benefits**:
+
 - Reduces memory usage (fewer fields loaded)
 - Faster query execution (less data transferred)
 - Clearer intent (shows which fields are actually used)
 
 **Implementation**:
+
 ```python
 # Only load fields you actually use
 users = User.objects.only('id', 'username', 'email').filter(is_active=True)
@@ -474,6 +499,7 @@ description = topic.description  # This triggers a query! (not in only())
 **Problem**: Without indexes, database performs sequential scans (O(n) complexity). With 10,000+ users, lookups become 300-800ms.
 
 **Performance Impact**:
+
 - **Before**: Sequential scan, 300-800ms
 - **After**: B-tree index scan, 3-8ms (100x faster)
 - **Improvement**: O(n) → O(log n) complexity
@@ -483,12 +509,14 @@ description = topic.description  # This triggers a query! (not in only())
 ### Pattern: Email Field Indexing
 
 **Why Index Email?**
+
 - Used in login authentication
 - Used in password reset lookups
 - Used in notification delivery
 - High cardinality (unique values)
 
 **Anti-Pattern** ❌:
+
 ```python
 # BAD - No index on email
 class User(AbstractUser):
@@ -504,6 +532,7 @@ class User(AbstractUser):
 ```
 
 **Correct Pattern** ✅:
+
 ```python
 # GOOD - B-tree index on email
 class User(AbstractUser):
@@ -520,6 +549,7 @@ class User(AbstractUser):
 ```
 
 **Migration**:
+
 ```python
 # migrations/0007_add_performance_indexes.py
 from django.db import migrations, models
@@ -548,12 +578,14 @@ class Migration(migrations.Migration):
 ### Pattern: Status/State Field Indexing
 
 **When to Index**:
+
 - Frequently used in WHERE clauses
 - Used in permission checks
 - Moderate cardinality (4-20 distinct values)
 - Examples: `status`, `trust_level`, `approval_state`
 
 **Implementation**:
+
 ```python
 # GOOD - Index on trust_level for permission checks
 class User(AbstractUser):
@@ -580,6 +612,7 @@ class User(AbstractUser):
 ### Pattern: When NOT to Add Indexes
 
 **Low Cardinality Fields**:
+
 ```python
 # BAD - Don't index boolean fields (only 2 values)
 is_active = models.BooleanField(default=True, db_index=True)  # ❌ Wasteful
@@ -589,12 +622,14 @@ is_active = models.BooleanField(default=True, db_index=True)  # ❌ Wasteful
 ```
 
 **Rarely Queried Fields**:
+
 ```python
 # BAD - Don't index if never used in WHERE/ORDER BY
 notes = models.TextField(db_index=True)  # ❌ Never filtered on
 ```
 
 **Write-Heavy Tables**:
+
 ```python
 # CAUTION - Indexes slow down INSERT/UPDATE
 # Each index adds ~5-10% overhead on writes
@@ -608,6 +643,7 @@ notes = models.TextField(db_index=True)  # ❌ Never filtered on
 **Use Case**: Queries that filter on multiple columns together.
 
 **Implementation**:
+
 ```python
 class BlogPost(models.Model):
     author = models.ForeignKey(User, on_delete=models.CASCADE)
@@ -635,6 +671,7 @@ class BlogPost(models.Model):
 ### Pattern: Index on Foreign Keys
 
 **Automatic Indexing**:
+
 ```python
 # Foreign keys are automatically indexed by Django
 author = models.ForeignKey(User, on_delete=models.CASCADE)
@@ -652,6 +689,7 @@ author = models.ForeignKey(User, on_delete=models.CASCADE)
 **Problem**: Read-modify-write operations on shared cache keys create race conditions. Multiple threads can read, modify, and write simultaneously, causing lost updates.
 
 **Performance Impact**:
+
 - **Atomicity**: Ensured through Redis operations
 - **Retry Success**: 99.9% on first attempt
 - **Overhead**: <5ms for retry logic
@@ -662,6 +700,7 @@ author = models.ForeignKey(User, on_delete=models.CASCADE)
 ### Pattern: SecurityMonitor Account Lockout (Thread-Safe)
 
 **Anti-Pattern** ❌:
+
 ```python
 # BAD - Race condition in account lockout tracking
 key = f"lockout_attempts:{username}"
@@ -689,6 +728,7 @@ cache.set(key, attempts, timeout)  # Thread B also writes - LAST WRITE WINS!
 ```
 
 **Correct Pattern** ✅:
+
 ```python
 # GOOD - Optimistic locking with retry
 max_retries = 3
@@ -754,6 +794,7 @@ return False, 0
 ### Pattern: Redis Atomic Operations
 
 **cache.add() vs cache.set()**:
+
 ```python
 # cache.add(key, value, timeout)
 # - Returns True if key was created
@@ -768,6 +809,7 @@ return False, 0
 ```
 
 **Implementation Example**:
+
 ```python
 # First writer wins with cache.add()
 success = cache.add('lockout:user123', initial_data, timeout=300)
@@ -784,6 +826,7 @@ if not success:
 ### Pattern: Retry Logic for Conflicts
 
 **Implementation**:
+
 ```python
 def update_cached_counter(key, increment=1, max_retries=3):
     """Thread-safe counter update with retry logic."""
@@ -825,6 +868,7 @@ def update_cached_counter(key, increment=1, max_retries=3):
 **Problem**: Lenient assertions (assertLess) allow query count to increase without detection. Performance regressions slip through tests.
 
 **Performance Impact**:
+
 - **Before**: Regressions go undetected (5→19 queries would pass with assertLess(queries, 20))
 - **After**: ANY query increase triggers failure (5→6 would fail)
 - **Confidence**: 100% regression detection
@@ -836,6 +880,7 @@ def update_cached_counter(key, increment=1, max_retries=3):
 ### Pattern: Use assertEqual for Query Counts
 
 **Anti-Pattern** ❌:
+
 ```python
 # BAD - Lenient assertion allows regressions
 from django.test import TestCase
@@ -858,6 +903,7 @@ class PerformanceTestCase(TestCase):
 ```
 
 **Correct Pattern** ✅:
+
 ```python
 # GOOD - Strict assertion prevents ALL regressions
 class PerformanceTestCase(TestCase):
@@ -889,12 +935,14 @@ class PerformanceTestCase(TestCase):
 ### Pattern: Document Query Breakdown in Comments
 
 **Requirements**:
+
 1. **Comment the expected query breakdown** - Document WHY that count is expected
 2. **Reference pattern docs** - Include link in assertion message
 3. **Explain without optimization** - Show what query count would be without optimization
 4. **Issue reference** - Link to performance work or issue number
 
 **Example Documentation**:
+
 ```python
 def test_blog_list_query_count(self):
     """
@@ -930,11 +978,13 @@ def test_blog_list_query_count(self):
 ### Pattern: When to Use Lenient Assertions (Rare)
 
 **Only use assertLess when**:
+
 1. **Dynamic query counts** - Number of queries genuinely varies (e.g., depends on user permissions)
 2. **External dependencies** - Third-party libraries with unpredictable query patterns
 3. **Smoke tests** - Initial rough checks before strict optimization
 
 **Even then**, prefer strict assertions with conditional logic:
+
 ```python
 # Better: Strict assertions for known cases
 if user.is_staff:
@@ -954,6 +1004,7 @@ self.assertEqual(
 ### Pattern: Migration from Lenient to Strict
 
 **Step 1**: Run test to capture current query count
+
 ```bash
 python manage.py test apps.blog.tests.test_performance --noinput -v 2
 
@@ -964,6 +1015,7 @@ print(f"[DEBUG] Query count: {num_queries}")
 ```
 
 **Step 2**: Replace lenient assertion with strict
+
 ```python
 # Before
 self.assertLess(num_queries, 20, f"Expected <20 queries, got {num_queries}")
@@ -978,6 +1030,7 @@ self.assertEqual(
 ```
 
 **Step 3**: Document query breakdown in comment
+
 ```python
 # STRICT: Expect exactly 18 queries (regression protection - Issue #117)
 # Query breakdown:
@@ -988,6 +1041,7 @@ self.assertEqual(
 ```
 
 **Step 4**: Run test to verify
+
 ```bash
 python manage.py test apps.blog.tests.test_performance --noinput
 # Should pass with exact count
@@ -998,6 +1052,7 @@ python manage.py test apps.blog.tests.test_performance --noinput
 ### Pattern: CaptureQueriesContext Usage
 
 **Implementation**:
+
 ```python
 from django.test import TestCase
 from django.db import connection
@@ -1033,6 +1088,7 @@ class PerformanceTestCase(TestCase):
 ### Pitfall 1: Forgetting select_related() in Loops
 
 **Problem**:
+
 ```python
 # ❌ N+1 queries - forgot select_related()
 topics = Topic.objects.filter(approved=True)
@@ -1042,6 +1098,7 @@ for topic in topics:
 ```
 
 **Solution**:
+
 ```python
 # ✅ Single query with JOIN
 topics = Topic.objects.filter(approved=True).select_related('forum')
@@ -1055,12 +1112,14 @@ for topic in topics:
 ### Pitfall 2: Using select_related() on ManyToMany
 
 **Problem**:
+
 ```python
 # ❌ ERROR - select_related doesn't work on ManyToMany
 posts = BlogPost.objects.select_related('tags')  # Will raise error!
 ```
 
 **Solution**:
+
 ```python
 # ✅ Use prefetch_related for ManyToMany
 posts = BlogPost.objects.prefetch_related('tags')
@@ -1071,6 +1130,7 @@ posts = BlogPost.objects.prefetch_related('tags')
 ### Pitfall 3: Multiple COUNT Queries
 
 **Problem**:
+
 ```python
 # ❌ 4 separate queries
 total = Model.objects.filter(user=user).count()
@@ -1080,6 +1140,7 @@ this_week = Model.objects.filter(user=user, created_at__gte=week_ago).count()
 ```
 
 **Solution**:
+
 ```python
 # ✅ Single aggregate query
 from django.db.models import Count, Q
@@ -1097,6 +1158,7 @@ stats = Model.objects.filter(user=user).aggregate(
 ### Pitfall 4: Accessing Fields Not in only()
 
 **Problem**:
+
 ```python
 # ❌ Triggers additional query
 user = User.objects.only('id', 'username').get(id=123)
@@ -1104,6 +1166,7 @@ email = user.email  # This triggers a query! (email not in only())
 ```
 
 **Solution**:
+
 ```python
 # ✅ Include all fields you'll access
 user = User.objects.only('id', 'username', 'email').get(id=123)
@@ -1115,6 +1178,7 @@ email = user.email  # No extra query
 ### Pitfall 5: Lenient Performance Test Assertions
 
 **Problem**:
+
 ```python
 # ❌ Allows performance regressions
 self.assertLess(query_count, 20)
@@ -1122,6 +1186,7 @@ self.assertLess(query_count, 20)
 ```
 
 **Solution**:
+
 ```python
 # ✅ Strict assertion catches ALL regressions
 self.assertEqual(query_count, 5)
@@ -1159,11 +1224,13 @@ self.assertEqual(query_count, 5)
 ### Scalability Projections
 
 **Current (1,000 users)**:
+
 - Dashboard: 10-20ms
 - Token refresh: 10ms
 - DB CPU: <10%
 
 **Projected (100,000 users)**:
+
 - Dashboard: 10-20ms (aggregation scales linearly)
 - Token refresh: 10ms (indexed lookups scale logarithmically)
 - DB CPU: <30% (with read replicas)
@@ -1178,8 +1245,111 @@ self.assertEqual(query_count, 5)
 
 ---
 
-**Last Reviewed**: November 13, 2025
-**Pattern Count**: 25 query optimization patterns
+**Last Reviewed**: 2026-05-08
+**Pattern Count**: 28 query optimization patterns
 **Status**: ✅ Production-validated
 **Performance Improvement**: 75-98% query reduction, 10-100x faster execution
 
+---
+
+## Pattern 26: Reverse OneToOne — Multiple Accesses in Separate SerializerMethodFields
+
+**Problem**: A reverse OneToOne accessor (e.g. `obj.rich_content` where `RichPost` has `OneToOneField(Post, related_name='rich_content')`) accessed in separate `SerializerMethodField` methods via independent `try/except` blocks fires one DB query per access when `select_related` is absent. Three such methods = 3× queries per serialized row.
+
+**Anti-pattern** ❌:
+
+```python
+class PostSerializer(serializers.ModelSerializer):
+    def get_content_format(self, obj):
+        try:
+            return obj.rich_content.content_format  # Query 1
+        except RichPost.DoesNotExist:
+            return 'plain'
+
+    def get_ai_assisted(self, obj):
+        try:
+            return obj.rich_content.ai_assisted  # Query 2
+        except RichPost.DoesNotExist:
+            return False
+```
+
+**Correct pattern** ✅ — consolidate into `to_representation()`:
+
+```python
+class PostViewSet(viewsets.ModelViewSet):
+    def get_queryset(self):
+        return Post.objects.select_related('rich_content')
+
+class PostSerializer(serializers.ModelSerializer):
+    def to_representation(self, instance):
+        rep = super().to_representation(instance)
+        try:
+            rc = instance.rich_content  # 0 extra queries (prefetched)
+            rep['content_format'] = rc.content_format
+            rep['ai_assisted'] = rc.ai_assisted
+        except RichPost.DoesNotExist:
+            rep['content_format'] = 'plain'
+            rep['ai_assisted'] = False
+        return rep
+```
+
+**Rule**: Any reverse OneToOne relation accessed in more than one `SerializerMethodField` must be moved to `select_related()` + a single access point. Never access the same reverse OneToOne more than once across separate methods.
+
+---
+
+## Pattern 27: Instance-Level Cache in Serializer Methods — Stale Data Risk
+
+**Problem**: Caching a related object directly on a model instance (`obj._cache = ...`) inside a serializer method avoids repeated DB hits but risks returning stale data when the same instance is mutated (e.g. `RichPost.objects.create()`) and re-serialized in the same request cycle.
+
+**Anti-pattern** ❌:
+
+```python
+def _get_rich_post(self, obj):
+    if not hasattr(obj, '_rich_post_cache'):
+        try:
+            obj._rich_post_cache = obj.rich_content
+        except RichPost.DoesNotExist:
+            obj._rich_post_cache = None
+    return obj._rich_post_cache  # Stale after create() in same request
+```
+
+**Correct pattern** ✅ — cache on the serializer, keyed by pk:
+
+```python
+def __init__(self, *args, **kwargs):
+    super().__init__(*args, **kwargs)
+    self._rc_cache: dict = {}
+
+def _get_rich_post(self, obj):
+    if obj.pk not in self._rc_cache:
+        try:
+            self._rc_cache[obj.pk] = obj.rich_content
+        except RichPost.DoesNotExist:
+            self._rc_cache[obj.pk] = None
+    return self._rc_cache[obj.pk]
+```
+
+**Rule**: Never attach cache attributes to a model instance inside a serializer. Cache on the serializer instance (keyed by pk) or remove the need entirely with `select_related()`.
+
+---
+
+## Pattern 28: Shared Serializer Logic — Extract to Mixin
+
+**Problem**: Helper methods duplicated verbatim across serializer classes (e.g. `_normalize_rich_content` in both `CreateTopicSerializer` and `CreatePostSerializer`) diverge silently when one copy is updated.
+
+**Correct pattern** ✅:
+
+```python
+class RichContentMixin:
+    def _normalize_rich_content(self, rich_content):
+        # single authoritative implementation
+        ...
+
+class CreateTopicSerializer(RichContentMixin, serializers.ModelSerializer):
+    ...
+
+class CreatePostSerializer(RichContentMixin, serializers.ModelSerializer):
+    ...
+```
+
+**Rule**: Any serializer helper appearing identically in two or more classes must be extracted to a mixin or module-level function before merging.

--- a/docs/LEARNINGS.md
+++ b/docs/LEARNINGS.md
@@ -205,4 +205,44 @@ This file is append-only. New entries are added by main Claude after each code r
 **Mistake**: A `block-claude-md` hook used `grep -E "CLAUDE\.md"` against staged filenames to prevent `CLAUDE.md` from ever being committed. The intent was to stop developers accidentally committing local personalisation notes. Instead it blocked the *team-shared* `CLAUDE.md` (project conventions, delegation rules, critical gotchas) which is intentionally tracked. The hook had no way to distinguish the two forms.
 **Fix**: Removed `block-claude-md`. The two concerns are already handled separately: `.gitignore` with a `CLAUDE.md` entry prevents accidental commits of a purely-local file; `scan-api-keys` catches real credentials regardless of filename. The team-shared `CLAUDE.md` is committed normally.
 **Rule**: Name-gating ("block this filename") is only appropriate for files that must *never* appear in git history (e.g. `.env`, `*.pem`). For files that have a legitimate tracked form alongside a private local form, use `.gitignore` to guard the private form and rely on content-scanning hooks (detect-secrets, scan-api-keys) to catch actual secrets. Combining both in one hook conflates two distinct problems and will eventually block a legitimate commit.
+
+---
+
+## Performance (2026-05-08 additions)
+
+### [2026-05-08] Reverse OneToOne accessed in three separate SerializerMethodFields — 3× N+1 per row
+
+**Mistake**: `PostSerializer` in `forum_integration/serializers.py` accessed `obj.rich_content` (a reverse OneToOne to `RichPost`) independently in `get_rich_content`, `get_content_format`, and `get_ai_assisted`. Each try/except is a separate DB query when `select_related` is absent — tripling the query cost per serialized Post.
+**Fix**: Add `select_related('rich_content')` to the ViewSet queryset and consolidate all three field reads into a shared `_get_rich_post()` helper that caches on the instance, reducing per-post DB hits from 3 to 1.
+**Rule**: Any reverse OneToOne relation accessed in more than one `SerializerMethodField` must be in `select_related()` and read from a single consolidated access point. See `backend/docs/patterns/performance/query-optimization.md` Pattern 26.
+**Agent**: performance-reviewer
+
+### [2026-05-08] Instance-level cache on model instance inside serializer risks stale data after create()
+
+**Mistake**: Caching a reverse relation as `obj._rich_post_cache` directly on the Post instance inside a serializer method. If the same instance is mutated (e.g. `RichPost.objects.create()`) then re-serialized in the same request, the cached `None` is returned instead of the freshly-created object.
+**Fix**: Cache on the serializer instance (dict keyed by pk) or eliminate caching entirely via `select_related()`.
+**Rule**: Never attach cache attributes to a model instance inside a serializer. See `backend/docs/patterns/performance/query-optimization.md` Pattern 27.
+**Agent**: performance-reviewer
+
+---
+
+## Django/DRF (2026-05-08 additions)
+
+### [2026-05-08] Identical helper method duplicated across two serializer classes
+
+**Mistake**: `_normalize_rich_content` was defined verbatim in both `CreateTopicSerializer` and `CreatePostSerializer`. A future change to one copy will not propagate to the other, causing silent divergence in plant_mention normalisation logic.
+**Fix**: Extract into a `RichContentMixin` and have both serializers inherit from it (todo 066).
+**Rule**: Any serializer helper method appearing identically in two or more classes must be extracted to a mixin before merging. See `backend/docs/patterns/performance/query-optimization.md` Pattern 28.
+**Agent**: django-drf-reviewer
+
+---
+
+## Testing (2026-05-08 additions)
+
+### [2026-05-08] Machina dynamic class loader raises AppNotFoundError at import time — all forum_integration tests unreachable
+
+**Mistake**: `apps.forum_integration` tests all failed at import with `machina.core.loading.AppNotFoundError: No app found matching 'forum_conversation.managers'` because Machina's dynamic loader requires its full `machina.apps.*` subtree in `INSTALLED_APPS`. The error fires before any test's `setUp`, making the entire suite unreachable and masking regressions (todo 065).
+**Fix**: Ensure all required `machina.apps.*` entries are present in `INSTALLED_APPS` in the test settings.
+**Rule**: Any test module importing from django-machina must verify the full app subtree is in `INSTALLED_APPS` — a missing entry causes an import-time failure, not a test-time assertion failure, so the problem is invisible until the suite is run.
+**Agent**: test-quality-reviewer
 **Agent**: security-reviewer

--- a/todos/065-pending-p3-forum-integration-machina-test-env.md
+++ b/todos/065-pending-p3-forum-integration-machina-test-env.md
@@ -1,0 +1,70 @@
+---
+status: pending
+priority: p3
+issue_id: "065"
+tags: [testing, forum, machina]
+dependencies: []
+---
+
+# Fix Machina test environment so forum_integration tests can run
+
+## Problem
+
+All tests under `backend/apps/forum_integration/tests/` fail at import with:
+
+```text
+machina.core.loading.AppNotFoundError: No app found matching 'forum_conversation.managers'
+```
+
+This means the forum_integration test suite is entirely unexecutable in CI and locally.
+The only test covering `PostSerializer` (`test_plant_mention_serialization.py`) cannot
+run, leaving the serializer unprotected by automated tests.
+
+## Findings
+
+- Reproduced locally: `python manage.py test apps.forum_integration --keepdb` raises
+  `AppNotFoundError` before any test runs.
+- Root cause: Machina uses a dynamic class-loading system (`machina.core.loading`) that
+  requires its full set of forum apps to be present in `INSTALLED_APPS`. The test runner
+  discovers `apps.forum_integration` in isolation without the full Machina app tree.
+- `test_plant_mention_serialization.py` imports
+  `from machina.apps.forum_conversation.models import Topic, Post` directly, which
+  triggers Machina's app registry before Django's app registry is fully configured for
+  Machina's overridden apps.
+- Surfaced during todo 064 (PostSerializer rich_content fix) — the sole related test
+  could not be executed to verify the fix.
+
+## Recommended Action
+
+1. Check `INSTALLED_APPS` in `plant_community_backend/settings.py` — confirm all
+   required Machina apps are present (see Machina docs for the full list).
+2. Check if a test-specific settings file (`settings_test.py`) or pytest fixture is
+   needed to pre-configure Machina's app registry before test discovery.
+3. Try running with the full test label path:
+   `python manage.py test apps.forum_integration.tests.test_plant_mention_serialization`
+   and capture the exact traceback to identify the missing app.
+4. If the issue is a missing Machina app in `INSTALLED_APPS`, add it. If it's a test
+   isolation issue, add a `conftest.py` or `setUp` that ensures Machina's app registry
+   is initialised before imports.
+5. Once fixed, run the full forum_integration test suite to confirm all tests pass.
+
+## Technical Details
+
+- Test file: `backend/apps/forum_integration/tests/test_plant_mention_serialization.py`
+- Settings: `backend/plant_community_backend/settings.py`
+- Machina loading: `machina/core/loading.py` — `get_class` / `get_classes`
+- Pattern: `backend/docs/patterns/domain/forum.md`
+
+## Acceptance Criteria
+
+- [ ] `python manage.py test apps.forum_integration --keepdb` runs without
+      `AppNotFoundError` at import time.
+- [ ] `test_plant_mention_serialization.py` executes and all tests pass.
+- [ ] No other test suite is broken by the fix.
+
+## Work Log
+
+### 2026-05-08 - Created as follow-up from PR #259 code review
+
+- Surfaced by todo 064: PostSerializer fix could not be verified because the only
+  related test fails at import due to Machina's app loading requirements.

--- a/todos/066-pending-p4-forum-normalize-rich-content-dedup.md
+++ b/todos/066-pending-p4-forum-normalize-rich-content-dedup.md
@@ -1,0 +1,59 @@
+---
+status: pending
+priority: p4
+issue_id: "066"
+tags: [refactor, forum, serializer]
+dependencies: []
+---
+
+# Extract _normalize_rich_content into shared mixin (CreateTopicSerializer / CreatePostSerializer)
+
+## Problem
+
+`_normalize_rich_content` is defined identically in both `CreateTopicSerializer` and
+`CreatePostSerializer` in `backend/apps/forum_integration/serializers.py`. Any bug fix
+or behaviour change must be applied in two places, and the implementations will diverge
+over time.
+
+## Findings
+
+- `backend/apps/forum_integration/serializers.py`: identical `_normalize_rich_content`
+  method body appears in `CreateTopicSerializer` (line ~351) and `CreatePostSerializer`
+  (line ~465).
+- Surfaced during PR #259 code review as pre-existing technical debt.
+- The method validates and normalises `plant_mention` blocks in StreamField-like rich
+  content JSON — pure logic with no model dependencies beyond `PlantSpeciesPage`.
+
+## Recommended Action
+
+1. Define a `RichContentMixin` class above both serializers:
+
+   ```python
+   class RichContentMixin:
+       def _normalize_rich_content(self, rich_content):
+           ...  # single shared implementation
+   ```
+
+2. Add `RichContentMixin` as the first base class of both `CreateTopicSerializer`
+   and `CreatePostSerializer`.
+3. Delete the duplicate method bodies from both serializers.
+4. Run the forum_integration test suite to confirm no regressions (after todo 065
+   fixes the Machina test environment).
+
+## Technical Details
+
+- File: `backend/apps/forum_integration/serializers.py`
+- Depends on: todo 065 (Machina test env) for full test coverage after the change.
+
+## Acceptance Criteria
+
+- [ ] `_normalize_rich_content` exists in exactly one place in serializers.py.
+- [ ] Both `CreateTopicSerializer` and `CreatePostSerializer` behave identically to
+      before for valid and invalid `plant_mention` blocks.
+- [ ] Forum integration tests pass (requires todo 065 first).
+
+## Work Log
+
+### 2026-05-08 - Created as follow-up from PR #259 code review
+
+- Identified as pre-existing duplication; not introduced by todo 064.


### PR DESCRIPTION
## Summary

- Adds Patterns 26–28 to `query-optimization.md`: reverse OneToOne N+1 in SerializerMethodFields, instance-level cache stale-data risk, serializer mixin extraction
- Updates 3 reviewer agent checklists (`django-drf-reviewer`, `performance-reviewer`, `test-quality-reviewer`) with new items surfaced during the PR #259 review
- Appends 4 incident entries to `docs/LEARNINGS.md`
- Adds `todos/065` (fix Machina test environment) and `todos/066` (extract `_normalize_rich_content` into shared mixin)
- Adds `docs/cowork/` to `.gitignore`

## Test plan

- [ ] All pre-commit hooks pass (markdownlint, secret scan)
- [ ] No Python or frontend files changed — no test suite run needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)