### PR TITLE
feat(harness): port OCRecipes automation — hooks, kimi-review, codify/audit skills

### DIFF
--- a/.claude/agents/docs-researcher.md
+++ b/.claude/agents/docs-researcher.md
@@ -1,0 +1,109 @@
+---
+name: docs-researcher
+description: Use to validate audit findings and find current documentation, best practices, and version-specific guidance for libraries and frameworks used in the project.
+model: sonnet
+---
+
+# Documentation & Best Practices Researcher Subagent
+
+You are a research agent for the plant_id_community project. You find and
+synthesize current documentation and best practices for the project's libraries
+and frameworks, and validate audit findings against current docs.
+
+## Project Tech Stack (reference)
+
+### Backend
+
+- **Django** + **Wagtail CMS** (admin at `/cms/`)
+- **Django REST Framework** — viewsets, serializers, permissions
+- **PostgreSQL** + **Redis** (caching, distributed locks)
+- **Celery** — async tasks
+- **django-ratelimit** — rate limiting
+- JWT auth + **Firebase** token exchange
+- Plant.id API v3 + PlantNet API (dual-provider plant ID)
+
+### Web
+
+- **React 19** + **TypeScript** (strict) + **Vite**
+- **react-router-dom** — routing
+- **Tailwind CSS 4**
+- **Vitest** + **Playwright** — testing
+
+### Mobile
+
+- **Flutter** + **Riverpod 3.x** + **go_router** + **Material 3**
+- **Firebase Auth** + `flutter_secure_storage`
+
+## Research Process
+
+1. **Understand the question.** Identify the exact library/feature and the
+   version the project uses (check `backend/requirements*.txt`,
+   `web/package.json`, `plant_community_mobile/pubspec.yaml`).
+2. **Gather documentation**, in priority order:
+   1. **Context7 MCP** — `mcp__plugin_context7_context7__resolve-library-id`
+      then `mcp__plugin_context7_context7__query-docs`.
+   2. **WebFetch** — official docs / GitHub READMEs.
+   3. **WebSearch** — best practices, community solutions.
+   4. **Project files** — `docs/rules/`, the `*/docs/patterns/` libraries,
+      `docs/LEARNINGS.md`, the root + platform `CLAUDE.md` files.
+3. **Synthesize** — summary, relevant API, recommended approach adapted to this
+   project, gotchas, and cited sources.
+
+## DO / DON'T
+
+- **DO** verify the project's library version before researching; cite sources;
+  give version-specific guidance; cross-reference `docs/rules/` and the pattern
+  libraries.
+- **DON'T** give generic advice; assume the latest version; recommend new
+  dependencies without justification; research what reading the code answers.
+
+## Output Format — Audit Phase 2.5 (validation mode)
+
+**When dispatched by the `audit` skill's Phase 2.5**, ignore the open-ended
+format below. Return exactly one verdict per finding ID:
+
+- `confirmed` — current docs agree the finding is valid
+- `better-fix` — real finding, but docs show a cleaner/different fix; describe it
+- `contradicted` — docs say the flagged pattern is fine; cite the doc
+- `not-applicable` — does not hinge on external library behavior (IDOR, missing
+  ownership check, N+1, dead code) — no doc call needed
+
+Every non-`not-applicable` verdict MUST cite the specific doc (library + section).
+If you incidentally notice an unmet current-doc best practice in code you already
+viewed, report it as a NEW finding candidate with file:line + citation. Do not
+perform a broad audit. Do not fix anything.
+
+## Output Format — open-ended research
+
+```markdown
+# Research: [Topic]
+
+## Summary
+[1-2 sentence key finding]
+
+## Library Version
+- Project uses: [version]
+- Latest stable: [current latest]
+- Docs reference: [URL]
+
+## Findings
+### [Finding 1]
+[Details with code examples]
+
+## Recommendation
+[What to do, adapted to this project's architecture]
+
+## Gotchas
+- [Pitfall 1]
+
+## Sources
+- [URL 1]
+```
+
+## Key files for cross-reference
+
+- `backend/requirements*.txt`, `web/package.json`, `plant_community_mobile/pubspec.yaml` — versions
+- `docs/rules/` — short binding rules
+- `backend/docs/patterns/`, `web/docs/patterns/`, `plant_community_mobile/docs/patterns/`, `firebase/docs/patterns/` — pattern libraries
+- `docs/LEARNINGS.md` — past gotchas and incidents
+- root + platform `CLAUDE.md` — architecture and conventions

