### PR TITLE
feat(skills): add todo workflow skills (next, batch, sweep, resume)

### DIFF
--- a/.claude/skills/todo-batch/SKILL.md
+++ b/.claude/skills/todo-batch/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: todo-batch
+description: Filter pending todos by priority, tags, or IDs and sweep through the matching subset. Use when the user says "/todo-batch", "batch todos", "sweep p3 todos", or "do all blog todos".
+---
+
+# Todo Batch — Filtered Sweep
+
+Like `todo-sweep`, but restricted to a user-defined subset. Useful for focused sprints (e.g., "all P3 blog issues" or "todos 074–076").
+
+## Steps
+
+1. **Parse filter criteria from invocation**
+
+   Extract flags from the user's message:
+
+   - `--priority pX` — restrict to one priority level
+   - `--ids A,B,C` — specific issue IDs
+   - `--tag tagname` — match todos whose `tags:` frontmatter contains the tag
+   - `--exclude-ids A,B` — skip specific IDs even if they match other criteria
+   - `--dry-run` — plan only, touch nothing
+
+   Natural language examples and their normalized forms:
+   - "batch all p3 blog todos" → `--priority p3 --tag blog`
+   - "do todos 074, 075, 076" → `--ids 074,075,076`
+   - "sweep remaining p2 issues" → `--priority p2`
+
+2. **Pre-flight — Working directory check**
+
+   ```bash
+   git status --short
+   ```
+
+   - Dirty? Offer: `stash / cancel / continue-anyway`
+   - On `stash`: `git stash push -m "todo-batch pre-flight"`
+
+3. **Discover candidates**
+
+   ```bash
+   grep -l "^status: pending" todos/*.md | grep -v -E '/(TEMPLATE|README|GITHUB|IMPLEMENTATION|QUICK_REFERENCE|RESEARCH)\.md$'
+   ```
+
+4. **Apply filters**
+
+   For each candidate, parse frontmatter and test:
+
+   - `--priority pX`: `priority` must equal `pX`
+   - `--ids A,B,C`: `issue_id` must be in the list
+   - `--tag foo`: `tags` array must contain `foo` (case-insensitive)
+   - `--exclude-ids`: drop if `issue_id` matches
+   - After filtering, **dependency-prune**: drop any todo whose `dependencies` include an id not in the filtered set AND not in `archive/`. (Dependencies outside the batch but already completed are fine.)
+
+5. **Sort**: priority ascending, then topological sort within priority.
+
+6. **Present filtered plan**
+
+   ```text
+   Todo Batch Plan
+   ===============
+   Filter: <human-readable description of parsed criteria>
+   Matching todos: <N>
+   <list with id, priority, title, effort if known>
+
+   Skipped by filter: <ids that matched criteria but were dependency-pruned>
+   Proceed? (yes / dry-run / edit-filter / cancel)
+   ```
+
+   - On `edit-filter`: return to step 1 with refined criteria.
+   - On `dry-run`: print what `completing-todos` would do for each todo, then stop.
+   - On `cancel`: exit.
+
+7. **Invoke `completing-todos` skill** with the equivalent filter flags.
+
+   Examples:
+   - `--priority p3` and `--tag blog` → pass both to the skill
+   - `--ids 074,075` → pass `--ids 074,075`
+
+   Announce: "I'm using the completing-todos skill to batch-process `<N>` filtered todos."
+
+8. **Post-flight — Sprint summary**
+
+   After Phase 2 wrap-up:
+
+   ```bash
+   git diff --stat HEAD
+   ```
+
+   Summarize:
+
+   ```text
+   Batch complete.
+     Filter applied: <criteria>
+     Completed: <list>
+     Skipped:   <list>
+     Dependency-pruned: <list>
+
+   Suggested commit message:
+     "<tag>-sprint: resolve <N> <priority> issues" (customize to filter)
+   ```
+
+## Filter Examples
+
+| What you say | Parsed flags | Result |
+|---|---|---|
+| "batch p3 blog" | `--priority p3 --tag blog` | 074, 075, 076 (if all match) |
+| "do 074 and 076" | `--ids 074,076` | Just those two, in order |
+| "sweep all p2" | `--priority p2` | Every pending P2 |
+| "batch todos tagged security" | `--tag security` | Any priority, security tag |
+| "batch p4 except 077" | `--priority p4 --exclude-ids 077` | All P4 minus one |
+
+## Safety Notes
+
+- Dependency-pruning is **automatic**; a todo blocked by an uncompleted dependency outside the batch will be silently excluded. This prevents mid-batch blockages.
+- If the filtered set is empty after dependency-pruning, abort with: "No actionable todos match the filter. Adjust criteria or complete dependencies first."
+- Never auto-commit.

