### PR TITLE
harness: complete todos 077 and 078

### DIFF
--- a/.claude/hooks/inject-patterns.sh
+++ b/.claude/hooks/inject-patterns.sh
@@ -105,10 +105,12 @@ if [ -n "$DOMAINS" ]; then
   done
 fi
 
-# Spill overflow to a stable temp file so the agent can read the rest.
+# Spill overflow to a per-invocation temp file so the agent can read the rest.
 # Claude Code's hook-output cap is ~10K; multi-domain injections can exceed this.
+# The `$$` PID suffix keeps concurrent hook invocations from clobbering each
+# other's spill file.
 THRESHOLD=9000
-SPILL_FILE="/tmp/plant-id-injection-context.md"
+SPILL_FILE="/tmp/plant-id-injection-context.$$.md"
 CONTEXT_SIZE=$(wc -c < "$TMPFILE")
 if [ "$CONTEXT_SIZE" -gt "$THRESHOLD" ]; then
   cp "$TMPFILE" "$SPILL_FILE"

--- a/.claude/hooks/test-inject-patterns.sh
+++ b/.claude/hooks/test-inject-patterns.sh
@@ -5,15 +5,19 @@
 set -uo pipefail
 
 HOOK="$(cd "$(dirname "$0")" && pwd)/inject-patterns.sh"
-SPILL_FILE="/tmp/plant-id-injection-context.md"
+# inject-patterns.sh writes its spill file to a per-PID path
+# (/tmp/plant-id-injection-context.<pid>.md), so match them with a glob.
+SPILL_GLOB="/tmp/plant-id-injection-context.*.md"
 PASS=0; FAIL=0
 
 run_hook() {
   local input="$1"
-  rm -f "$SPILL_FILE"
-  local output spill=""
+  rm -f $SPILL_GLOB
+  local output spill="" f
   output=$(echo "$input" | bash "$HOOK" 2>/dev/null || true)
-  [ -f "$SPILL_FILE" ] && spill=$(cat "$SPILL_FILE")
+  for f in $SPILL_GLOB; do
+    [ -f "$f" ] && spill+=$(cat "$f")
+  done
   printf '%s\n%s' "$output" "$spill"
 }
 
@@ -39,7 +43,7 @@ check_no_match() {
 
 check_empty() {
   local name="$1" input="$2" output
-  rm -f "$SPILL_FILE"
+  rm -f $SPILL_GLOB
   output=$(echo "$input" | bash "$HOOK" 2>/dev/null || true)
   if [ -z "$output" ]; then
     echo "PASS: $name"; PASS=$((PASS + 1))

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -29,17 +29,6 @@
           }
         ]
       }
-    ],
-    "Stop": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "[ -s /tmp/plant-id-deferred.txt ] && python3 -c \"import json; items=open('/tmp/plant-id-deferred.txt').read().strip(); print(json.dumps({'systemMessage': 'Deferred items not yet tracked as todos:\\n' + items + '\\n\\nAsk Claude to create todos for them in todos/'}))\" 2>/dev/null || true",
-            "statusMessage": "Checking for untracked deferred items..."
-          }
-        ]
-      }
     ]
   }
 }

--- a/todos/archive/077-completed-p4-inject-patterns-spill-race.md
+++ b/todos/archive/077-completed-p4-inject-patterns-spill-race.md
@@ -1,5 +1,5 @@
 ---
-status: in_progress
+status: completed
 priority: p4
 issue_id: "077"
 tags: [harness, hooks]
@@ -42,9 +42,9 @@ wrong or partial rule context.
 
 ## Acceptance Criteria
 
-- [ ] Spill file path is unique per hook invocation.
-- [ ] The truncation notice points at the path actually written.
-- [ ] `test-inject-patterns.sh` passes against the new path scheme.
+- [x] Spill file path is unique per hook invocation.
+- [x] The truncation notice points at the path actually written.
+- [x] `test-inject-patterns.sh` passes against the new path scheme.
 
 ## Work Log
 
@@ -75,6 +75,31 @@ wrong or partial rule context.
   the 9000-byte `THRESHOLD`. The fix is still correct defensive hygiene.
 - **To complete:** a human applies the two edits above, then runs
   `bash .claude/hooks/test-inject-patterns.sh` (expect all checks pass).
