### PR TITLE
test(forum): startup-verification tests for ENABLE_FORUM=True/False paths (todo 067)

### DIFF
--- a/backend/apps/forum_integration/tests/test_settings.py
+++ b/backend/apps/forum_integration/tests/test_settings.py
@@ -1,0 +1,109 @@
+import os
+import subprocess
+import sys
+
+from django.conf import settings
+from django.test import SimpleTestCase
+
+_SETTINGS_MODULE = "plant_community_backend.settings"
+
+_INSTALLED_APPS_SCRIPT = (
+    "import os, sys; sys.path.insert(0, os.getcwd()); "
+    "import django; django.setup(); "
+    "from django.conf import settings as s; "
+    "print('\\n'.join(s.INSTALLED_APPS))"
+)
+
+
+def _installed_apps_for(*, enable_forum: bool) -> list[str]:
+    env = {
+        **os.environ,
+        "ENABLE_FORUM": "True" if enable_forum else "False",
+        "DJANGO_SETTINGS_MODULE": _SETTINGS_MODULE,
+    }
+    result = subprocess.run(
+        [sys.executable, "-c", _INSTALLED_APPS_SCRIPT],
+        cwd=settings.BASE_DIR,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    if result.returncode != 0:
+        raise AssertionError(
+            f"django.setup() failed (ENABLE_FORUM={enable_forum}):\n"
+            f"STDERR:\n{result.stderr}\nSTDOUT:\n{result.stdout}"
+        )
+    return result.stdout.strip().splitlines()
+
+
+def _manage_check(*, enable_forum: bool) -> subprocess.CompletedProcess:
+    env = {
+        **os.environ,
+        "ENABLE_FORUM": "True" if enable_forum else "False",
+        "DJANGO_SETTINGS_MODULE": _SETTINGS_MODULE,
+    }
+    return subprocess.run(
+        [sys.executable, "manage.py", "check"],
+        cwd=settings.BASE_DIR,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+
+
+class ForumStartupCheckTest(SimpleTestCase):
+    """manage.py check passes for both ENABLE_FORUM values."""
+
+    def test_check_passes_with_forum_disabled(self):
+        result = _manage_check(enable_forum=False)
+        self.assertEqual(
+            result.returncode,
+            0,
+            msg=f"manage.py check failed (ENABLE_FORUM=False):\n{result.stderr}\n{result.stdout}",
+        )
+
+    def test_check_passes_with_forum_enabled(self):
+        result = _manage_check(enable_forum=True)
+        self.assertEqual(
+            result.returncode,
+            0,
+            msg=f"manage.py check failed (ENABLE_FORUM=True):\n{result.stderr}\n{result.stdout}",
+        )
+
+
+class EnableForumFalseInstalledAppsTest(SimpleTestCase):
+    """INSTALLED_APPS is correct when ENABLE_FORUM=False (headless forum path)."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls._apps = _installed_apps_for(enable_forum=False)
+
+    def test_headless_forum_in_installed_apps(self):
+        self.assertIn("apps.forum", self._apps)
+
+    def test_forum_integration_not_in_installed_apps(self):
+        self.assertNotIn("apps.forum_integration", self._apps)
+
+    def test_machina_forum_not_in_installed_apps(self):
+        self.assertNotIn("machina.apps.forum", self._apps)
+
+
+class EnableForumTrueInstalledAppsTest(SimpleTestCase):
+    """INSTALLED_APPS is correct when ENABLE_FORUM=True (Machina path)."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls._apps = _installed_apps_for(enable_forum=True)
+
+    def test_forum_integration_in_installed_apps(self):
+        self.assertIn("apps.forum_integration", self._apps)
+
+    def test_headless_forum_not_in_installed_apps(self):
+        self.assertNotIn("apps.forum", self._apps)
+
+    def test_machina_forum_in_installed_apps(self):
+        self.assertIn("machina.apps.forum", self._apps)

--- a/backend/apps/forum_integration/tests/test_settings.py
+++ b/backend/apps/forum_integration/tests/test_settings.py
@@ -37,6 +37,7 @@ def _installed_apps_for(*, enable_forum: bool) -> list[str]:
     return result.stdout.strip().splitlines()
 
 
+# manage.py check may attempt DB/cache connections via Channels/caching system checks.
 def _manage_check(*, enable_forum: bool) -> subprocess.CompletedProcess:
     env = {
         **os.environ,

--- a/todos/archive/067-completed-p3-enable-forum-startup-tests.md
+++ b/todos/archive/067-completed-p3-enable-forum-startup-tests.md
@@ -1,0 +1,109 @@
+---
+status: completed
+priority: p3
+issue_id: "067"
+tags: [testing, forum, settings]
+dependencies: ["065"]
+---
+
+# Add startup-verification tests for ENABLE_FORUM=True/False paths
+
+## Problem
+
+PR #261 made `INSTALLED_APPS`, context processors, and template dirs conditional on
+`ENABLE_FORUM`. There are no automated tests verifying that either configuration
+starts cleanly. A future change to settings.py could silently break one path and
+it would only surface as a runtime crash.
+
+## Findings
+
+- PR #261 (todo 065 implementation) modified `settings.py` to gate `MACHINA_APPS`,
+  Machina context processors, and template dirs behind `ENABLE_FORUM`.
+- Surfaced during `/review` of PR #261 (2026-05-09).
+- `backend/apps/forum_integration/tests/` exists but has no test covering Django
+  system checks for either `ENABLE_FORUM` value.
+
+## Recommended Action
+
+1. Add a test module `backend/apps/forum_integration/tests/test_settings.py` (or
+   `test_startup.py`) that:
+
+   a. **ENABLE_FORUM=False path** — assert `apps.forum` is in `settings.INSTALLED_APPS`
+      and `machina.apps.forum` is NOT:
+
+      ```python
+      from django.test import TestCase, override_settings
+      from django.apps import apps
+
+      class EnableForumFalseTest(TestCase):
+          def test_headless_forum_app_loaded(self):
+              self.assertIn('forum', [a.label for a in apps.get_app_configs()])
+              self.assertNotIn(
+                  'machina.apps.forum',
+                  [a.name for a in apps.get_app_configs()],
+              )
+      ```
+
+   b. **ENABLE_FORUM=True path** — use `@override_settings` to swap INSTALLED_APPS
+      and verify `apps.forum_integration` is present and `apps.forum` is absent.
+      Note: `override_settings` does not re-run app registry — test should verify
+      `INSTALLED_APPS` list contents rather than the live app registry.
+
+      ```python
+      @override_settings(ENABLE_FORUM=True)
+      def test_enable_forum_flag_gates_machina_apps(self):
+          # Check the constructed list, not the live registry
+          from django.conf import settings
+          self.assertIn('apps.forum_integration', settings.INSTALLED_APPS)
+          self.assertNotIn('apps.forum', settings.INSTALLED_APPS)
+      ```
+
+   c. Run `python manage.py check --deploy` (or `check`) under each config and
+      assert exit code 0.
+
+2. Run with `--keepdb` to avoid full DB rebuild.
+
+## Technical Details
+
+- File to create: `backend/apps/forum_integration/tests/test_settings.py`
+- Pattern doc: `backend/docs/patterns/domain/forum.md`
+- Note: `override_settings` does not reload the app registry mid-test; for the
+  `ENABLE_FORUM=True` branch, assert against the `INSTALLED_APPS` list (constructed
+  at import time) rather than the live `apps.get_app_configs()` registry.
+- If a full registry-reload test is needed, use a subprocess call to
+  `python manage.py check` with `ENABLE_FORUM=True` in the environment.
+
+## Acceptance Criteria
+
+- [x] `python manage.py test apps.forum_integration.tests.test_settings --keepdb`
+      passes with zero errors.
+- [x] The test asserts `apps.forum` IN INSTALLED_APPS when ENABLE_FORUM=False.
+- [x] The test asserts `apps.forum_integration` IN INSTALLED_APPS when ENABLE_FORUM=True
+      and `apps.forum` NOT in INSTALLED_APPS.
+- [x] No database mocks used (real PostgreSQL test DB per project convention).
+
+## Work Log
+
+### 2026-05-09 - Created from PR #261 review
+
+- Gap identified: PR #261 added conditional INSTALLED_APPS logic with no test coverage.
+- Reviewer note: "A simple TestCase with call_command('check') would suffice, or even
+  just a note in the todo acceptance criteria that manual verification was done."
+
+### 2026-05-09 - Started by completing-todos skill (run 2026-05-09-1324)
+
+- Picked up by automated workflow.
+- Approach: SimpleTestCase with subprocess calls for both ENABLE_FORUM paths — environment-independent, tests both configurations on every run.
+- Verification output: `Ran 8 tests in 3.827s OK` — all 4 acceptance criteria passed.
+  - `ForumStartupCheckTest` (2 tests): manage.py check exits 0 for both ENABLE_FORUM values.
+  - `EnableForumFalseInstalledAppsTest` (3 tests): apps.forum in, forum_integration absent, machina absent.
+  - `EnableForumTrueInstalledAppsTest` (3 tests): forum_integration in, apps.forum absent, machina present.
+
+### 2026-05-09 - Completed by completing-todos skill (run 2026-05-09-1324)
+
+- Verification: all 8 acceptance criteria passed (`Ran 8 tests in 3.561s OK` after repair).
+- Review: 7 findings total — 0 critical/high, 2 medium, 2 low, 2 info. Medium findings repaired (added subprocess timeout=60, pinned DJANGO_SETTINGS_MODULE in env dict).
+- Known issues: low findings noted but not blocking.
+  - `manage.py check` has implicit DB dependency (consistent with real-Postgres convention).
+  - Mirror-image test classes — acceptable for clarity.
+  - Four subprocess spawns add ~3.5s to suite (acceptable at current scale).


### PR DESCRIPTION
## Summary

- Adds `backend/apps/forum_integration/tests/test_settings.py` with 8 `SimpleTestCase` tests covering both `ENABLE_FORUM` startup paths
- Tests use subprocess so they're environment-independent — both configurations are verified on every run regardless of what `.env` has set
- Covers: `manage.py check` exit codes for each path + `INSTALLED_APPS` list contents (headless `apps.forum` vs Machina `apps.forum_integration`)

## Test plan

- [x] `python manage.py test apps.forum_integration.tests.test_settings --keepdb` passes (8/8 verified locally)
- [x] `ForumStartupCheckTest` — `manage.py check` exits 0 for both `ENABLE_FORUM=False` and `ENABLE_FORUM=True`
- [x] `EnableForumFalseInstalledAppsTest` — `apps.forum` present, `apps.forum_integration` and `machina.apps.forum` absent
- [x] `EnableForumTrueInstalledAppsTest` — `apps.forum_integration` and `machina.apps.forum` present, `apps.forum` absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)