--- a/.claude/skills/todo-next/SKILL.md
+++ b/.claude/skills/todo-next/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: todo-next
+description: Pick and complete the single highest-priority pending todo. Daily-driver workflow. Use when the user says "/todo-next", "do next todo", or "pick up next task".
+---
+
+# Todo Next — Daily Driver
+
+Complete exactly one pending todo: the highest-priority, dependency-resolved item.
+
+## Steps
+
+1. **Pre-flight — Check working directory state**
+
+   ```bash
+   git status --short
+   ```
+
+   - If output is non-empty, warn the user: `Working directory is dirty. Continue? (yes / stash / cancel)`
+   - On `stash`: run `git stash push -m "todo-next pre-flight"` and continue.
+   - On `cancel`: exit immediately.
+
+2. **Discover pending todos**
+
+   ```bash
+   grep -l "^status: pending" todos/*.md | grep -v -E '/(TEMPLATE|README|GITHUB|IMPLEMENTATION|QUICK_REFERENCE|RESEARCH)\.md$' | sort
+   ```
+
+3. **Parse frontmatter** of each candidate: read `priority`, `issue_id`, `dependencies`, and title (first `#` line).
+
+4. **Sort**: p1 → p2 → p3 → p4. Within each priority, dependency-respecting topological sort. Skip any todo whose `dependencies` list contains an id that is not in `archive/` (i.e., not completed).
+
+5. **Pick the first item** as the next todo.
+
+6. **Present to user for confirmation:**
+
+   ```text
+   Next todo: <issue_id> [<priority>] <title>
+   Estimated effort: <from todo file if available>
+   Files likely touched: <from Technical Details section>
+   Proceed? (yes / skip / cancel)
+   ```
+
+   - On `skip`: remove this id from consideration, return to step 5 with the next item.
+   - On `cancel`: exit immediately.
+
+7. **Invoke the `completing-todos` skill** with `--ids <issue_id>`.
+
+   Announce: "I'm using the completing-todos skill to work through todo <issue_id>."
+
+8. **Post-flight — Git hygiene reminder**
+
+   After the skill exits (Phase 2 wrap-up):
+
+   ```bash
+   git status --short
+   git diff --stat HEAD
+   ```
+
+   Suggest to the user:
+
+   ```text
+   Todo <issue_id> complete. Review the diff above.
+   Suggested commit: git commit -m "<issue_id>: <title>"
+   ```
+
+   If a stash was created in step 1, remind: `Stash found: run git stash pop when ready.`
+
+## Safety Notes
+
+- Never auto-commit. The workflow only suggests commit messages.
+- If `completing-todos` marks the todo `skipped` (verification failed), the workflow ends cleanly; do not auto-pick another.
+- If the user cancels at any confirmation prompt, leave all files untouched.

