### PR TITLE
chore(deps): bump urllib3 to 2.7.0 (CVE-2026-44431/44432)

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -212,7 +212,7 @@ typing_extensions==4.15.0
 tzdata==2025.2
 tzlocal==5.3.1
 uritemplate==4.2.0
-urllib3==2.6.3
+urllib3==2.7.0
 uvicorn==0.46.0
 uvloop==0.22.1
 vine==5.1.0


### PR DESCRIPTION
## Summary
- Bumps `urllib3` 2.6.3 → 2.7.0 in `backend/requirements.txt`.
- Fixes the Backend Python Security Scan (`pip-audit`) failure on `main`:
  - CVE-2026-44431 — fixed in 2.7.0
  - CVE-2026-44432 — fixed in 2.7.0

## Notes
Pre-existing failure on `main`, unrelated to any feature work. Splitting it out
so it can land independently and unblock other PRs' security checks.

## Test plan
- [ ] Backend Python Security Scan passes (pip-audit reports no vulnerabilities)
- [ ] Backend test suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)