--- a/.claude/hooks/guard-worktree-isolation.sh
+++ b/.claude/hooks/guard-worktree-isolation.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# PreToolUse hook — block worktree-isolated agents from editing the main checkout.
+# When the session cwd is inside a linked worktree (.claude/worktrees/agent-* or
+# .worktrees/<name>), an Edit/Write/MultiEdit whose absolute file_path is under the
+# main repo root but outside that worktree is the isolation-leak signature — deny it.
+# Relative paths resolve against the (in-worktree) cwd and are always allowed.
+# Fails open on parse failure. Scope: Edit/Write/MultiEdit (see settings.json).
+# Tests: .claude/hooks/test-guard-worktree-isolation.sh
+set -uo pipefail
+
+command -v jq >/dev/null 2>&1 || exit 0
+
+INPUT=$(cat)
+CWD=$(printf '%s' "$INPUT" | jq -re '.cwd' 2>/dev/null) || exit 0
+FILE_PATH=$(printf '%s' "$INPUT" | jq -re '.tool_input.file_path' 2>/dev/null) || exit 0
+
+# Determine the worktree root from the session cwd, if inside one.
+case "$CWD" in
+  */.claude/worktrees/agent-*)
+    WT_ROOT=$(printf '%s' "$CWD" | sed -E 's#(.*/\.claude/worktrees/agent-[^/]+).*#\1#')
+    MAIN_ROOT="${WT_ROOT%/.claude/worktrees/agent-*}"
+    ;;
+  */.worktrees/*)
+    WT_ROOT=$(printf '%s' "$CWD" | sed -E 's#(.*/\.worktrees/[^/]+).*#\1#')
+    MAIN_ROOT="${WT_ROOT%/.worktrees/*}"
+    ;;
+  *) exit 0 ;;
+esac
+
+# An empty MAIN_ROOT would make the deny pattern collapse to /* and block every
+# edit. Unreachable unless the repo lives at filesystem root — fail open.
+[ -n "$MAIN_ROOT" ] || exit 0
+
+# Relative file_path resolves against cwd (inside the worktree) — always safe.
+case "$FILE_PATH" in
+  /*) ;;
+  *) exit 0 ;;
+esac
+
+# Absolute file_path: classify it. The worktree dir itself lives under MAIN_ROOT,
+# so the in-worktree check must come first.
+case "$FILE_PATH" in
+  "$WT_ROOT"|"$WT_ROOT"/*) exit 0 ;;   # inside the worktree — allowed
+  "$MAIN_ROOT"/*) ;;                   # under main repo, outside worktree — the leak
+  *) exit 0 ;;                         # entirely outside the repo (e.g. /tmp) — allowed
+esac
+
+REASON=$(printf '%s\n  %s\n%s' \
+  "Worktree isolation guard: this session is running inside the worktree" \
+  "$WT_ROOT" \
+  "but the edit targets the absolute path $FILE_PATH under the main checkout. Re-issue the edit with a worktree-rooted path (under the worktree directory above).")
+
+jq -n --arg r "$REASON" \
+  '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":$r}}'
+exit 0

--- a/.claude/hooks/inject-patterns.sh
+++ b/.claude/hooks/inject-patterns.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# PreToolUse hook — inject relevant binding rules before Edit/Write/MultiEdit.
+# Reads tool event JSON from stdin; outputs additionalContext JSON or exits 0 silently.
+# Rules live in docs/rules/<domain>.md (short by design). Long-form detail stays
+# in the per-stack */docs/patterns/ libraries — this hook only surfaces the
+# compact checklists plus a discipline preamble.
+# Tests: .claude/hooks/test-inject-patterns.sh
+set -uo pipefail
+
+INPUT=$(cat)
+
+TOOL_NAME=$(printf '%s' "$INPUT" | jq -re '.tool_name' 2>/dev/null) || exit 0
+FILE_PATH=$(printf '%s' "$INPUT" | jq -re '.tool_input.file_path' 2>/dev/null) || exit 0
+
+[[ "$TOOL_NAME" == "Edit" || "$TOOL_NAME" == "Write" || "$TOOL_NAME" == "MultiEdit" ]] || exit 0
+
+# Resolve paths relative to project root (two levels up from .claude/hooks/)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+RULES_DIR="$PROJECT_ROOT/docs/rules"
+
+# Normalize to a repo-relative path so the matchers below are uniform whether
+# the Edit tool sent an absolute path or a relative one. A leading "/" is
+# stripped only when the path is under PROJECT_ROOT; paths outside it are left
+# as-is and simply fall through to no domain match.
+REL="${FILE_PATH#"$PROJECT_ROOT"/}"
+
+# Map file path to domains. Independent if-blocks so multiple rows can match.
+DOMAINS=""
+add_domain() {
+  case ",$DOMAINS," in
+    *,"$1",*) ;;
+    *) DOMAINS="${DOMAINS:+$DOMAINS,}$1" ;;
+  esac
+}
+
+[[ "$REL" == backend/apps/blog/* ]] && \
+  { add_domain wagtail; add_domain api; add_domain security; }
+
+[[ "$REL" == */migrations/* ]] && \
+  { add_domain database; add_domain security; }
+
+[[ "$REL" == */serializers.py ]] && add_domain api
+
+[[ "$REL" == */tasks.py || "$REL" == *celery* || "$REL" == */beat*.py ]] && \
+  add_domain celery
+
+[[ "$REL" == */views.py || "$REL" == */viewsets.py || \
+   "$REL" == */permissions.py ]] && \
+  { add_domain api; add_domain security; }
+
+[[ "$REL" == */models.py ]] && { add_domain database; add_domain security; }
+
+[[ "$REL" == */cache*.py || "$REL" == */signals.py ]] && add_domain caching
+
+# Generic backend Python catch-all (only if nothing more specific matched).
+if [ -z "$DOMAINS" ]; then
+  [[ "$REL" == backend/*.py ]] && \
+    { add_domain api; add_domain security; add_domain database; }
+fi
+
+[[ "$REL" == firebase/* || "$REL" == *firebase* ]] && \
+  { add_domain firebase; add_domain security; }
+
+[[ "$REL" == *.dart ]] && add_domain flutter
+
+[[ "$REL" == web/src/*.tsx ]] && { add_domain react; add_domain typescript; }
+
+# Test files accumulate the testing domain regardless of enclosing directory.
+[[ "$REL" == */tests/* || "$REL" == *test_*.py || "$REL" == *_test.py || \
+   "$REL" == *.test.ts || "$REL" == *.test.tsx || \
+   "$REL" == *.spec.ts || "$REL" == *.spec.tsx ]] && \
+  add_domain testing
+
+# typescript fallback for .ts/.tsx files when no more-specific domain matched.
+if [ -z "$DOMAINS" ]; then
+  case "$REL" in
+    *.ts|*.tsx) add_domain typescript ;;
+  esac
+fi
+
+# Build context in a temp file (avoids subshell newline stripping)
+TMPFILE=$(mktemp)
+trap 'rm -f "$TMPFILE"' EXIT
+
+printf '=== Pre-write context for %s ===\n' "$FILE_PATH" >> "$TMPFILE"
+
+cat >> "$TMPFILE" <<'EOF'
+
+[DISCIPLINE — applies before any edit]
+- Think before coding. State your assumptions out loud. If the request is ambiguous, ask. If a simpler approach exists, push back. Stop when you are confused, name what is unclear, do not just pick one interpretation and run.
+- Simplicity first. Write the minimum code that solves the problem. No speculative abstractions. No flexibility nobody asked for. The test: would a senior engineer call this overcomplicated.
+- Surgical changes. Touch only what the task requires. Do not improve neighboring code. Do not refactor what is not broken. Every changed line should trace back to the request.
+- Goal-driven execution. Turn vague instructions into verifiable targets before writing a line. "Add validation" becomes "write tests for invalid inputs, then make them pass."
+EOF
+
+if [ -n "$DOMAINS" ]; then
+  IFS=',' read -ra DOMAIN_LIST <<< "$DOMAINS"
+  for DOMAIN in "${DOMAIN_LIST[@]}"; do
+    RULES_FILE="$RULES_DIR/${DOMAIN}.md"
+    if [ -f "$RULES_FILE" ]; then
+      printf '\n[RULES — %s]\n' "$DOMAIN" >> "$TMPFILE"
+      cat "$RULES_FILE" >> "$TMPFILE"
+    fi
+  done
+fi
+
+# Spill overflow to a stable temp file so the agent can read the rest.
+# Claude Code's hook-output cap is ~10K; multi-domain injections can exceed this.
+THRESHOLD=9000
+SPILL_FILE="/tmp/plant-id-injection-context.md"
+CONTEXT_SIZE=$(wc -c < "$TMPFILE")
+if [ "$CONTEXT_SIZE" -gt "$THRESHOLD" ]; then
+  cp "$TMPFILE" "$SPILL_FILE"
+  head -c 8800 "$TMPFILE" > "${TMPFILE}.trunc"
+  mv "${TMPFILE}.trunc" "$TMPFILE"
+  printf '\n\n[TRUNCATED — %d bytes total. Full rule context written to %s. Read that file for the rest before editing.]\n' \
+    "$CONTEXT_SIZE" "$SPILL_FILE" >> "$TMPFILE"
+fi
+
+CONTEXT=$(cat "$TMPFILE")
+jq -n --arg ctx "$CONTEXT" \
+  '{"hookSpecificOutput":{"hookEventName":"PreToolUse","additionalContext":$ctx}}'

--- a/.claude/hooks/kimi-review.sh
+++ b/.claude/hooks/kimi-review.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# PreToolUse hook for Bash — when the about-to-run command is a real `git commit`,
+# run kimi-review over the staged diff. CRITICAL findings block the commit;
+# WARNING findings are surfaced as additionalContext but do not block.
+#
+# Skip semantics (all early exit 0, silently):
+#   - $SKIP_KIMI_REVIEW=1                  → user opt-out (CI, rebases, known-good)
+#   - `kimi-review` not on PATH            → dev without the tool installed
+#   - `jq` not on PATH                     → cannot parse hook event or build JSON safely
+# Tests: .claude/hooks/test-kimi-review.sh
+
+set -uo pipefail
+
+# 1) Explicit opt-out
+[ -n "${SKIP_KIMI_REVIEW:-}" ] && exit 0
+
+# 2) Required tooling — auto-skip if missing
+command -v jq >/dev/null 2>&1 || exit 0
+command -v kimi-review >/dev/null 2>&1 || exit 0
+
+# 3) Read the hook event JSON and extract the pending Bash command
+INPUT=$(cat)
+COMMAND=$(printf '%s' "$INPUT" | jq -re '.tool_input.command' 2>/dev/null) || exit 0
+
+# 4) Match only real `git commit` invocations. Anchored at ^ so substrings like
+#    `echo git commit ...` are rejected; trailing ([[:space:]]|$) so `commit-graph`
+#    and other `commit*` subcommands are rejected. Allows leading VAR=val env
+#    prefixes and `git -c key=val commit ...` chains.
+GIT_COMMIT_RE='^([[:space:]]*[A-Za-z_][A-Za-z0-9_]*=[^[:space:]]+[[:space:]]+)*git([[:space:]]+-c[[:space:]]+[^[:space:]]+)*[[:space:]]+commit([[:space:]]|$)'
+[[ "$COMMAND" =~ $GIT_COMMIT_RE ]] || exit 0
+
+# 5) No staged changes → nothing to review
+FILES=$(git diff --cached --name-only 2>/dev/null)
+[ -n "$FILES" ] || exit 0
+
+# 6) Map staged files to docs/rules/ domains
+PATTERNS=''
+add_pattern() {
+  case ",$PATTERNS," in
+    *,$1,*) ;;
+    *) PATTERNS="${PATTERNS:+$PATTERNS,}$1" ;;
+  esac
+}
+
+while IFS= read -r file; do
+  # Directory/file-role classification — first match wins per file.
+  case "$file" in
+    backend/apps/blog/*)
+      add_pattern wagtail; add_pattern api; add_pattern security ;;
+    */migrations/*)
+      add_pattern database; add_pattern security ;;
+    */serializers.py)
+      add_pattern api ;;
+    */tasks.py|*celery*|*/beat*.py)
+      add_pattern celery ;;
+    */views.py|*/viewsets.py|*/api/*.py|*/permissions.py)
+      add_pattern api; add_pattern security ;;
+    */models.py)
+      add_pattern database; add_pattern security ;;
+    */cache*.py|*/signals.py)
+      add_pattern caching ;;
+    backend/*.py)
+      add_pattern api; add_pattern security; add_pattern database; add_pattern caching ;;
+    firebase/*|*firebase*)
+      add_pattern firebase; add_pattern security ;;
+    web/src/*.tsx)
+      add_pattern react; add_pattern typescript ;;
+    web/src/*.ts)
+      add_pattern typescript ;;
+    plant_community_mobile/*.dart)
+      add_pattern flutter ;;
+  esac
+  # Extension/test classification — additive, runs for every file.
+  case "$file" in
+    *test_*.py|*_test.py|*/tests/*|*.test.ts|*.test.tsx|*.spec.ts|*.spec.tsx)
+      add_pattern testing ;;
+  esac
+done <<< "$FILES"
+
+# 7) Run review on the staged diff. Only CRITICAL + WARNING (project convention).
+#    docs/rules/ holds the compact binding-rule checklists; missing files are
+#    silently skipped by kimi-review, so passing names freely is safe.
+if [ -n "$PATTERNS" ]; then
+  REVIEW=$(git diff --cached | kimi-review \
+    --scope "staged for commit" \
+    --profile plant_id \
+    --rules "$PATTERNS" \
+    --tiers CRITICAL,WARNING 2>&1)
+else
+  REVIEW=$(git diff --cached | kimi-review \
+    --scope "staged for commit" \
+    --profile plant_id \
+    --tiers CRITICAL,WARNING 2>&1)
+fi
+
+# 8) Detect CRITICAL findings. kimi-review emits every real finding as
+#    `[TIER] path:line — description`, so an actual CRITICAL finding carries the
+#    bracketed `[CRITICAL]` tag followed by a body. The discriminating signal is
+#    the brackets: negative phrasing ("No CRITICAL or WARNING findings") contains
+#    the bare word but never the bracketed tag. The trailing `.*[^[:space:]]`
+#    requires a finding body, so a bare `[CRITICAL]` does not block. Literal
+#    brackets use POSIX bracket-expression escaping for GNU/BSD grep portability.
+if printf '%s\n' "$REVIEW" | grep -Eq '[[]CRITICAL[]].*[^[:space:]]'; then
+  REASON=$(printf 'kimi-review blocked the commit — CRITICAL finding present.\n\n%s\n\n%s' \
+    "${PATTERNS:+rules: $PATTERNS}" \
+    "$REVIEW")
+  jq -n --arg reason "$REASON" \
+    '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":$reason}}'
+  exit 0
+fi
+
+# 9) No CRITICAL — surface review (including any WARNING) as additionalContext.
+jq -n --arg r "$REVIEW" --arg p "$PATTERNS" \
+  '{"hookSpecificOutput":{"hookEventName":"PreToolUse","additionalContext":((if ($p | length) > 0 then "kimi-review rules: " + $p + "\n" else "" end) + "kimi-review findings (WARNING is non-blocking; CRITICAL would have blocked):\n" + $r)}}' \
+  2>/dev/null || true
+exit 0

--- a/.claude/hooks/test-guard-worktree-isolation.sh
+++ b/.claude/hooks/test-guard-worktree-isolation.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Tests for guard-worktree-isolation.sh — run from anywhere.
+# The hook only needs `jq` (real); no stubs are required.
+set -uo pipefail
+
+HOOK="$(cd "$(dirname "$0")" && pwd)/guard-worktree-isolation.sh"
+PASS=0; FAIL=0
+
+run_hook() { echo "$1" | bash "$HOOK" 2>/dev/null; }
+
+assert_deny() {
+  local name="$1" out
+  out=$(run_hook "$2")
+  if echo "$out" | grep -q '"permissionDecision": "deny"'; then
+    echo "PASS: $name"; PASS=$((PASS+1))
+  else
+    echo "FAIL: $name (expected a deny decision)"
+    echo "  got: $(echo "$out" | head -3)"
+    FAIL=$((FAIL+1))
+  fi
+}
+
+assert_allow() {
+  local name="$1" out
+  out=$(run_hook "$2")
+  if [ -z "$out" ]; then
+    echo "PASS: $name"; PASS=$((PASS+1))
+  else
+    echo "FAIL: $name (expected no output / allow)"
+    echo "  got: $(echo "$out" | head -3)"
+    FAIL=$((FAIL+1))
+  fi
+}
+
+REPO='/Users/x/projects/plant_id_community'
+AGENT_WT="$REPO/.claude/worktrees/agent-abc"
+NAMED_WT="$REPO/.worktrees/fix-csrf-duplication"
+
+# ---- .claude/worktrees/agent-* form ----
+assert_deny "agent worktree: absolute main-checkout path is denied" \
+  "{\"cwd\":\"$AGENT_WT\",\"tool_input\":{\"file_path\":\"$REPO/backend/manage.py\"}}"
+
+assert_deny "agent worktree: deny fires when cwd is a worktree subdirectory" \
+  "{\"cwd\":\"$AGENT_WT/backend\",\"tool_input\":{\"file_path\":\"$REPO/backend/manage.py\"}}"
+
+assert_allow "agent worktree: absolute path inside the worktree is allowed" \
+  "{\"cwd\":\"$AGENT_WT\",\"tool_input\":{\"file_path\":\"$AGENT_WT/backend/manage.py\"}}"
+
+# ---- .worktrees/<name> form ----
+assert_deny "named worktree: absolute main-checkout path is denied" \
+  "{\"cwd\":\"$NAMED_WT\",\"tool_input\":{\"file_path\":\"$REPO/backend/manage.py\"}}"
+
+assert_allow "named worktree: absolute path inside the worktree is allowed" \
+  "{\"cwd\":\"$NAMED_WT\",\"tool_input\":{\"file_path\":\"$NAMED_WT/backend/manage.py\"}}"
+
+assert_allow "named worktree: relative path is allowed" \
+  "{\"cwd\":\"$NAMED_WT\",\"tool_input\":{\"file_path\":\"backend/manage.py\"}}"
+
+# ---- common cases ----
+assert_allow "non-worktree session is untouched" \
+  "{\"cwd\":\"$REPO\",\"tool_input\":{\"file_path\":\"$REPO/backend/manage.py\"}}"
+
+assert_allow "absolute path outside the repo is allowed" \
+  "{\"cwd\":\"$AGENT_WT\",\"tool_input\":{\"file_path\":\"/tmp/scratch.txt\"}}"
+
+assert_allow "empty MAIN_ROOT edge case fails open" \
+  '{"cwd":"/.claude/worktrees/agent-abc","tool_input":{"file_path":"/etc/passwd"}}'
+
+assert_allow "malformed JSON fails open" \
+  'not json at all'
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ $FAIL -eq 0 ]

--- a/.claude/hooks/test-inject-patterns.sh
+++ b/.claude/hooks/test-inject-patterns.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# Tests for inject-patterns.sh — run from anywhere.
+# Requires docs/rules/<domain>.md files to exist (the hook only emits a
+# [RULES — domain] block when the corresponding file is present).
+set -uo pipefail
+
+HOOK="$(cd "$(dirname "$0")" && pwd)/inject-patterns.sh"
+SPILL_FILE="/tmp/plant-id-injection-context.md"
+PASS=0; FAIL=0
+
+run_hook() {
+  local input="$1"
+  rm -f "$SPILL_FILE"
+  local output spill=""
+  output=$(echo "$input" | bash "$HOOK" 2>/dev/null || true)
+  [ -f "$SPILL_FILE" ] && spill=$(cat "$SPILL_FILE")
+  printf '%s\n%s' "$output" "$spill"
+}
+
+check() {
+  local name="$1" input="$2" pattern="$3" combined
+  combined=$(run_hook "$input")
+  if echo "$combined" | grep -q "$pattern"; then
+    echo "PASS: $name"; PASS=$((PASS + 1))
+  else
+    echo "FAIL: $name"; echo "  expected to find: $pattern"; FAIL=$((FAIL + 1))
+  fi
+}
+
+check_no_match() {
+  local name="$1" input="$2" pattern="$3" combined
+  combined=$(run_hook "$input")
+  if echo "$combined" | grep -q "$pattern"; then
+    echo "FAIL: $name (expected NOT to find: $pattern)"; FAIL=$((FAIL + 1))
+  else
+    echo "PASS: $name"; PASS=$((PASS + 1))
+  fi
+}
+
+check_empty() {
+  local name="$1" input="$2" output
+  rm -f "$SPILL_FILE"
+  output=$(echo "$input" | bash "$HOOK" 2>/dev/null || true)
+  if [ -z "$output" ]; then
+    echo "PASS: $name"; PASS=$((PASS + 1))
+  else
+    echo "FAIL: $name (expected empty)"; echo "  got: $(echo "$output" | head -3)"; FAIL=$((FAIL + 1))
+  fi
+}
+
+# blog → wagtail + api + security
+check "blog models → wagtail rules" \
+  '{"tool_name":"Edit","tool_input":{"file_path":"backend/apps/blog/models.py"}}' \
+  "RULES — wagtail"
+
+# migrations → database + security
+check "migration → database rules" \
+  '{"tool_name":"Edit","tool_input":{"file_path":"backend/apps/plant_identification/migrations/0001_initial.py"}}' \
+  "RULES — database"
+
+check "migration → security rules" \
+  '{"tool_name":"Edit","tool_input":{"file_path":"backend/apps/plant_identification/migrations/0001_initial.py"}}' \
+  "RULES — security"
+
+# serializers → api
+check "serializers → api rules" \
+  '{"tool_name":"Edit","tool_input":{"file_path":"backend/apps/forum/serializers.py"}}' \
+  "RULES — api"
+
+# views → api + security
+check "views → api rules" \
+  '{"tool_name":"Edit","tool_input":{"file_path":"backend/apps/users/views.py"}}' \
+  "RULES — api"
+
+check "views → security rules" \
+  '{"tool_name":"Edit","tool_input":{"file_path":"backend/apps/users/views.py"}}' \
+  "RULES — security"
+
+# tasks → celery
+check "tasks → celery rules" \
+  '{"tool_name":"Edit","tool_input":{"file_path":"backend/apps/blog/tasks.py"}}' \
+  "RULES — celery"
+
+# React component → react + typescript
+check "web component → react rules" \
+  '{"tool_name":"Write","tool_input":{"file_path":"web/src/components/BlogCard.tsx"}}' \
+  "RULES — react"
+
+# Plain .ts → typescript fallback
+check "web .ts → typescript fallback" \
+  '{"tool_name":"Edit","tool_input":{"file_path":"web/src/lib/api.ts"}}' \
+  "RULES — typescript"
+
+# Flutter → flutter
+check "dart file → flutter rules" \
+  '{"tool_name":"Write","tool_input":{"file_path":"plant_community_mobile/lib/main.dart"}}' \
+  "RULES — flutter"
+
+# Test file → testing (additive)
+check "backend test file → testing rules" \
+  '{"tool_name":"Edit","tool_input":{"file_path":"backend/apps/forum/tests/test_views.py"}}' \
+  "RULES — testing"
+
+# Output is valid JSON
+check "output is valid JSON with hookSpecificOutput" \
+  '{"tool_name":"Edit","tool_input":{"file_path":"backend/apps/users/views.py"}}' \
+  "hookSpecificOutput"
+
+# Discipline preamble always emitted for Edit/Write
+check "non-domain file → discipline preamble emitted" \
+  '{"tool_name":"Edit","tool_input":{"file_path":"README.md"}}' \
+  "DISCIPLINE"
+
+check_no_match "non-domain file → no RULES blocks" \
+  '{"tool_name":"Edit","tool_input":{"file_path":"README.md"}}' \
+  "RULES — "
+
+# Read tool → no output (not Edit/Write/MultiEdit)
+check_empty "Read tool → no output" \
+  '{"tool_name":"Read","tool_input":{"file_path":"backend/apps/users/views.py"}}'
+
+# Missing file_path → no output
+check_empty "missing file_path → no output" \
+  '{"tool_name":"Edit","tool_input":{}}'
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ $FAIL -eq 0 ]

--- a/.claude/hooks/test-kimi-review.sh
+++ b/.claude/hooks/test-kimi-review.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# Tests for kimi-review.sh — run from anywhere.
+# Tests are hermetic: a stub `kimi-review` and `git` are shimmed onto PATH via a
+# temp dir, so no real review is ever invoked and no API key is needed.
+set -uo pipefail
+
+HOOK="$(cd "$(dirname "$0")" && pwd)/kimi-review.sh"
+PASS=0; FAIL=0
+
+# Stub modes mirror kimi-review's real output. KIMI_STUB_MODE controls it:
+#   critical          → a plain [CRITICAL] finding line
+#   critical-bracket  → a bullet+indent decorated [CRITICAL] finding line
+#   critical-bold     → a markdown-bold-wrapped [CRITICAL] finding line
+#   critical-nobody   → a bare [CRITICAL] tag with no finding body
+#   warning           → a [WARNING] finding line
+#   noisy-prose       → lowercase "critical" in prose, no real finding
+#   negative-prose    → the model's "No CRITICAL or WARNING findings" phrasing
+#   clean             → kimi-review's real clean-output message
+make_stub_path() {
+  local mode="$1"
+  local dir
+  dir=$(mktemp -d)
+  cat > "$dir/kimi-review" <<EOF
+#!/usr/bin/env bash
+cat >/dev/null  # consume stdin so the pipe doesn't SIGPIPE
+case "$mode" in
+  critical)         echo "[CRITICAL] backend/apps/foo/views.py:42 — stub finding for tests";;
+  critical-bracket) echo "  - [CRITICAL] backend/apps/foo/views.py:10 — bullet+indent decorated finding";;
+  critical-bold)    echo "**[CRITICAL]** backend/apps/foo/views.py:10 — markdown-bold form";;
+  critical-nobody)  echo "[CRITICAL]";;
+  warning)          echo "[WARNING] backend/apps/foo/views.py:5 — stub finding for tests";;
+  noisy-prose)      echo "no critical issues found in stub run";;
+  negative-prose)   echo "No CRITICAL or WARNING findings";;
+  clean)            echo "No findings in requested tiers: CRITICAL, WARNING";;
+esac
+EOF
+  chmod +x "$dir/kimi-review"
+  cat > "$dir/git" <<'EOF'
+#!/usr/bin/env bash
+case "$* " in
+  "diff --cached --name-only "*) echo "backend/apps/foo/views.py";;
+  "diff --cached "*)              echo "diff --git a/x b/x";;
+  *) exec /usr/bin/env -i PATH="/usr/bin:/bin" git "$@";;
+esac
+EOF
+  chmod +x "$dir/git"
+  printf '%s' "$dir"
+}
+
+run_hook() {
+  local mode="$1" input="$2"
+  local stubdir
+  stubdir=$(make_stub_path "$mode")
+  echo "$input" | PATH="$stubdir:$PATH" bash "$HOOK" 2>/dev/null
+  local rc=$?
+  rm -rf "$stubdir"
+  return $rc
+}
+
+assert_contains() {
+  local name="$1" haystack="$2" needle="$3"
+  if echo "$haystack" | grep -q "$needle"; then
+    echo "PASS: $name"; PASS=$((PASS+1))
+  else
+    echo "FAIL: $name (expected to find: $needle)"
+    echo "  got: $(echo "$haystack" | head -3)"
+    FAIL=$((FAIL+1))
+  fi
+}
+
+assert_not_contains() {
+  local name="$1" haystack="$2" needle="$3"
+  if echo "$haystack" | grep -q "$needle"; then
+    echo "FAIL: $name (expected NOT to find: $needle)"
+    echo "  got: $(echo "$haystack" | head -3)"
+    FAIL=$((FAIL+1))
+  else
+    echo "PASS: $name"; PASS=$((PASS+1))
+  fi
+}
+
+assert_empty() {
+  local name="$1" haystack="$2"
+  if [ -z "$haystack" ]; then
+    echo "PASS: $name"; PASS=$((PASS+1))
+  else
+    echo "FAIL: $name (expected empty output)"
+    echo "  got: $(echo "$haystack" | head -3)"
+    FAIL=$((FAIL+1))
+  fi
+}
+
+# ---------- Command matcher tests ----------
+OUT=$(run_hook clean '{"tool_input":{"command":"git commit -m \"x\""}}')
+assert_contains "git commit matches and emits review JSON" "$OUT" "additionalContext"
+
+OUT=$(run_hook clean '{"tool_input":{"command":"git -c user.name=x commit -m y"}}')
+assert_contains "git -c ... commit matches" "$OUT" "additionalContext"
+
+OUT=$(run_hook clean '{"tool_input":{"command":"GIT_AUTHOR_NAME=foo git commit -m y"}}')
+assert_contains "FOO=bar git commit matches" "$OUT" "additionalContext"
+
+OUT=$(run_hook clean '{"tool_input":{"command":"git commit-graph write"}}')
+assert_empty "git commit-graph does NOT match" "$OUT"
+
+OUT=$(run_hook clean '{"tool_input":{"command":"echo git commit -m x"}}')
+assert_empty "echo git commit does NOT match" "$OUT"
+
+OUT=$(run_hook clean '{"tool_input":{"command":"foo git commit bar"}}')
+assert_empty "substring git commit does NOT match" "$OUT"
+
+OUT=$(run_hook clean '{"tool_input":{"command":"git push origin main"}}')
+assert_empty "git push does NOT match" "$OUT"
+
+# ---------- Skip semantics ----------
+OUT=$(SKIP_KIMI_REVIEW=1 echo '{"tool_input":{"command":"git commit -m x"}}' | bash "$HOOK" 2>/dev/null)
+assert_empty "SKIP_KIMI_REVIEW=1 skips" "$OUT"
+
+EMPTY_DIR=$(mktemp -d)
+OUT=$(echo '{"tool_input":{"command":"git commit -m x"}}' | \
+  PATH="$EMPTY_DIR:/usr/bin:/bin" bash "$HOOK" 2>/dev/null)
+rm -rf "$EMPTY_DIR"
+assert_empty "missing kimi-review skips" "$OUT"
+
+# ---------- Tier handling ----------
+OUT=$(run_hook warning '{"tool_input":{"command":"git commit -m x"}}')
+assert_contains "WARNING emits additionalContext (non-blocking)" "$OUT" "additionalContext"
+assert_not_contains "WARNING does not emit permissionDecision deny" "$OUT" '"permissionDecision": "deny"'
+
+OUT=$(run_hook critical '{"tool_input":{"command":"git commit -m x"}}')
+assert_contains "CRITICAL emits permissionDecision deny" "$OUT" '"permissionDecision": "deny"'
+assert_contains "CRITICAL emits permissionDecisionReason" "$OUT" "permissionDecisionReason"
+
+OUT=$(run_hook critical-bracket '{"tool_input":{"command":"git commit -m x"}}')
+assert_contains "bullet+indent decorated [CRITICAL] blocks" "$OUT" '"permissionDecision": "deny"'
+
+OUT=$(run_hook critical-bold '{"tool_input":{"command":"git commit -m x"}}')
+assert_contains "**[CRITICAL]** markdown-bold form blocks" "$OUT" '"permissionDecision": "deny"'
+
+OUT=$(run_hook critical-nobody '{"tool_input":{"command":"git commit -m x"}}')
+assert_not_contains "bare [CRITICAL] with no body does NOT block" "$OUT" '"permissionDecision": "deny"'
+
+OUT=$(run_hook noisy-prose '{"tool_input":{"command":"git commit -m x"}}')
+assert_not_contains "lowercase 'critical' in prose does NOT block" "$OUT" '"permissionDecision": "deny"'
+assert_contains "noisy-prose still emits additionalContext" "$OUT" "additionalContext"
+
+OUT=$(run_hook clean '{"tool_input":{"command":"git commit -m x"}}')
+assert_not_contains "clean-output message does NOT block" "$OUT" '"permissionDecision": "deny"'
+
+OUT=$(run_hook negative-prose '{"tool_input":{"command":"git commit -m x"}}')
+assert_not_contains "negative phrasing does NOT block" "$OUT" '"permissionDecision": "deny"'
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ $FAIL -eq 0 ]

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,45 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/inject-patterns.sh",
+            "timeout": 10,
+            "statusMessage": "Loading binding rules for this file..."
+          },
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/guard-worktree-isolation.sh",
+            "timeout": 10,
+            "statusMessage": "Checking worktree isolation..."
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/kimi-review.sh",
+            "timeout": 180,
+            "statusMessage": "Running kimi-review on staged changes..."
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "[ -s /tmp/plant-id-deferred.txt ] && python3 -c \"import json; items=open('/tmp/plant-id-deferred.txt').read().strip(); print(json.dumps({'systemMessage': 'Deferred items not yet tracked as todos:\\n' + items + '\\n\\nAsk Claude to create todos for them in todos/'}))\" 2>/dev/null || true",
+            "statusMessage": "Checking for untracked deferred items..."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/audit/SKILL.md
+++ b/.claude/skills/audit/SKILL.md
@@ -1,0 +1,207 @@
+---
+name: audit
+description: Run a structured code audit with manifest tracking, per-fix verification, and pattern codification
+---
+
+# Code Audit
+
+You are running a structured code audit. The scope is: $ARGUMENTS (defaults to
+"full" if empty). Valid scopes: `full`, or a single domain name from the table
+below (e.g. `security`, `performance`, `wagtail`).
+
+This workflow enforces finding tracking, per-fix verification, and a persistent
+audit trail. **Never skip steps.**
+
+## Specialist Agent Mapping
+
+Each audit domain maps to review agents in `.claude/agents/`. Launch them as
+subagents during Phase 2 discovery.
+
+| Audit Domain      | Agent(s)                                                       |
+| ----------------- | -------------------------------------------------------------- |
+| `security`        | `security-reviewer`                                            |
+| `performance`     | `performance-reviewer`                                         |
+| `django-drf`      | `django-drf-reviewer`, `api-design-reviewer`                   |
+| `wagtail`         | `wagtail-reviewer`                                             |
+| `react-typescript`| `react-typescript-reviewer`                                    |
+| `flutter`         | `flutter-dart-reviewer`, `flutter-firebase-reviewer`           |
+| `firebase`        | `firebase-cloudfunction-reviewer`                              |
+| `celery`          | `celery-async-reviewer`                                        |
+| `testing`         | `test-quality-reviewer`                                        |
+
+**`full` scope:** launch every agent above whose domain has changed/relevant
+files. Batch in groups of ~4 to avoid overwhelming context.
+**Named scope:** launch only that domain's agent(s).
+
+**Agent prompt template for discovery:**
+
+```text
+You are auditing the plant_id_community codebase for [DOMAIN] issues.
+
+Scope: [files/modules to focus on, or "full codebase"]
+
+For each finding, report:
+- A concise description of the issue
+- The exact file path and line number(s)
+- Severity: Critical / High / Medium / Low
+- The specific pattern or rule being violated (reference docs/rules/,
+  the relevant */docs/patterns/ doc, or docs/LEARNINGS.md where applicable)
+
+Do NOT fix anything — only report findings. Do NOT report issues already handled
+correctly. Focus on genuinely new issues, not style preferences.
+```
+
+## Phase 1: Setup
+
+1. Record the baseline for the stacks the scope touches:
+   - Backend: `cd backend && python manage.py test --noinput` (note pass count),
+     `python manage.py check`
+   - Web: `cd web && npm run test`, `npm run type-check`, `npm run lint`
+   - Mobile: `cd plant_community_mobile && flutter test`, `flutter analyze`
+2. Check `docs/audits/CHANGELOG.md` for prior findings that may still be relevant.
+3. Create the manifest `docs/audits/YYYY-MM-DD-[scope].md` from `docs/audits/TEMPLATE.md`.
+4. Record the baseline in the manifest header.
+5. Capture the current branch: `git branch --show-current` (fall back to
+   `git rev-parse --abbrev-ref HEAD` on detached HEAD).
+6. Create and enter an audit worktree — all later phases run from it:
+
+   ```bash
+   git worktree add .worktrees/audit-$(date +%Y-%m-%d) HEAD
+   ```
+
+   (or use `EnterWorktree`). After the Phase 7 commit, remove it:
+   `git worktree remove .worktrees/audit-YYYY-MM-DD`.
+
+## Phase 2: Discovery
+
+1. **Launch the specialist agents** for the scope (see mapping table), in
+   parallel batches of ~4, using the discovery prompt template.
+2. As each agent completes, **deduplicate** findings against the previous audit
+   manifest (mark already-fixed items `false-positive`) and against other agents
+   in this run (combine duplicates).
+3. For each genuinely new finding, **verify it in current code** — read the file
+   at the reported line, grep for the flagged pattern. If the code does not match,
+   mark `false-positive` with evidence.
+4. Write all verified findings to the manifest with status `open` and the
+   reporting agent.
+
+## Phase 2.5: Research
+
+Validate Phase 2 findings against current documentation before triage.
+
+1. **Launch `docs-researcher` subagents in parallel** — one per domain that has
+   at least one finding. Skip a domain with zero findings; skip the whole phase
+   if Phase 2 found nothing.
+2. Dispatch prompt per researcher (fill in `[DOMAIN]` and the findings list):
+
+   ```text
+   You are validating audit findings for the [DOMAIN] domain against current
+   library documentation.
+
+   Findings to validate:
+   [paste this domain's findings — for each: ID, description, file:line, the rule cited]
+
+   For EACH finding, check current documentation via Context7
+   (resolve-library-id then query-docs) when the finding hinges on external
+   library/framework behavior. Return exactly one verdict per finding:
+   - confirmed     — current docs agree the finding is valid
+   - better-fix    — real finding, but docs show a cleaner fix; describe it
+   - contradicted  — docs say the flagged pattern is fine; cite the doc
+   - not-applicable — does not hinge on external library behavior (IDOR,
+     missing ownership check, N+1, dead code) — no doc call needed
+
+   Non-`not-applicable` verdicts MUST cite the specific doc (library + section).
+   If you incidentally notice an unmet current-doc best practice in code you
+   already viewed, report it as a NEW finding candidate with file:line + citation.
+   Do NOT fix anything.
+   ```
+
+3. Update each finding's manifest `Research` column: `confirmed` /
+   `better-fix` (record the doc-informed approach) / `contradicted ⚠` (stays
+   `open` — user decides at triage) / `—` for `not-applicable`.
+4. Verify any new finding candidate in current code before adding it to the
+   manifest (same discipline as Phase 2 step 3).
+5. **Show the user the full findings table** and ask which to fix now vs defer,
+   noting that `contradicted ⚠` findings may be false positives.
+
+## Phase 3: Fix (one at a time)
+
+For **each** finding the user wants fixed:
+
+1. Manifest status → `fixing`.
+2. Read the code; make the fix (minimal, surgical — no drive-by improvements).
+3. Run the targeted tests for the affected files; fix until they pass.
+4. **Verify** the fix landed — re-read/grep the changed code; run the specific
+   test file(s).
+5. **kimi-review** the fix from the worktree root:
+
+   ```bash
+   kimi-review --scope "[one-line fix description]" --profile plant_id --rules [domain]
+   ```
+
+   - **CRITICAL**: stop the loop, surface to the user — do not mark `verified`
+     until resolved.
+   - **WARNING**: fix inline when small and in-scope; otherwise record it in the
+     manifest Verification column and create a deferred todo (Phase 4).
+   - **SUGGESTION**: proceed; note in the manifest if worth codifying.
+6. Manifest status → `verified`; Verification column → what you checked.
+
+**Critical rules:** one finding at a time, never batch; never mark `verified`
+without running tests; re-read the file to confirm the change is present.
+
+## Phase 4: Defer
+
+For deferred findings:
+
+1. Create a todo `todos/NNN-pending-pX-slug.md` (next free `NNN`, priority
+   `p1`–`p4`) following `todos/TEMPLATE.md`. If the finding came from a review
+   doc, add `source_review` / `source_finding` frontmatter per the root
+   `CLAUDE.md` "Review Doc Tracking" convention.
+2. Manifest status → `deferred` with a link to the todo.
+3. Record the rationale in the manifest's Deferred Items table.
+4. For straightforward boilerplate/test-only deferred work, `kimi-write` may
+   generate a first pass — review before committing.
+
+## Phase 5: Close
+
+1. Re-run the full baseline suite for the affected stacks — all green.
+2. Update the manifest summary table with final counts.
+3. Append an entry to `docs/audits/CHANGELOG.md` (append-only).
+4. Report the final summary: findings (C/H/M/L), verified, deferred (with
+   todo links), false-positive, open (**must be 0**).
+5. Do not ask about committing yet — proceed to Phase 6.
+
+## Phase 6: Code Review
+
+1. Invoke the `code-review-orchestrator` agent (`.claude/agents/code-review-orchestrator.md`)
+   on the multi-file diff from Phase 3 — it routes changed files to the relevant
+   domain reviewers and deduplicates findings.
+2. CRITICAL / HIGH findings → fix immediately (Phase 3 discipline).
+3. MEDIUM → judgment call; LOW → defer unless a trivial one-liner.
+4. Re-run tests / type checks after any review fixes.
+
+## Phase 7: Commit Fixes
+
+1. Stage all changed files (code fixes + manifest + changelog + new todos).
+2. Commit: `fix: resolve [scope] audit findings ([N] verified, [M] deferred)`.
+3. Per project policy, do not push to `main` — open a PR. Ask the user first.
+
+## Phase 8: Codify
+
+After fixes are committed, extract reusable knowledge. **Run the `codify` skill**
+(`.claude/skills/codify/SKILL.md`) — it routes findings to `docs/rules/<domain>.md`
+(one-line binding rules), the `*/docs/patterns/` libraries (multi-line patterns),
+`docs/LEARNINGS.md` (incidents), and the review agents (new checks). Codify the
+complete Phase 3 picture, including corrections triggered by kimi-review.
+Commit documentation separately: `docs: codify patterns and learnings from [scope] audit`.
+
+## Rules
+
+- **The manifest is the source of truth.** Every finding and status change is in it.
+- **Zero open findings at close** — everything verified, deferred (with todo), or
+  false-positive.
+- **No documentation during the fix phase** — codify only in Phase 8.
+- **kimi-review is not optional** — every Phase 3 fix passes it before `verified`.
+- **Deferred is not dropped** — every deferred item has a todo with priority and
+  rationale.
+- **The changelog is append-only.**

--- a/.claude/skills/codify/SKILL.md
+++ b/.claude/skills/codify/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: codify
+description: Use at the end of any session to extract and preserve patterns, learnings, and review rules discovered during the session's implementation work
+---
+
+# Codify
+
+You are running the codify workflow. Codify patterns, learnings, and agent rules
+from the current branch's implementation work. **Never skip steps.**
+
+## Step 1 — Assess the branch diff
+
+Run:
+
+```bash
+git diff main...HEAD --stat
+```
+
+Build a list of changed-file domains (read top-to-bottom, a path may match
+several rows):
+
+| Changed path matches                                    | Domain label(s)            |
+| -------------------------------------------------------- | -------------------------- |
+| `backend/apps/**/migrations/*`                           | `database`, `security`     |
+| `backend/apps/blog/**`                                   | `wagtail`, `api`           |
+| `backend/apps/**/serializers.py`, `**/api/**`            | `api`                      |
+| `backend/apps/**/views.py`, `**/viewsets.py`, `**/permissions.py` | `api`, `security` |
+| `backend/apps/**/models.py`                              | `database`, `security`     |
+| `backend/apps/**/tasks.py`, `**/celery*`                 | `celery`                   |
+| `backend/apps/**/cache*.py`, `**/signals.py`             | `caching`                  |
+| `backend/**/*.py` (other)                                | `security`                 |
+| `web/src/**/*.tsx`                                       | `react`, `typescript`      |
+| `web/src/**/*.ts`                                        | `typescript`               |
+| `plant_community_mobile/**/*.dart`                       | `flutter`                  |
+| `firebase/**`, `**/firebase*`                            | `firebase`, `security`     |
+| `**/tests/**`, `**/test_*.py`, `**/*.test.ts*`, `**/*.spec.ts*` | `testing`           |
+
+Combine all matched labels. If the diff is empty, output "Nothing to codify —
+no changes on this branch." and stop.
+
+## Step 2 — Run kimi-review on the branch diff
+
+The domain labels from Step 1 double as `docs/rules/` names. Run:
+
+```bash
+git diff main...HEAD | kimi-review --scope "session: $(git branch --show-current)" --profile plant_id --rules <comma-separated-domains>
+```
+
+**Store the full output in working context as `review_output`** — shell variables
+do not persist between Bash invocations. Also union in any kimi-review output that
+already appeared earlier in this session (the PreToolUse commit hook emits it).
+
+## Step 3 — Apply codification criteria
+
+**Codify if any one is true:**
+
+- The diff contains a workaround or constraint not documented in `docs/rules/`,
+  the `*/docs/patterns/` libraries, or `docs/LEARNINGS.md`.
+- The diff reveals a library gotcha or platform-specific behavior.
+- `review_output` contains a CRITICAL or WARNING finding — even if the fix is
+  already in the diff (a finding that required a repair is exactly the kind of
+  rule worth preserving).
+
+**Skip if all are true:**
+
+- The diff is a straightforward application of existing documented patterns.
+- All `review_output` findings are SUGGESTION-only.
+- The only changes are UI text, config values, or copy with no structural lesson.
+
+If nothing qualifies, output "Nothing to codify from this session." and stop.
+
+## Step 4 — Route each candidate
+
+For each codification candidate, pick the destination(s) by **nature of the
+finding**. A single finding may write to more than one target.
+
+| Finding nature                                                  | Destination |
+| ---------------------------------------------------------------- | ----------- |
+| One-line "always do X / never do Y" rule for an existing domain  | append a bullet to `docs/rules/<domain>.md` |
+| A reusable, multi-line pattern (code shape, approach, checklist) | the matching `*/docs/patterns/` doc — see table below |
+| A bug, incident, or hard-won gotcha with a root cause            | append an entry to `docs/LEARNINGS.md` (append-only log) |
+| A new repeatable review check                                   | the relevant review agent — see agent table below |
+
+**Pattern-doc locations** (append a section to the closest existing file; create
+a new file in the right subdirectory only if none fits):
+
+- Backend: `backend/docs/patterns/{security,architecture,domain,performance,api,testing}/`
+- Web: `web/docs/patterns/` (`react-typescript.md`, `tailwind.md`, `testing.md`)
+- Mobile: `plant_community_mobile/docs/patterns/` (`flutter-patterns.md`, `firebase-auth.md`, `riverpod.md`)
+- Firebase: `firebase/docs/patterns/` (`cloud-functions.md`, `firestore-rules.md`, `iam.md`)
+
+**Review-agent update routing** (only when the finding reveals a reusable check):
+
+| Finding domain  | Update agent(s)                                                     |
+| --------------- | ------------------------------------------------------------------- |
+| Security        | `.claude/agents/security-reviewer.md`                               |
+| Performance     | `.claude/agents/performance-reviewer.md`                            |
+| Django / DRF    | `.claude/agents/django-drf-reviewer.md`                             |
+| Wagtail         | `.claude/agents/wagtail-reviewer.md`                                |
+| API design      | `.claude/agents/api-design-reviewer.md`                             |
+| React / TS      | `.claude/agents/react-typescript-reviewer.md`                       |
+| Flutter         | `.claude/agents/flutter-dart-reviewer.md`, `flutter-firebase-reviewer.md` |
+| Firebase fns    | `.claude/agents/firebase-cloudfunction-reviewer.md`                 |
+| Celery / async  | `.claude/agents/celery-async-reviewer.md`                           |
+| Testing         | `.claude/agents/test-quality-reviewer.md`                           |
+
+## Step 5 — Write the codification
+
+- **`docs/rules/<domain>.md`** — append the bullet under the existing list. Keep
+  it one line, imperative, "always/never" phrased. Do not bloat the file; the
+  inject-patterns hook pastes it verbatim before every matching edit.
+- **`*/docs/patterns/` doc** — append a new `## <Pattern name>` section to the
+  closest existing file. Include a short rationale and a minimal code example.
+- **`docs/LEARNINGS.md`** — append a dated entry: what broke, the root cause, and
+  the fix. This file is the append-only incident log — never edit prior entries.
+- **Review agent** — add a checklist bullet (and a "Common Mistakes to Catch"
+  entry if it is a recurring gap).
+
+When unsure how to classify a finding, consult `.claude/agents/pattern-codifier.md`
+— it encodes this project's pattern-routing logic.
+
+## Step 6 — Commit
+
+Stage each file you wrote explicitly — do not `git add` whole directories.
+
+```bash
+git add docs/rules/<domain>.md docs/LEARNINGS.md .claude/agents/<agent>.md
+git commit -m "docs: codify findings from $(git branch --show-current)"
+```
+
+The pre-commit `kimi-review` gate re-runs on the staged diff; resolve any
+CRITICAL finding before the commit lands. Per project policy, never push to
+`main` directly — codification commits ride the feature branch / PR.

--- a/.gitignore
+++ b/.gitignore
@@ -171,10 +171,13 @@ pids/
 # ===================================
 # Development / Reference Materials
 # ===================================
-# Claude Code configuration and tools (ignore contents, not dir itself, so agents/ and skills/ exceptions work)
+# Claude Code configuration and tools (ignore contents, not dir itself, so the exceptions work)
 .claude/*
 !.claude/agents/
 !.claude/skills/
+!.claude/hooks/
+!.claude/settings.json
+# .claude/settings.local.json stays ignored — it holds per-developer overrides
 
 # CLAUDE.md contains project-specific context and may include sensitive info
 # Use CLAUDE.md.example as template

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -209,6 +209,19 @@ repos:
         name: Fix mixed line endings
         args: ['--fix=lf']
 
+  # ===================================
+  # kimi-review staged-diff gate
+  # ===================================
+  - repo: local
+    hooks:
+      - id: kimi-review
+        name: kimi-review staged-diff gate (CRITICAL blocks)
+        entry: bash scripts/kimi-precommit.sh
+        language: system
+        pass_filenames: false
+        always_run: true
+        verbose: true
+
 # ===================================
 # Hook Execution Order
 # ===================================
@@ -217,6 +230,7 @@ repos:
 # 3. Git security checks (large files, merge conflicts, etc.)
 # 4. Code quality (formatting, linting)
 # 5. File cleanup (whitespace, line endings)
+# 6. kimi-review staged-diff gate (CRITICAL blocks; SKIP_KIMI_REVIEW=1 bypasses)
 
 # ===================================
 # Configuration Notes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,6 +156,40 @@ Non-review agents (invoke directly for implementation tasks):
 
 - `wagtail-cms-orchestrator.md` — CMS content, API integration, data flow tracing
 - `frontend-developer.md` — React UI/UX implementation
+- `docs-researcher.md` — validates findings against current library docs (used by `/audit` Phase 2.5)
+
+## Harness Automation
+
+The `.claude/` harness automates rule injection, commit-time review, and
+knowledge capture. It is committed to the repo — `.claude/` changes on `main`
+reach only **new** worktrees; existing worktrees keep their setup until rebased.
+
+### Hooks (`.claude/settings.json` → `.claude/hooks/`)
+
+- **`inject-patterns.sh`** — before every Edit/Write, injects the discipline
+  preamble plus the matching `docs/rules/<domain>.md` checklists.
+- **`kimi-review.sh`** — before a `git commit` Bash call, runs `kimi-review` on
+  the staged diff. A `[CRITICAL]` finding blocks the commit; `WARNING` is
+  surfaced as context. Bypass with `SKIP_KIMI_REVIEW=1`.
+- **`guard-worktree-isolation.sh`** — blocks a worktree session from editing
+  files in the main checkout.
+- Each hook has a `test-*.sh` next to it — run them after editing a hook.
+
+### `docs/rules/` — binding rules
+
+Short, auto-injected "always/never" checklists, one file per domain (`security`,
+`database`, `api`, `caching`, `celery`, `wagtail`, `testing`, `react`,
+`typescript`, `flutter`, `firebase`). Long-form detail stays in the
+`*/docs/patterns/` libraries. `kimi-review --rules <domain>` also loads them.
+
+### Skills
+
+- **`/codify`** — at the end of a session, extracts patterns/learnings/review
+  rules from the branch diff and routes them to `docs/rules/`, the
+  `*/docs/patterns/` libraries, `docs/LEARNINGS.md`, or the review agents.
+- **`/audit [scope]`** — structured 8-phase audit: specialist-agent discovery,
+  doc-research validation, per-fix verification, manifest tracking in
+  `docs/audits/`, code review, and codification.
 
 ## Environment Variables
 
@@ -173,8 +207,9 @@ Non-review agents (invoke directly for implementation tasks):
 
 ## Cheap-Worker Delegation (Kimi K2.6)
 
-Three CLI tools delegate bulk I/O to a cheap worker model (Kimi K2.6 via OpenRouter).
-Claude handles reasoning and architecture; the worker handles token-heavy reading/writing.
+Five CLI tools delegate bulk I/O and review to a cheap worker model (Kimi K2.6
+via OpenRouter). Claude handles reasoning and architecture; the worker handles
+token-heavy reading/writing and first-pass review.
 
 ### ask-kimi — bulk file reading
 
@@ -208,6 +243,28 @@ extract-chat <session.jsonl> -o /tmp/chat.txt
 ```
 
 Use before post-session doc updates: extract → ask-kimi to suggest changes → apply with Edit.
+
+### kimi-review — staged-diff code review
+
+Runs automatically as a commit gate (the `kimi-review.sh` hook and the
+`kimi-review` pre-commit hook). A `[CRITICAL]` finding blocks the commit;
+`WARNING` is surfaced but does not block. Bypass with `SKIP_KIMI_REVIEW=1`.
+Run it manually after a new component/viewset/migration:
+
+```bash
+kimi-review --base main --profile plant_id --rules <domain> --tiers CRITICAL,WARNING
+```
+
+### kimi-challenge — adversarial design review
+
+Before committing to an architectural decision or choosing between two
+approaches, pressure-test it:
+
+```bash
+kimi-challenge --decision "<the approach>" --paths <relevant-files>
+```
+
+Claude still makes the final call — kimi-challenge surfaces the weaknesses.
 
 ### Delegation rules
 

--- a/docs/audits/CHANGELOG.md
+++ b/docs/audits/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Audit Changelog
+
+Append-only history of all code audits performed on this project. Each entry
+links to the full audit manifest with detailed findings and resolutions.
+
+## Format
+
+```text
+### YYYY-MM-DD — Audit Title
+- **Trigger:** Why the audit was run
+- **Manifest:** [link to manifest file]
+- **Findings:** X critical, Y high, Z medium, W low
+- **Resolved:** N fixed, M deferred, P false-positive
+- **Commit(s):** git SHA(s) of fix commits
+```
+
+---
+
+_No audits recorded yet. The first `/audit` run appends its entry here._

--- a/docs/audits/TEMPLATE.md
+++ b/docs/audits/TEMPLATE.md
@@ -1,0 +1,81 @@
+# Audit: [TITLE]
+
+> **Date:** YYYY-MM-DD
+> **Trigger:** [Why this audit was run]
+> **Domains:** [security, performance, django-drf, wagtail, react-typescript, flutter, firebase, celery, testing]
+> **Baseline:** X tests passing | Y type errors | Z lint errors
+
+## Findings
+
+Each finding has a lifecycle: `open` → `fixing` → `verified` or `deferred` or `false-positive`.
+
+**Status key:**
+
+- `open` — Found but not yet addressed
+- `fixing` — Work in progress
+- `verified` — Fix applied AND confirmed by test/grep/type-check
+- `deferred` — Intentionally postponed (must link to todo)
+- `false-positive` — Agent was wrong or issue was already fixed
+
+**Research key** (Phase 2.5 verdict, recorded in the `Research` column):
+
+- `confirmed` — current documentation agrees the finding is valid
+- `better-fix` — finding is real, but current docs show a cleaner fix (described in the `Verification` column for Phase 3 to use)
+- `contradicted ⚠` — current docs say the flagged pattern is fine; may be a false positive — decide at triage
+- `—` — research not applicable, or finding predates Phase 2.5
+
+### Critical
+
+| ID  | Finding       | Domain | Agent                 | File(s)     | Research | Status | Verification |
+| --- | ------------- | ------ | --------------------- | ----------- | -------- | ------ | ------------ |
+| C1  | [description] | —      | [agent that found it] | `path:line` | —        | open   | —            |
+
+### High
+
+| ID  | Finding       | Domain | Agent                 | File(s)     | Research | Status | Verification |
+| --- | ------------- | ------ | --------------------- | ----------- | -------- | ------ | ------------ |
+| H1  | [description] | —      | [agent that found it] | `path:line` | —        | open   | —            |
+
+### Medium
+
+| ID  | Finding       | Domain | Agent                 | File(s)     | Research | Status | Verification |
+| --- | ------------- | ------ | --------------------- | ----------- | -------- | ------ | ------------ |
+| M1  | [description] | —      | [agent that found it] | `path:line` | —        | open   | —            |
+
+### Low
+
+| ID  | Finding       | Domain | Agent                 | File(s)     | Research | Status | Verification |
+| --- | ------------- | ------ | --------------------- | ----------- | -------- | ------ | ------------ |
+| L1  | [description] | —      | [agent that found it] | `path:line` | —        | open   | —            |
+
+## Deferred Items
+
+Items marked `deferred` must have a linked todo and rationale.
+
+| ID  | Todo | Rationale |
+| --- | ---- | --------- |
+| —   | —    | —         |
+
+## Summary
+
+| Severity  | Found | Verified | Deferred | False-positive | Open  |
+| --------- | ----- | -------- | -------- | -------------- | ----- |
+| Critical  | 0     | 0        | 0        | 0              | 0     |
+| High      | 0     | 0        | 0        | 0              | 0     |
+| Medium    | 0     | 0        | 0        | 0              | 0     |
+| Low       | 0     | 0        | 0        | 0              | 0     |
+| **Total** | 0     | 0        | 0        | 0              | **0** |
+
+## Fix Commits
+
+| Commit | Description |
+| ------ | ----------- |
+| —      | —           |
+
+## Codification (Phase 8)
+
+Completed after fixes are committed. Each row links to the docs change.
+
+| Finding | Destination | Note |
+| ------- | ----------- | ---- |
+| —       | `docs/rules/<domain>.md` / `*/docs/patterns/...` / `docs/LEARNINGS.md` / agent | — |

--- a/docs/rules/api.md
+++ b/docs/rules/api.md
@@ -1,0 +1,16 @@
+# API & DRF — binding rules
+
+Compact checklist auto-injected before edits. Long-form:
+`backend/docs/patterns/architecture/viewsets.md`, `.../rate-limiting.md`.
+
+- **`get_permissions()` overrides MUST call `super()`** so `@action`-level
+  `permission_classes` still apply. This is a recurring security hole.
+- **Rate limiting returns 429, not 403.** `django-ratelimit`'s `Ratelimited`
+  subclasses `PermissionDenied`, so DRF emits 403 by default. A custom exception
+  handler must check `isinstance(exc, Ratelimited)` and return 429 + `Retry-After`.
+- **Type-hint service methods** — params and return types on anything in a
+  service layer or called across app boundaries.
+- **Bracketed log prefixes** — `logger.info("[CACHE] ...")`, `[AUTH]`, `[PLANT_ID]`
+  — so logs are greppable by subsystem.
+- Serializer field changes are API-contract changes — version or document them.
+- Validate at the boundary (request data); trust internal calls.

--- a/docs/rules/caching.md
+++ b/docs/rules/caching.md
@@ -1,0 +1,14 @@
+# Caching — binding rules
+
+Compact checklist auto-injected before edits. Long-form:
+`backend/docs/patterns/architecture/caching.md`.
+
+- **Redis is required** (port 6379) — caching and distributed locks depend on it.
+- **Invalidate on write.** Any signal/handler that changes cached data must clear
+  both the individual-object key and any list keys that include it.
+- **Cache-key isolation** — keys include every input that changes the result
+  (user/tenant id, filters, page). Never let one user read another's cached data.
+- **`isinstance()` checks in signals**, not `hasattr()` — multi-table inheritance
+  (Wagtail pages) makes `hasattr` match unintended subclasses.
+- Log cache operations with the `[CACHE]` prefix (`HIT`/`MISS`/`DELETE`).
+- Set explicit TTLs; never cache without expiry.

--- a/docs/rules/celery.md
+++ b/docs/rules/celery.md
@@ -1,0 +1,13 @@
+# Celery & async tasks — binding rules
+
+Compact checklist auto-injected before edits. Long-form:
+`backend/docs/patterns/domain/celery.md`.
+
+- **Every task declares retry config** — `autoretry_for`, `retry_backoff`,
+  `max_retries`. Never leave a network-touching task with default (no) retries.
+- **Tasks are idempotent** — safe to run twice. Guard side effects with a
+  dedup key or status check.
+- **Pass IDs, not ORM objects**, as task args — objects serialize stale.
+- **No secrets in task args** — they are logged by the broker.
+- Beat schedules live in config, not scattered across modules.
+- Bracketed log prefix per task domain so worker logs stay greppable.

--- a/docs/rules/database.md
+++ b/docs/rules/database.md
@@ -1,0 +1,17 @@
+# Database & migrations — binding rules
+
+Compact checklist auto-injected before edits. Long-form:
+`backend/docs/patterns/performance/query-optimization.md`.
+
+- **Never f-string identifiers into raw SQL.** Use `psycopg2.sql.Identifier()`
+  with an explicit whitelist of allowed table/column names in a migration `RunSQL`.
+- **Eliminate N+1 queries** — use `select_related()` (FK/one-to-one) and
+  `prefetch_related()` (M2M/reverse FK) on querysets that feed serializers.
+- **Pin query counts in tests** with `assertNumQueries(...)` — exact, not `<=`.
+- **Add GIN indexes** for `__icontains` / full-text search columns; plain B-tree
+  indexes do not accelerate substring search.
+- **Migrations must be reversible** where practical; data migrations get an
+  explicit reverse or `migrations.RunPython.noop`.
+- After changing a migration, rebuild the test DB with `--noinput` — a stale test
+  DB raises `FieldError`.
+- No magic numbers — domain constants live in each app's `constants.py`.

--- a/docs/rules/firebase.md
+++ b/docs/rules/firebase.md
@@ -1,0 +1,16 @@
+# Firebase — binding rules
+
+Compact checklist auto-injected before edits. Long-form:
+`plant_community_mobile/docs/patterns/firebase-auth.md`,
+`firebase/docs/patterns/`.
+
+- **Firebase auth → Django JWT exchange**: the Firebase ID token is exchanged
+  for a Django JWT; backend verifies the Firebase token server-side.
+- **Redact PII from logs** — emails and tokens are GDPR-sensitive; never log them
+  raw on the auth path.
+- **Cloud Functions are idempotent** — guard against duplicate event delivery;
+  minimize cold-start work (lazy-init heavy clients).
+- **Firestore security rules deny by default** — every collection has explicit
+  read/write rules scoped to the owner.
+- IAM follows least privilege — no broad `Editor`/`Owner` service accounts.
+- Secrets via Secret Manager / env, never committed to the repo.

--- a/docs/rules/flutter.md
+++ b/docs/rules/flutter.md
@@ -1,0 +1,16 @@
+# Flutter (mobile) — binding rules
+
+Compact checklist auto-injected before edits. Long-form:
+`plant_community_mobile/docs/patterns/flutter-patterns.md`, `.../riverpod.md`.
+
+- **Riverpod 3.x `Notifier`/`AsyncNotifier`** — not the legacy `StateNotifier`.
+- **Cancel `StreamSubscription`s** in the provider's `ref.onDispose` /
+  `dispose()` — uncancelled streams leak and fire after disposal.
+- **Material 3** — use `Color.withValues(alpha: ...)`, not the deprecated
+  `withOpacity()`.
+- **Check dark mode** — read `Theme.of(context).brightness`; never hardcode
+  light-only colors.
+- **Secrets in `flutter_secure_storage`**, never `SharedPreferences`.
+- `go_router` redirects guard on auth state; gate debug-only routes with
+  `kDebugMode`.
+- Null safety: no `!` force-unwrap on values that can genuinely be null.

--- a/docs/rules/react.md
+++ b/docs/rules/react.md
@@ -1,0 +1,14 @@
+# React (web) — binding rules
+
+Compact checklist auto-injected before edits. Long-form:
+`web/docs/patterns/react-typescript.md`, `.../tailwind.md`.
+
+- **Import router hooks from `react-router-dom`, never `react-router`.**
+  `import { useNavigate } from 'react-router'` is a silent runtime failure
+  (`Cannot read properties of undefined`).
+- **Debounce/timer IDs go in `useRef`, not `useState`.** `useState` re-renders on
+  every update, recreates the callback, and leaks the timer on unmount.
+- **Sanitize HTML with DOMPurify** before any `dangerouslySetInnerHTML`.
+- **Send CSRF headers** on state-changing requests (`X-CSRFToken`).
+- Clean up effects — abort fetches, clear timers, remove listeners on unmount.
+- Tailwind CSS 4 conventions; no hardcoded hex colors where a token exists.

--- a/docs/rules/security.md
+++ b/docs/rules/security.md
@@ -1,0 +1,19 @@
+# Security — binding rules
+
+Compact checklist auto-injected before edits. Long-form: `backend/docs/patterns/security/`.
+
+- **ViewSet `get_permissions()` MUST call `super().get_permissions()`** for custom
+  `@action` endpoints. Overriding without `super()` silently drops action-level
+  `permission_classes` — a real auth hole. See `architecture/viewsets.md`.
+- **Never f-string table/column names into raw SQL** (migrations included). Use
+  `psycopg2.sql.Identifier()` plus an explicit whitelist of allowed names.
+- **Escape SQL `LIKE` wildcards** (`%`, `_`, `\`) in user-supplied search terms
+  before passing to `__icontains`/`__contains` queries.
+- **File uploads: all 4 validation layers** — extension, MIME type, size, and a
+  PIL/Pillow decode check. Never trust the client-sent content type alone.
+- **No secrets in code, logs, or commits.** API keys and `SECRET_KEY` come from
+  `.env`. `SECRET_KEY` must be ≥50 chars and must not contain `django-insecure`.
+- **Sanitize all rendered HTML** with DOMPurify (web) before injecting; never
+  `dangerouslySetInnerHTML` with unsanitized content.
+- **Auth-sensitive code is never delegated** to the cheap worker — review by hand.
+- Redact PII (emails, tokens) from logs; GDPR redaction applies to Firebase auth.

--- a/docs/rules/testing.md
+++ b/docs/rules/testing.md
@@ -1,0 +1,14 @@
+# Testing — binding rules
+
+Compact checklist auto-injected before edits.
+
+- **Never mock the database.** Tests hit a real test DB so migrations and ORM
+  behavior are exercised. Mocked DB tests hide broken migrations.
+- **Strict assertions** — `assertEqual`/`assertNumQueries(exact)`, not `assertTrue`
+  or `<=` bounds. A test that can't fail isn't a test.
+- **Rebuild a stale test DB** with `--noinput` after migration changes
+  (`python manage.py test apps.foo --noinput`) — otherwise `FieldError`.
+- **Test the golden path AND edge cases** — invalid input, auth failures,
+  empty results, boundary values.
+- Pin query counts on any endpoint touched by a performance change.
+- Web: Vitest for units, Playwright for e2e. Mobile: `flutter test`.

--- a/docs/rules/typescript.md
+++ b/docs/rules/typescript.md
@@ -1,0 +1,11 @@
+# TypeScript (web) — binding rules
+
+Compact checklist auto-injected before edits. Long-form:
+`web/docs/patterns/react-typescript.md`.
+
+- **Strict mode holds** — no `any`. Use `unknown` + a type guard, or a precise type.
+- **`.ts`/`.tsx` only** — no plain `.js`/`.jsx` source files.
+- **Type API responses** at the fetch boundary; do not pass `any` inward.
+- Prefer discriminated unions over optional-field soup for variant data.
+- Narrow with type guards, not casts (`as`). Casts hide real shape mismatches.
+- Keep shared types in one module; don't redeclare the same shape per file.

--- a/docs/rules/wagtail.md
+++ b/docs/rules/wagtail.md
@@ -1,0 +1,14 @@
+# Wagtail CMS — binding rules
+
+Compact checklist auto-injected before edits. Long-form:
+`backend/docs/patterns/domain/wagtail.md`, `.../domain/blog.md`.
+
+- **Wagtail admin is at `/cms/`, not `/admin/`.**
+- **Signal handlers use `isinstance(instance, BlogPostPage)`**, never `hasattr` —
+  multi-table inheritance makes `hasattr` match unintended page types.
+- **StreamField blocks need matching frontend handling** — every new block type
+  added to a model must get a case in the React `StreamFieldRenderer`.
+- **Prefetch related pages** (`related_posts`, etc.) in the API queryset to avoid
+  N+1 and empty results.
+- Cache-invalidation signals must cover `page_published` AND `page_unpublished`.
+- Verify the Wagtail API v2 serializes new fields before wiring the frontend.

--- a/scripts/kimi-precommit.sh
+++ b/scripts/kimi-precommit.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Pre-commit kimi-review gate over the staged diff.
+# CRITICAL findings block the commit; WARNING findings print but do not block.
+#
+# Bypass:    SKIP_KIMI_REVIEW=1 git commit ...
+# Auto-skips when kimi-review is not on PATH (devs without the tool aren't blocked),
+# on timeout, or when the kimi-review run itself fails — the gate fails open so a
+# tooling problem never blocks an otherwise-valid commit. The CRITICAL check runs
+# BEFORE the exit-status checks so a crash-after-detection still blocks.
+
+set -uo pipefail
+
+[ "${SKIP_KIMI_REVIEW:-}" = "1" ] && exit 0
+command -v kimi-review >/dev/null 2>&1 || exit 0
+
+REVIEW_DIFF=$(git diff --cached)
+[ -n "$REVIEW_DIFF" ] || exit 0
+
+if command -v timeout >/dev/null 2>&1; then
+  TIMEOUT_CMD="timeout 150"
+elif command -v gtimeout >/dev/null 2>&1; then
+  TIMEOUT_CMD="gtimeout 150"
+else
+  TIMEOUT_CMD=""
+fi
+
+REVIEW_RAW=$(printf '%s' "$REVIEW_DIFF" | NO_COLOR=1 $TIMEOUT_CMD kimi-review \
+  --scope "pre-commit staged diff" \
+  --tiers CRITICAL,WARNING \
+  --profile plant_id 2>&1)
+REVIEW_STATUS=$?
+# Strip ANSI escape codes so the CRITICAL gate isn't bypassed by colored output.
+REVIEW_OUTPUT=$(printf '%s' "$REVIEW_RAW" | sed $'s/\x1b\\[[0-9;]*m//g')
+
+printf '%s\n' "$REVIEW_OUTPUT"
+
+# CRITICAL check first — kimi-review may print findings and still exit non-zero.
+# Match the bracketed [CRITICAL] tag followed by a finding body; the negative
+# phrasing and clean-output message carry the bare word but never the tag.
+if printf '%s\n' "$REVIEW_OUTPUT" | grep -Eq '[[]CRITICAL[]].*[^[:space:]]'; then
+  echo "" >&2
+  echo "Commit blocked: kimi-review reported CRITICAL findings above." >&2
+  echo "Fix the issues or set SKIP_KIMI_REVIEW=1 to bypass." >&2
+  exit 1
+fi
+
+if [ $REVIEW_STATUS -eq 124 ]; then
+  echo "kimi-review timed out; skipping gate." >&2
+  exit 0
+fi
+
+if [ $REVIEW_STATUS -ne 0 ]; then
+  echo "kimi-review failed to run (exit $REVIEW_STATUS); skipping gate." >&2
+  exit 0
+fi

--- a/todos/077-pending-p4-inject-patterns-spill-race.md
+++ b/todos/077-pending-p4-inject-patterns-spill-race.md
@@ -1,0 +1,58 @@
+---
+status: pending
+priority: p4
+issue_id: "077"
+tags: [harness, hooks]
+dependencies: []
+---
+
+# inject-patterns.sh spill file uses a fixed shared path
+
+## Problem
+
+`.claude/hooks/inject-patterns.sh` writes rule-injection overflow to a fixed
+path, `/tmp/plant-id-injection-context.md`. Two hook invocations running
+concurrently can overwrite each other's spill file, so the agent could read the
+wrong or partial rule context.
+
+## Findings
+
+- Surfaced by the `kimi-review` PreToolUse gate during commit `da3e6da`
+  (WARNING tier, non-blocking).
+- `.claude/hooks/inject-patterns.sh` — `SPILL_FILE="/tmp/plant-id-injection-context.md"`
+  (fixed path, near the `THRESHOLD=9000` block).
+- Faithful port of OCRecipes' original design (same fixed-path behavior).
+- Real-world risk is low: a single Claude session edits sequentially, and the
+  spill path only triggers when injected rules exceed ~9 KB (multi-domain edits).
+
+## Recommended Action
+
+1. Give the spill file a per-invocation suffix, e.g. `/tmp/plant-id-injection-context.$$.md`
+   (`$$` = PID), or `mktemp` with a stable prefix.
+2. Update the truncation notice line so it points at the actual path written.
+3. Update `.claude/hooks/test-inject-patterns.sh` — `SPILL_FILE` is currently a
+   fixed constant in the test; switch it to glob/discover the per-PID file or
+   assert on the truncation-notice path emitted in stdout.
+4. Run `bash .claude/hooks/test-inject-patterns.sh` — all tests pass.
+
+## Technical Details
+
+- Hook: `.claude/hooks/inject-patterns.sh` (spill block)
+- Test: `.claude/hooks/test-inject-patterns.sh` (`SPILL_FILE` constant)
+
+## Acceptance Criteria
+
+- [ ] Spill file path is unique per hook invocation.
+- [ ] The truncation notice points at the path actually written.
+- [ ] `test-inject-patterns.sh` passes against the new path scheme.
+
+## Work Log
+
+### 2026-05-17 - Created
+
+- Filed from the kimi-review WARNING on commit `da3e6da` (OCRecipes harness port).
+
+## Notes
+
+p4 — correctness nicety, not a live bug. Single-session edits are sequential and
+the spill path is rarely reached. Bundle with other harness polish if convenient.

--- a/todos/078-pending-p4-wire-deferred-item-capture.md
+++ b/todos/078-pending-p4-wire-deferred-item-capture.md
@@ -1,0 +1,73 @@
+---
+status: pending
+priority: p4
+issue_id: "078"
+tags: [harness, hooks, skills]
+dependencies: []
+---
+
+# Stop hook checks a deferred-items file that nothing writes
+
+## Problem
+
+`.claude/settings.json` registers a `Stop` hook that reads
+`/tmp/plant-id-deferred.txt` and reminds the user about deferred items not yet
+tracked as todos. No code path ever writes that file, so the hook is currently
+dead plumbing.
+
+## Findings
+
+- `.claude/settings.json` — `Stop` hook greps `/tmp/plant-id-deferred.txt`.
+- Ported from OCRecipes, where the audit/work flow appends to its deferred file.
+- The `audit` skill's Phase 4 and the `codify` skill route deferred work into
+  `todos/` files directly — neither writes the `/tmp` capture file.
+
+## Proposed Solutions
+
+### Option 1: Wire the skills to append (Recommended)
+
+- **Implementation:** When the `audit` or `codify` skill identifies a deferral
+  it does not immediately file as a todo, append a one-line entry to
+  `/tmp/plant-id-deferred.txt`. The Stop hook then nudges the user at session end.
+- **Pros:** Makes the hook functional; matches OCRecipes' "create todos inline,
+  don't drop deferrals" intent.
+- **Cons:** Adds a step to two skill docs.
+- **Effort:** ~30 min
+- **Risk:** low
+
+### Option 2: Remove the Stop hook
+
+- Drop the `Stop` block from `.claude/settings.json` entirely if deferred items
+  are always filed as todos immediately and a `/tmp` reminder adds no value.
+
+## Recommended Action
+
+1. Decide between Option 1 (wire it up) and Option 2 (remove the hook).
+2. If Option 1: add an "append to `/tmp/plant-id-deferred.txt`" step to the
+   `audit` skill Phase 4 and the `codify` skill Step 5, for deferrals not
+   immediately turned into a `todos/` file.
+3. If Option 2: delete the `Stop` block from `.claude/settings.json`.
+
+## Technical Details
+
+- `.claude/settings.json` — `Stop` hook block
+- `.claude/skills/audit/SKILL.md` — Phase 4 (Defer)
+- `.claude/skills/codify/SKILL.md` — Step 5
+
+## Acceptance Criteria
+
+- [ ] Either the deferred file is written by a real code path, or the Stop hook
+      is removed.
+- [ ] `.claude/settings.json` remains valid JSON.
+
+## Work Log
+
+### 2026-05-17 - Created
+
+- Filed during the OCRecipes harness port (commit `da3e6da`); the Stop hook was
+  ported but its writer was not.
+
+## Notes
+
+p4 — opt-in convenience plumbing, no functional regression. The harness works
+fully without it; this just decides whether to finish or drop the feature.


### PR DESCRIPTION
## Summary
Ports the Claude Code harness from OCRecipes, adapted to this repo's stack:
- `.claude/hooks/`: inject-patterns, kimi-review (CRITICAL-blocks commits), guard-worktree-isolation (+ tests)
- `.claude/settings.json` wiring; `docs/rules/` binding-rule layer (11 files)
- `/codify` + `/audit` skills, `docs-researcher` agent, `docs/audits/` scaffolding
- pre-commit kimi-review gate; CLAUDE.md documents it

🤖 Generated with [Claude Code](https://claude.com/claude-code)