--- a/.claude/skills/todo-resume/SKILL.md
+++ b/.claude/skills/todo-resume/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: todo-resume
+description: Resume, restart, or discard an interrupted todo run from its checkpoint file. Use when the user says "/todo-resume", "resume todos", "continue todo run", or "pick up where I left off".
+---
+
+# Todo Resume — Interrupted Run Recovery
+
+Detect and recover from a previous `todo-sweep`, `todo-batch`, or `todo-next` that was interrupted (killed process, IDE restart, user abort).
+
+## Steps
+
+1. **Scan for checkpoints**
+
+   ```bash
+   ls -1t todos/.completing-todos-run-*.json 2>/dev/null
+   ```
+
+   - If **no files found**: report "No interrupted runs found. Start fresh with `/todo-next` or `/todo-sweep`." Exit.
+
+2. **Read the most recent checkpoint**
+
+   Parse the JSON. Extract:
+   - `run_id`
+   - `started_at`
+   - `plan` (array of issue_ids)
+   - `completed` (array)
+   - `skipped` (array)
+   - `aborted_at` (ISO timestamp or null)
+   - `filter_flags` (array of strings, e.g., `["--priority", "p3"]`)
+
+3. **Compute progress**
+
+   ```text
+   total = len(plan)
+   done = len(completed) + len(skipped)
+   remaining = [id for id in plan if id not in completed and id not in skipped]
+   next_up = remaining[0] if remaining else none
+   ```
+
+4. **Present status**
+
+   ```text
+   Interrupted Run Found
+   =======================
+   Run ID: <run_id>
+   Started: <started_at>
+   Status: <done>/<total> complete, <len(remaining)> remaining
+
+   Completed: <list or "none">
+   Skipped:   <list or "none">
+   Remaining: <list>
+
+   Next up: <next_up> [<priority>] <title>
+   Original filter: <filter_flags or "none">
+   ```
+
+5. **Prompt for action**
+
+   ```text
+   Choose: (resume / restart / discard / inspect)
+   ```
+
+   - **`resume`** → skip all ids in `completed` and `skipped`; invoke `completing-todos` starting at `next_up` with the same `filter_flags`.
+   - **`restart`** → delete the checkpoint file (`rm todos/.completing-todos-run-<run_id>.json`), then behave as if the user invoked the **original workflow** (`todo-sweep`, `todo-batch`, or `todo-next`) with the same filter_flags. Re-run from Phase 0 (full re-discovery and confirmation).
+   - **`discard`** → delete the checkpoint file. Ask: "Also reset any `in_progress` todos to `pending`? (yes / no)". On `yes`, for each file matching `todos/*-in_progress-*.md`, rename it back to `*-pending-*` and flip frontmatter `status: in_progress` → `status: pending`.
+   - **`inspect`** → read the checkpoint JSON in full, show the Work Log entries of the most recently completed todo, then return to step 5.
+
+6. **On `resume` — Delegate to `completing-todos` skill**
+
+   Construct the invocation: include `filter_flags` plus a mechanism to start at `next_up`. If the skill does not natively support resume-from-id, present the plan for the remaining todos and let the user confirm a normal `--ids` invocation on the remaining set.
+
+   Announce: "Resuming run <run_id> from todo <next_up>."
+
+7. **On `restart` — Clean start**
+
+   Delete checkpoint, then:
+   - If `filter_flags` was empty → invoke `todo-sweep` workflow.
+   - If `filter_flags` contained `--priority`, `--tag`, or `--ids` → invoke `todo-batch` workflow with those flags.
+   - If `filter_flags` contained `--ids` with exactly one id → invoke `todo-next` workflow.
+
+8. **Post-flight — Clean up checkpoint**
+
+   After the resumed/restarted run reaches Phase 2 (all remaining todos in terminal state):
+
+   ```bash
+   rm -f todos/.completing-todos-run-<run_id>.json
+   ```
+
+   Confirm: "Checkpoint cleaned up. Run fully resolved."
+
+## Edge Cases
+
+- **Multiple checkpoints**: Always use the most recently modified (`ls -1t`). If the user wants an older one, they must rename or delete newer ones manually.
+- **All todos completed but checkpoint remains**: On detection, report "Run <run_id> appears fully complete but checkpoint was not cleaned up." Offer to delete the stale checkpoint.
+- **`in_progress` todo not in checkpoint plan**: This means a todo was started outside the skill. Warn: "Todo `<id>` is in_progress but not tracked by any checkpoint. Manual intervention recommended."
+
+## Safety Notes
+
+- `discard` with reset is **destructive to state** (renames files, flips frontmatter). Always confirm before executing.
+- Never delete or move archived todos during recovery.
+- If a `git mv` step from a previous run left the repo in an odd state (e.g., staged rename without commit), warn the user to `git status` before proceeding.