+
+### 2026-05-19 - Started by completing-todos skill (run 2026-05-19-0044)
+
+- Re-picked up; auto mode is off so harness edits surface permission prompts
+  rather than hard-blocking.
+
+### 2026-05-19 - Implementation
+
+- `.claude/hooks/inject-patterns.sh`: `SPILL_FILE` now
+  `/tmp/plant-id-injection-context.$$.md` (`$$` = PID, unique per invocation).
+  The truncation notice already interpolates `"$SPILL_FILE"`, so it now points
+  at the per-PID path automatically.
+- `.claude/hooks/test-inject-patterns.sh`: replaced the fixed `SPILL_FILE`
+  constant with a `SPILL_GLOB="/tmp/plant-id-injection-context.*.md"`; `run_hook`
+  and `check_empty` now `rm -f $SPILL_GLOB` and `run_hook` cats each glob match.
+- Verification:
+  - `bash .claude/hooks/test-inject-patterns.sh` → `Results: 16 passed, 0 failed` / exit 0.
+  - Two `bash` invocations of `echo /tmp/...$$.md` produced PIDs 74906 and 74907 —
+    distinct paths, confirming per-invocation uniqueness.
+
+### 2026-05-19 - Completed by completing-todos skill (run 2026-05-19-0044)
+
+- Verification: all 3 acceptance criteria passed (16/16 hook tests, per-PID path confirmed).
+- Review: code-review-orchestrator dispatched (direct shell review — no shell
+  specialist agent) — 0 findings, no blocking.
 
 ## Notes
 

--- a/todos/archive/078-completed-p4-wire-deferred-item-capture.md
+++ b/todos/archive/078-completed-p4-wire-deferred-item-capture.md
@@ -1,5 +1,5 @@
 ---
-status: in_progress
+status: completed
 priority: p4
 issue_id: "078"
 tags: [harness, hooks, skills]
@@ -56,9 +56,9 @@ dead plumbing.
 
 ## Acceptance Criteria
 
-- [ ] Either the deferred file is written by a real code path, or the Stop hook
+- [x] Either the deferred file is written by a real code path, or the Stop hook
       is removed.
-- [ ] `.claude/settings.json` remains valid JSON.
+- [x] `.claude/settings.json` remains valid JSON.
 
 ## Work Log
 
@@ -83,6 +83,24 @@ dead plumbing.
   `/tmp/plant-id-deferred.txt`, which no code path writes; the harness works
   fully without it (see Notes). After deletion the file is still valid JSON —
   verify with `python3 -m json.tool .claude/settings.json`.
+
+### 2026-05-19 - Started + implemented by completing-todos skill (run 2026-05-19-0044)
+
+- Re-picked up; auto mode off, so the `.claude/settings.json` edit was
+  permission-prompted and approved rather than hard-blocked.
+- Applied **Option 2** — deleted the `"Stop"` hook block from
+  `.claude/settings.json` (the dead plumbing that grepped the never-written
+  `/tmp/plant-id-deferred.txt`).
+- Verification:
+  - `grep '"Stop"' .claude/settings.json` → no match (hook removed).
+  - `python3 -m json.tool .claude/settings.json` → exit 0 (valid JSON).
+  - `grep -rln "plant-id-deferred" .claude/` → no references remain.
+
+### 2026-05-19 - Completed by completing-todos skill (run 2026-05-19-0044)
+
+- Verification: both acceptance criteria passed (Stop hook removed; JSON valid).
+- Review: code-review-orchestrator dispatched (direct JSON-config review) —
+  0 findings, no blocking.
 
 ## Notes
 


### PR DESCRIPTION
## Summary

Completes the two p4 harness todos (077, 078) that the earlier `/todo-sweep` could not finish because editing `.claude/` files was blocked by the auto-mode self-modification guard.

- **077** — `inject-patterns.sh` now writes its rule-injection spill file to a per-PID path (`/tmp/plant-id-injection-context.$$.md`) instead of a fixed shared path, so concurrent hook invocations cannot clobber each other's spill file. `test-inject-patterns.sh` updated to glob-discover the per-PID file.
- **078** — removed the dead `Stop` hook from `.claude/settings.json`. It grepped `/tmp/plant-id-deferred.txt`, a file no code path ever writes (Option 2 from the todo: drop the unused plumbing).

## Test plan

- [x] `bash .claude/hooks/test-inject-patterns.sh` — 16 passed, 0 failed
- [x] `python3 -m json.tool .claude/settings.json` — valid JSON
- [x] Pre-commit hooks pass (JSON syntax, kimi-review — no findings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)