### PR TITLE
ci: add kimi-review PR gate (server-side code review)

### DIFF
--- a/.github/workflows/kimi-review.yml
+++ b/.github/workflows/kimi-review.yml
@@ -1,0 +1,57 @@
+name: kimi-review
+
+# Server-side code-review gate. Runs the vendored kimi-review CLI over each PR
+# diff; a [CRITICAL] finding fails the check so branch protection blocks the
+# merge. Unlike the local pre-commit hook, this runs for every contributor
+# regardless of whether they have the kimi-review CLI installed.
+
+on:
+  pull_request:
+    branches: [main]
+
+# A newer push to the same PR cancels an in-flight review run.
+concurrency:
+  group: kimi-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  kimi-review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          # Full history so the base..HEAD diff can be computed.
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
+
+      - name: Install kimi-review dependencies
+        run: pip install --quiet openai
+
+      - name: Run kimi-review on the PR diff
+        env:
+          # kimi-review reads WORKER_API_KEY or OPENROUTER_API_KEY.
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+        run: |
+          if [ -z "$OPENROUTER_API_KEY" ]; then
+            echo "::warning::OPENROUTER_API_KEY secret is not set — kimi-review gate skipped."
+            exit 0
+          fi
+
+          REVIEW=$(git diff "${{ github.event.pull_request.base.sha }}...HEAD" \
+            | python3 scripts/kimi-review \
+                --scope "PR #${{ github.event.pull_request.number }}" \
+                --profile plant_id \
+                --tiers CRITICAL,WARNING 2>&1)
+          echo "$REVIEW"
+
+          # Block only on a bracketed [CRITICAL] finding with a body. The
+          # clean-output and "no findings" messages contain the bare word but
+          # never the tag. WARNING findings are reported but do not fail.
+          if printf '%s\n' "$REVIEW" | grep -Eq '[[]CRITICAL[]].*[^[:space:]]'; then
+            echo "::error::kimi-review reported CRITICAL finding(s) — see the log above."
+            exit 1
+          fi
+          echo "kimi-review: no CRITICAL findings."