--- a/.claude/skills/todo-sweep/SKILL.md
+++ b/.claude/skills/todo-sweep/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: todo-sweep
+description: Batch through all pending todos in priority order. Use when you want to clear the backlog — when the user says "/todo-sweep", "sweep todos", "clear all pending todos", or "batch complete todos".
+---
+
+# Todo Sweep — Backlog Clearer
+
+Run the `completing-todos` skill across **all** pending todos, sequentially, in priority order.
+
+## Steps
+
+1. **Pre-flight — Working directory check**
+
+   ```bash
+   git status --short
+   ```
+
+   - If dirty, warn and offer: `stash / cancel / continue-anyway`
+   - On `stash`: `git stash push -m "todo-sweep pre-flight"`
+   - On `cancel`: exit.
+   - On `continue-anyway`: proceed but remind user to review diff before committing.
+
+2. **Smoke test — Quick repo health check**
+
+   Run a 30-second smoke test appropriate to the codebase. Choose the fastest relevant check:
+
+   ```bash
+   # If backend Django tests are fast:
+   cd backend && python -m pytest apps/blog/tests/test_smoke.py -x --tb=short 2>/dev/null || true
+
+   # Or if a lint/type-check is faster:
+   # cd web && npm run type-check 2>/dev/null || true
+   ```
+
+   This is informational only; do not block on failure.
+
+3. **Discover and scope**
+
+   Count pending todos by priority:
+
+   ```bash
+   for p in p1 p2 p3 p4; do
+     count=$(grep -l "^priority: $p" todos/*.md 2>/dev/null | wc -l | tr -d ' ')
+     echo "$p: $count"
+   done
+   ```
+
+   Also run:
+
+   ```bash
+   grep -l "^status: pending" todos/*.md | grep -v -E '/(TEMPLATE|README|GITHUB|IMPLEMENTATION|QUICK_REFERENCE|RESEARCH)\.md$' | wc -l
+   ```
+
+4. **Confirm batch scope**
+
+   Present to user:
+
+   ```text
+   Todo Sweep Plan
+   ===============
+   Pending todos: <N total>
+     P1: <n>  P2: <n>  P3: <n>  P4: <n>
+   Order: priority ascending, then dependency-respecting topo-sort.
+   Mode: SEQUENTIAL (one at a time, safe for colliding files).
+   Dry-run available.
+
+   Proceed? (yes / dry-run / cancel)
+   ```
+
+   - On `dry-run`: invoke `completing-todos` with `--dry-run`. Print the plan and stop.
+   - On `cancel`: exit.
+
+5. **Invoke `completing-todos` skill** with no filter flags (all pending).
+
+   Announce: "I'm using the completing-todos skill to sweep through all pending todos."
+
+6. **Per-todo safety pause**
+
+   After each todo is archived (Phase 1 Step 5 completes), briefly summarize:
+
+   ```text
+   Completed <issue_id>. <N> of <total> done.
+   Changed files this todo: <list from git diff --name-only HEAD~1..HEAD or git diff --stat>
+   ```
+
+   If `completing-todos` returns `skipped` for a todo, note it and continue to the next.
+
+7. **Post-flight — Run summary & commit strategy**
+
+   After Phase 2 wrap-up:
+
+   ```bash
+   git diff --stat HEAD
+   ```
+
+   Suggest commit options:
+
+   ```text
+   Sweep complete.
+     Completed: <list>
+     Skipped:   <list or "none">
+
+   Commit strategies:
+     A) One commit per todo (safest, verbose history):
+        for each todo: git add <its-files> && git commit -m "<id>: <title>"
+     B) Single batch commit (concise):
+        git commit -m "todo-sweep: resolve <N> pending issues" -m "<bullet list of ids>"
+     C) Review interactively: git add -p
+   ```
+
+   If a stash exists from step 1, remind: `Run git stash pop when ready.`
+
+## Safety Notes
+
+- This workflow is intentionally **sequential**; no `--parallel` flag is exposed.
+- If the user chooses `repair` during code review (Phase 1 Step 4), `completing-todos` exits the loop after that todo. The workflow then presents the option to `continue-sweep` (resume the remaining plan) or `stop-here`.
+- Never auto-commit.


### PR DESCRIPTION
## Summary

Adds four todo-workflow skills layered on top of the existing `completing-todos` skill:

- **todo-next** — complete the single highest-priority, dependency-resolved pending todo (daily driver)
- **todo-batch** — sweep a filtered subset of todos (by priority, tag, or id)
- **todo-sweep** — sweep all pending todos sequentially in priority order
- **todo-resume** — resume, restart, or discard an interrupted run from its checkpoint file

All paths in the skill files are repo-relative so the skills work on any clone, not just the author's machine.

## Test plan

- [x] Pre-commit hooks pass (markdownlint, kimi-review — no findings)
- [ ] Exercise each skill (`/todo-next`, `/todo-batch`, `/todo-sweep`, `/todo-resume`) against the live `todos/` backlog

🤖 Generated with [Claude Code](https://claude.com/claude-code)