### PR TITLE
ci: run backend-checks on all PRs so docs-only PRs aren't blocked

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -9,10 +9,10 @@ name: Backend CI
       - '.python-version'
   pull_request:
     branches: [main, develop]
-    paths:
-      - 'backend/**'
-      - '.github/workflows/backend-ci.yml'
-      - '.python-version'
+    # No path filter on pull_request: the backend-checks job is a required
+    # status check, so it must report on every PR. A path-filtered required
+    # check never reports on PRs that miss the filter (e.g. docs-only changes),
+    # which permanently blocks the merge.
 
 jobs:
   backend-checks:


### PR DESCRIPTION
## Summary

The `backend-checks` job in `backend-ci.yml` (status check **"Install
dependencies and run Django checks"**) is a *required* check in `main` branch
protection. Its `pull_request` trigger was path-filtered to `backend/**`, so:

- a docs-only PR never triggered the workflow
- the required check never reported
- the PR was permanently `BLOCKED` (hit on PR #272 — merged via admin override)

This drops the `pull_request` path filter so the required check reports on every
PR. The `push` trigger keeps its path filter — there is no branch-protection
deadlock on push.

Trade-off: docs-only PRs now run the backend check (~1 min, pip-cached). That's
a small, predictable cost versus a permanent merge block.

## Test plan

- [ ] This PR touches `.github/workflows/backend-ci.yml` (in the old filter), so
      the backend-checks job runs and reports here.
- [ ] After merge: open a docs-only PR and confirm "Install dependencies and run
      Django checks" reports (no longer BLOCKED).

🤖 Generated with [Claude Code](https://claude.com/claude-code)