--- a/scripts/kimi-review
+++ b/scripts/kimi-review
@@ -1,0 +1,310 @@
+#!/usr/bin/env python3
+"""Delegate code review to Kimi. Returns CRITICAL / WARNING / SUGGESTION findings."""
+import argparse, os, sys, pathlib, subprocess
+from openai import OpenAI
+
+client = OpenAI(
+    api_key=os.environ.get("WORKER_API_KEY", os.environ.get("OPENROUTER_API_KEY", "")),
+    base_url=os.environ.get("WORKER_BASE_URL", "https://openrouter.ai/api/v1"),
+    timeout=90.0,
+)
+
+TIER_DEFINITIONS = {
+    "CRITICAL": "bugs, security holes, data loss risks, broken logic",
+    "WARNING": "performance issues, bad patterns, missing error handling",
+    "SUGGESTION": "style, readability, minor improvements",
+}
+
+PROJECT_PROFILES = {
+    "generic": "",
+    "ocrecipes": """
+Project profile: OCRecipes (Expo/React Native + Express/Drizzle/PostgreSQL nutrition app).
+
+Review priorities:
+- Auth/security: Bearer JWT auth only; flag missing ownership/userId checks, IDOR risks, token leaks, secret exposure, unsafe admin paths.
+- Health/nutrition data: flag cross-user data access, unsafe medical/nutrition advice paths, and changes that could corrupt logs, meal plans, receipts, pantry, or IAP state.
+- API/backend: Express route handlers should use existing error/auth patterns; Drizzle queries should preserve transactions, soft-delete/ownership filters, and JSONB safety.
+- Client: React Native/Expo code should follow existing navigation, safe-area, accessibility, TanStack Query, and theme patterns; flag web-only assumptions.
+- AI/evals: prompt, classifier, and eval changes should preserve safety/accuracy gates, cache-key isolation, deterministic behavior where intended, and avoid prompt-injection regressions.
+- Tests: flag missing focused tests only when the diff changes shared behavior, security boundaries, storage contracts, navigation flows, or AI routing/eval semantics.
+""".strip(),
+    "plant_id": """
+Project profile: Plant ID Community (Django/Wagtail + DRF backend, React/TypeScript web, Flutter mobile, Firebase).
+
+Review priorities:
+- Auth/permissions: DRF `get_permissions()` overrides MUST call `super().get_permissions()` or action-level `permission_classes` are silently dropped — flag any override that does not. JWT auth + Firebase token exchange; flag missing ownership checks, IDOR risks, token/secret exposure.
+- Migrations/SQL: never f-string table/column names into raw SQL — require `psycopg2.sql.Identifier()` + a whitelist. Escape SQL LIKE wildcards in user-supplied search terms.
+- Rate limiting: `django-ratelimit`'s `Ratelimited` subclasses `PermissionDenied`, so it returns 403 by default — flag rate-limit paths that don't route through the custom handler for an RFC-compliant 429 + Retry-After.
+- Performance: flag N+1 queries (missing `select_related`/`prefetch_related`), missing `assertNumQueries`, and `__icontains` search without a GIN index.
+- Wagtail: signal handlers must use `isinstance(instance, BlogPostPage)`, not `hasattr` (multi-table inheritance); new StreamField blocks need matching React `StreamFieldRenderer` cases.
+- React/TypeScript: router hooks import from `react-router-dom` not `react-router`; debounce/timer IDs use `useRef` not `useState`; HTML rendered via DOMPurify; no `any`.
+- Flutter: Riverpod 3.x `Notifier`; cancel `StreamSubscription`s on dispose; Material 3 `withValues()`; secrets in `flutter_secure_storage`.
+- File uploads: require all 4 validation layers (extension, MIME, size, PIL decode).
+- Tests: flag mocked databases and weak assertions; tests must hit a real test DB with strict (exact) assertions.
+""".strip(),
+}
+
+p = argparse.ArgumentParser(description="Code review via Kimi")
+p.add_argument("--base", default=None,
+               help="Branch or commit to diff against (default: HEAD~1; ignored if stdin piped)")
+p.add_argument("--scope", default=None, help="One-line context for the reviewer")
+p.add_argument("--paths", nargs="+", help="Files to include as full content for context")
+p.add_argument(
+    "--patterns",
+    default=None,
+    help="Comma-separated docs/patterns names or paths to include as review context (e.g. security,api or docs/patterns/security.md)",
+)
+p.add_argument(
+    "--pattern-max-chars",
+    type=int,
+    default=0,
+    help="Maximum characters to include from each pattern file; 0 for full files (default: 0 = full files)",
+)
+p.add_argument("--max-tokens", type=int, default=131072,
+               help="Total token budget (reasoning + output)")
+p.add_argument("--model", default=os.environ.get("WORKER_MODEL", "deepseek/deepseek-v4-flash"))
+p.add_argument(
+    "--tiers",
+    default="CRITICAL,WARNING,SUGGESTION",
+    help="Comma-separated finding tiers to request and return (default: CRITICAL,WARNING,SUGGESTION)",
+)
+p.add_argument(
+    "--rules",
+    default=None,
+    help="Comma-separated docs/rules names to include as compact checklists (e.g. security,accessibility). "
+         "Loaded without truncation. Missing files are silently skipped.",
+)
+p.add_argument(
+    "--profile",
+    choices=["auto", "generic", "ocrecipes", "plant_id"],
+    default="auto",
+    help="Project review profile to apply (default: auto)",
+)
+args = p.parse_args()
+
+requested_tiers = [tier.strip().upper() for tier in args.tiers.split(",") if tier.strip()]
+invalid_tiers = [tier for tier in requested_tiers if tier not in TIER_DEFINITIONS]
+if invalid_tiers:
+    print(
+        "Error: invalid --tiers value(s): "
+        + ", ".join(invalid_tiers)
+        + ". Valid tiers: "
+        + ", ".join(TIER_DEFINITIONS),
+        file=sys.stderr,
+    )
+    sys.exit(2)
+if not requested_tiers:
+    print("Error: --tiers must include at least one tier.", file=sys.stderr)
+    sys.exit(2)
+
+# Get the diff: stdin takes priority (only if it actually has content),
+# then --base, then HEAD~1 fallback
+root_result = subprocess.run(
+    ["git", "rev-parse", "--show-toplevel"],
+    capture_output=True, text=True,
+)
+git_root = root_result.stdout.strip() if root_result.returncode == 0 else None
+
+stdin_data = sys.stdin.read() if not sys.stdin.isatty() else ""
+if stdin_data.strip():
+    diff = stdin_data
+else:
+    if not git_root:
+        print("Error: not inside a git repository.", file=sys.stderr)
+        sys.exit(1)
+
+    ref = f"{args.base}..HEAD" if args.base else "HEAD~1"
+    result = subprocess.run(
+        ["git", "diff", ref],
+        capture_output=True, text=True, cwd=git_root,
+    )
+    if result.returncode != 0:
+        print(
+            f"Error: git diff failed — are you in a git repository?\n{result.stderr.strip()}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    diff = result.stdout
+    if not diff.strip():
+        print(f"Error: git diff {ref} produced no output — nothing to review.", file=sys.stderr)
+        sys.exit(1)
+
+if args.profile == "auto":
+    profile = "generic"
+    if git_root:
+        root_path = pathlib.Path(git_root)
+        claude_md = root_path / "CLAUDE.md"
+        claude_md_head = (
+            claude_md.read_text(errors="replace")[:2000] if claude_md.exists() else ""
+        )
+        if root_path.name == "OCRecipes" or "OCRecipes" in claude_md_head:
+            profile = "ocrecipes"
+        elif root_path.name == "plant_id_community" or "Plant ID Community" in claude_md_head:
+            profile = "plant_id"
+else:
+    profile = args.profile
+
+def resolve_pattern_path(pattern, git_root):
+    candidate = pathlib.Path(pattern)
+    if candidate.suffix == "":
+        candidate = pathlib.Path("docs") / "patterns" / f"{pattern}.md"
+    elif candidate.parts[:2] != ("docs", "patterns") and len(candidate.parts) == 1:
+        candidate = pathlib.Path("docs") / "patterns" / candidate.name
+
+    if candidate.is_absolute():
+        return candidate
+    base = pathlib.Path(git_root) if git_root else pathlib.Path.cwd()
+    resolved = base / candidate
+    # docs/patterns/ was renamed to docs/legacy-patterns/ in some repos
+    # (OCRecipes Phase 2). Fall back to it when docs/patterns/ is absent.
+    if not resolved.exists() and candidate.parts[:2] == ("docs", "patterns"):
+        legacy = base / "docs" / "legacy-patterns" / candidate.name
+        if legacy.exists():
+            return legacy
+    return resolved
+
+pattern_paths = []
+if args.patterns:
+    for pattern in args.patterns.split(","):
+        pattern = pattern.strip()
+        if not pattern:
+            continue
+        path = resolve_pattern_path(pattern, git_root)
+        if not path.exists():
+            print(f"Error: pattern file not found: {path}", file=sys.stderr)
+            sys.exit(1)
+        pattern_paths.append(path)
+
+# Rules files: compact checklists from docs/rules/, loaded without truncation.
+# Missing entries are silently skipped so the hook can pass the same names as --patterns.
+rules_paths = []
+if args.rules:
+    base = pathlib.Path(git_root) if git_root else pathlib.Path.cwd()
+    for name in args.rules.split(","):
+        name = name.strip()
+        if not name:
+            continue
+        candidate = pathlib.Path("docs") / "rules" / f"{name}.md"
+        full = (base / candidate) if not candidate.is_absolute() else candidate
+        if full.exists():
+            rules_paths.append(full)
+
+# Build user message
+focus = f"Focus: {args.scope}\n\n" if args.scope else ""
+file_context = ""
+context_paths = []
+if args.paths:
+    context_paths.extend(pathlib.Path(path) for path in args.paths)
+context_paths.extend(pattern_paths)
+context_paths.extend(rules_paths)
+if context_paths:
+    blocks = []
+    for path in context_paths:
+        content = path.read_text(errors="replace")
+        if path in pattern_paths and args.pattern_max_chars > 0 and len(content) > args.pattern_max_chars:
+            content = (
+                content[: args.pattern_max_chars]
+                + "\n\n[TRUNCATED: pass --pattern-max-chars 0 to include the full pattern file.]"
+            )
+        blocks.append(f"<file path='{path}'>\n{content}\n</file>")
+    file_context = "\n\n" + "\n\n".join(blocks)
+
+user_msg = f"{focus}<diff>\n{diff}\n</diff>{file_context}"
+
+tier_lines = "\n".join(
+    f"{tier} — {TIER_DEFINITIONS[tier]}" for tier in requested_tiers
+)
+profile_guidance = PROJECT_PROFILES[profile]
+profile_block = f"\n\n{profile_guidance}" if profile_guidance else ""
+
+try:
+    resp = client.chat.completions.create(
+        model=args.model,
+        messages=[
+            {
+                "role": "system",
+                "content": (
+                    "You are a senior code reviewer auditing a code change. "
+                    "Your review is a quality gate — defects you miss reach production.\n\n"
+                    "Input: a unified git diff inside <diff>, optionally followed by <file> "
+                    "blocks containing source context, docs/patterns/* convention docs, or "
+                    "docs/rules/* checklists.\n\n"
+                    "Return findings only in these tiers:\n\n"
+                    f"{tier_lines}\n\n"
+                    "Review the change systematically, in this priority order — earlier "
+                    "categories outrank later ones when triaging effort:\n"
+                    "1. Security & access control — authn/authz, ownership and userId checks, "
+                    "injection, SSRF, secret or token exposure, unsafe input handling.\n"
+                    "2. Data integrity — transactions, race conditions, corruption of persisted "
+                    "state, migration and schema safety.\n"
+                    "3. Correctness — logic errors, wrong conditionals, off-by-one, unhandled "
+                    "cases, broken control flow.\n"
+                    "4. Error handling & resilience — unhandled rejections, swallowed errors, "
+                    "missing validation at boundaries.\n"
+                    "5. Regression risk — changed shared behavior, broken contracts, removed "
+                    "guards or checks.\n"
+                    "6. Test coverage — missing tests for the above when the diff changes "
+                    "shared behavior, security boundaries, or storage contracts.\n\n"
+                    "Treat any included docs/patterns or docs/rules file as the project's "
+                    "binding standards — flag violations and cite the specific convention."
+                    f"{profile_block}\n\n"
+                    "Constraints:\n"
+                    "- Calibrate severity honestly. Do not inflate a WARNING into a CRITICAL, "
+                    "and never invent findings to fill a tier.\n"
+                    "- If the diff lacks the context to confirm a risk, report it only when the "
+                    "risk is concrete, and state what must be checked.\n"
+                    "- Report style preferences only when SUGGESTION is a requested tier.\n\n"
+                    "Format every finding exactly as:\n"
+                    "[TIER] path/to/file.ts:42 — short description\n"
+                    "  Detail: one or two sentences on why it is wrong and what to fix.\n\n"
+                    "Example:\n"
+                    "[CRITICAL] server/routes/meals.ts:88 — update handler missing ownership check\n"
+                    "  Detail: The query filters by mealId but not userId, so any authenticated "
+                    "user can edit another user's meal. Add eq(meals.userId, req.userId) to the "
+                    "where clause.\n\n"
+                    "Order findings most-severe first within each tier, and omit any tier that "
+                    "has no findings.\n"
+                    "Do not summarize the diff. Do not praise. Find problems."
+                ),
+            },
+            {"role": "user", "content": user_msg},
+        ],
+        max_tokens=args.max_tokens,
+    )
+except Exception as e:
+    print(f"[ERROR: kimi-review request failed: {e}]", file=sys.stderr)
+    sys.exit(1)
+
+answer = resp.choices[0].message.content
+if answer:
+    allowed_tiers = set(requested_tiers)
+    filtered_lines = []
+    keep_current_finding = False
+    saw_finding = False
+    for line in answer.splitlines():
+        stripped = line.lstrip()
+        if stripped.startswith("[") and "]" in stripped:
+            saw_finding = True
+            tier = stripped[1 : stripped.index("]")].strip().upper()
+            keep_current_finding = tier in allowed_tiers
+            if keep_current_finding:
+                filtered_lines.append(line)
+        elif keep_current_finding or not saw_finding:
+            filtered_lines.append(line)
+
+    filtered_answer = "\n".join(filtered_lines).strip()
+    if filtered_answer:
+        print(filtered_answer)
+    else:
+        print(f"No findings in requested tiers: {', '.join(requested_tiers)}")
+else:
+    print("[ERROR: ran out of tokens — raise --max-tokens]", file=sys.stderr)
+    sys.exit(1)
+
+u = resp.usage
+cached = getattr(getattr(u, "prompt_tokens_details", None), "cached_tokens", 0) or 0
+print(
+    f"\n[kimi: {u.prompt_tokens} in ({cached} cached) / "
+    f"{u.completion_tokens} out | finish: {resp.choices[0].finish_reason}]",
+    file=sys.stderr,
+)


### PR DESCRIPTION
## Summary
- Adds a `kimi-review` GitHub Actions workflow that runs on every PR and fails the check on a `[CRITICAL]` finding — branch protection then blocks the merge.
- Enforces the code-review gate for **all** contributors, regardless of whether they have the `kimi-review` CLI installed locally (the local pre-commit hook only runs for those who do).
- Vendors `scripts/kimi-review` (faithful copy of the personal `~/.local/bin/kimi-review`, portable shebang) so CI can run it.

## Setup required
Add an `OPENROUTER_API_KEY` repository secret. Until then the workflow fails-open (skips with a warning).

## Notes
- Fork PRs don't receive the secret → the gate skips for them; only same-repo branch PRs send diffs to OpenRouter (same exposure as the existing local hooks).
- Blocks on `[CRITICAL]` only; `WARNING` is reported but non-blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)