### PR TITLE
fix(security): resolve backend dependency CVEs blocking the security scan (todo 089)

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -44,9 +44,19 @@ jobs:
       - name: Run pip-audit (fail on vulnerabilities)
         run: |
           cd backend
-          # CVE-2026-42304 (Twisted 25.5.0): suppressed 2026-05-08 — no stable fix exists (fix is RC-only 26.4.0rc2).
-          # Remove this flag when Twisted >=26.4.0 stable is released on PyPI.
-          pip-audit -r requirements.txt --ignore-vuln CVE-2026-42304
+          # Suppressed advisories — each has no upstream fix and is not reachable through app code.
+          # Revisit and drop the flag whenever a patched release ships (tracked in todo 089).
+          # CVE-2026-42304 (Twisted 25.5.0): no stable fix exists (fix is RC-only 26.4.0rc2). Remove when Twisted >=26.4.0 stable releases.
+          # PYSEC-2026-89  (Markdown 3.8.1): no upstream fix (OSV: all versions affected); markdown not imported by app code; DoS path unreachable.
+          # PYSEC-2026-97  (nltk 3.9.4):     no upstream fix (already latest); filestring() path traversal not called by app code.
+          # PYSEC-2024-277 (joblib 1.5.2):   supplier-disputed; not imported by app code.
+          # PYSEC-2025-183 (PyJWT 2.12.1):   supplier-disputed; mitigated by project's strong SECRET_KEY (>=50 chars) requirement.
+          pip-audit -r requirements.txt \
+            --ignore-vuln CVE-2026-42304 \
+            --ignore-vuln PYSEC-2026-89 \
+            --ignore-vuln PYSEC-2026-97 \
+            --ignore-vuln PYSEC-2024-277 \
+            --ignore-vuln PYSEC-2025-183
         continue-on-error: false
 
       - name: Upload pip-audit report

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -50,7 +50,7 @@ jobs:
           # PYSEC-2026-89  (Markdown 3.8.1): no upstream fix (OSV: all versions affected); markdown not imported by app code; DoS path unreachable.
           # PYSEC-2026-97  (nltk 3.9.4):     no upstream fix (already latest); filestring() path traversal not called by app code.
           # PYSEC-2024-277 (joblib 1.5.2):   supplier-disputed; not imported by app code.
-          # PYSEC-2025-183 (PyJWT 2.12.1):   supplier-disputed; mitigated by project's strong SECRET_KEY (>=50 chars) requirement.
+          # PYSEC-2025-183 (PyJWT 2.12.1):   supplier-disputed; mitigated by JWT_SECRET_KEY (the SIMPLE_JWT SIGNING_KEY PyJWT signs with), validated >=50 chars fail-fast at settings import in ALL environments (settings.py:658).
           pip-audit -r requirements.txt \
             --ignore-vuln CVE-2026-42304 \
             --ignore-vuln PYSEC-2026-89 \

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -102,7 +102,7 @@ httptools==0.7.1
 httpx==0.28.1
 hyperframe==6.1.0
 hyperlink==21.0.0
-idna==3.11
+idna==3.15
 incremental==24.7.2
 inflection==0.5.1
 iniconfig==2.3.0

--- a/todos/090-pending-p3-forumpostimage-schema-broken.md
+++ b/todos/090-pending-p3-forumpostimage-schema-broken.md
@@ -1,0 +1,69 @@
+---
+status: pending
+priority: p3
+issue_id: "090"
+tags: [api, drf, openapi, forum, bug]
+dependencies: []
+---
+
+# DRF schema generation broken — ForumPostImageSerializer references non-existent fields
+
+## Problem
+
+OpenAPI schema generation (`drf_spectacular`) raises `ImproperlyConfigured` and
+aborts entirely, so `/api/schema/`, `/api/docs/` (Swagger), and `/api/redoc/`
+all break. The root-level helper `backend/test_schema.py` (swept into Django test
+discovery by its `test_*` name) fails the full `python manage.py test` run because
+of it. Pre-existing since PR #262 (2026-05-09); surfaced while completing todo 089.
+
+## Findings
+
+- `python backend/test_schema.py` fails deterministically:
+  `django.core.exceptions.ImproperlyConfigured: Field name 'caption' is not valid
+  for model 'ForumPostImage' in 'apps.forum_integration.serializers.ForumPostImageSerializer'.`
+- `apps/forum_integration/serializers.py:471` `ForumPostImageSerializer.Meta.fields`
+  (line 481) lists `caption` and `uploaded_at`.
+- `apps/forum_integration/models.py:613` `ForumPostImage` has **neither**: its
+  metadata fields are `alt_text` (669), `original_filename` (653), `file_size`
+  (658), `upload_order` (663), and timestamps `created_at`/`updated_at` (676–677).
+  So `caption` is undefined (crashes first) and `uploaded_at` is a latent second
+  mismatch (should be `created_at`).
+- Last commit on the serializer: `f337b01` (2026-05-09, PR #262) — predates and is
+  unrelated to todo 089's dependency work.
+- `apps/forum_integration/models.py:679` `ForumPostImage.Meta` confirms no `caption`.
+
+## Recommended Action
+
+Reconcile the serializer's `fields` list with the model. Either:
+
+1. **Drop the non-existent fields** — remove `caption`; replace `uploaded_at` with
+   `created_at` in `ForumPostImageSerializer.Meta.fields`. (Lowest-risk if the
+   frontend doesn't depend on a `caption`/`uploaded_at` key.)
+2. **Or add the missing model fields** — add a `caption` field + migration if a
+   caption is actually a product requirement, and alias `uploaded_at`
+   (`serializers.DateTimeField(source="created_at", read_only=True)`).
+
+Check the React/Flutter forum image consumers before choosing; option 1 is the
+default unless a caption feature is intended.
+
+## Acceptance Criteria
+
+- [ ] `python backend/test_schema.py` exits 0 and prints "Schema generated successfully".
+- [ ] `python manage.py test` (full, unscoped) reports 0 errors (the `test_schema`
+      discovery error is gone).
+- [ ] No forum-image API consumer references a removed field (`caption`/`uploaded_at`).
+
+## Work Log
+
+### 2026-05-20 - Created
+
+- Surfaced during todo 089 (dependency-CVE pass). The full test suite's sole error
+  was this pre-existing schema-generation failure; filed separately per the
+  "don't bundle unrelated work" precedent rather than fixing it inside 089's PR.
+
+## Notes
+
+p3 — real regression (schema/docs endpoints broken), but it sat unnoticed for 11
+days, so it is not blocking. The serializer↔model field drift suggests a missing
+schema-generation check in CI; consider gating `test_schema.py` (or a proper
+`spectacular --validate`) in the pipeline as part of the fix.

--- a/todos/archive/089-completed-p2-backend-dependency-cves.md
+++ b/todos/archive/089-completed-p2-backend-dependency-cves.md
@@ -1,5 +1,5 @@
 ---
-status: pending
+status: completed
 priority: p2
 issue_id: "089"
 tags: [security, dependencies, ci]
@@ -58,11 +58,11 @@ issue is mitigated by the project's strong-`SECRET_KEY` requirement.
 
 ## Acceptance Criteria
 
-- [ ] `idna` bumped to ≥3.15 in `backend/requirements.txt`.
-- [ ] The 4 no-fix advisories suppressed with per-CVE justification comments in
+- [x] `idna` bumped to ≥3.15 in `backend/requirements.txt`.
+- [x] The 4 no-fix advisories suppressed with per-CVE justification comments in
       the CI security-scan workflow.
-- [ ] `Backend Python Security Scan` passes on a PR again.
-- [ ] `python manage.py test` passes after the `idna` bump.
+- [x] `Backend Python Security Scan` passes on a PR again.
+- [x] `python manage.py test` passes after the `idna` bump.
 
 ## Work Log
 
@@ -72,6 +72,55 @@ issue is mitigated by the project's strong-`SECRET_KEY` requirement.
   `Backend Python Security Scan`. Investigated all 5 CVEs (OSV + PyPI + usage
   grep) and captured the bump/suppress plan here for a dedicated security pass.
   User opted to file this rather than bundle a dependency change into the revert.
+
+### 2026-05-20 - Started by completing-todos skill (run 2026-05-20-2330)
+
+- Picked up by automated workflow.
+
+### 2026-05-20 - Implemented & verified
+
+- **AC1** — `backend/requirements.txt:105` now `idna==3.15` (confirmed `idna 3.15`
+  is the latest PyPI release via `pip index versions idna`).
+- **AC2** — `.github/workflows/security-scan.yml:54-59` now passes five
+  `--ignore-vuln` flags (CVE-2026-42304, PYSEC-2026-89, PYSEC-2026-97,
+  PYSEC-2024-277, PYSEC-2025-183), each with a per-CVE justification comment
+  (lines 47-53). YAML re-read to confirm `continue-on-error: false` stays at
+  step level and the `\` continuations nest under `run: |`.
+- **AC3** — ran the exact gating command locally:
+  `pip-audit -r requirements.txt --ignore-vuln …×5` →
+  `No known vulnerabilities found, 5 ignored` (exit 0). (Real CI confirmation
+  pends the PR; local run replicates the workflow step verbatim.)
+- **AC4** — `python manage.py test apps --noinput` → `Ran 628 tests in 122.155s`,
+  `OK (skipped=11)`, exit 0. Scoped to `apps/` to exclude a **pre-existing,
+  unrelated** root-level `test_schema.py` discovery error
+  (`ImproperlyConfigured: Field name 'caption' is not valid for model
+  'ForumPostImage'`) — the serializer was last touched in PR #262 (2026-05-09),
+  not by this change, and idna (a transitive IDN/punycode lib) cannot affect DRF
+  serializer field resolution. 628 = the full run's 629 minus that one script
+  error, proving the idna bump introduced no regressions. Filed as **todo 090**.
+
+### 2026-05-20 - Code review (code-review-orchestrator → security-reviewer)
+
+- **0 blocking findings** (no critical/high). YAML validity and idna transitive
+  safety independently re-verified by the reviewer.
+
+#### Known issues (non-blocking, low severity)
+
+- The five `--ignore-vuln` suppressions have no machine-enforced expiry; they
+  rely on this todo + manual recheck. The "tracked in todo 089" comment will
+  point at the archived todo once this is moved. Suggested follow-up: a dated
+  "review by" note per advisory, or a non-gating scheduled pip-audit run without
+  the ignore flags to surface when fixes ship.
+- `PYSEC-2025-183` (PyJWT) is the weakest suppression — auth-critical lib,
+  disputed advisory, mitigation (SECRET_KEY ≥50 chars) asserted but not
+  re-validated in CI. Suggested follow-up: a test asserting SECRET_KEY length so
+  the mitigation can't silently regress.
+
+### 2026-05-20 - Completed by completing-todos skill (run 2026-05-20-2330)
+
+- Verification: all 4 acceptance criteria passed (idna pin, 5 suppression flags,
+  pip-audit clean exit 0, `test apps` 628 OK).
+- Review: 4 findings total, 0 blocking — 2 low + 2 info recorded under Known issues.
 
 ## Notes
 

--- a/todos/archive/089-completed-p2-backend-dependency-cves.md
+++ b/todos/archive/089-completed-p2-backend-dependency-cves.md
@@ -112,9 +112,13 @@ issue is mitigated by the project's strong-`SECRET_KEY` requirement.
   "review by" note per advisory, or a non-gating scheduled pip-audit run without
   the ignore flags to surface when fixes ship.
 - `PYSEC-2025-183` (PyJWT) is the weakest suppression — auth-critical lib,
-  disputed advisory, mitigation (SECRET_KEY ≥50 chars) asserted but not
-  re-validated in CI. Suggested follow-up: a test asserting SECRET_KEY length so
-  the mitigation can't silently regress.
+  disputed advisory. **Resolved:** the mitigation is already enforced fail-fast.
+  PyJWT signs with `JWT_SECRET_KEY` (`SIMPLE_JWT["SIGNING_KEY"]`, settings.py:674),
+  which is validated `>=50` chars at settings import in ALL environments
+  (settings.py:658) — Django won't boot with a short key, so every CI job that
+  loads settings enforces it. The workflow comment was corrected to cite
+  `JWT_SECRET_KEY` + settings.py:658 (it previously cited `SECRET_KEY`, which is
+  only length-checked in production). No separate test needed.
 
 ### 2026-05-20 - Completed by completing-todos skill (run 2026-05-20-2330)
 


### PR DESCRIPTION
## Summary

- **Bump `idna` 3.11 → 3.15** in `backend/requirements.txt` — the real upstream fix for CVE-2026-45409 (confirmed latest on PyPI; no transitive dependent caps it below 3.15).
- **Suppress four no-fix / disputed advisories** in the `pip-audit` CI gate, each with a per-CVE justification comment, alongside the pre-existing Twisted suppression:
  - `PYSEC-2026-89` (Markdown) — no upstream fix; not imported by app code; DoS path unreachable.
  - `PYSEC-2026-97` (nltk) — no upstream fix (already latest); `filestring()` not called by app code.
  - `PYSEC-2024-277` (joblib) — supplier-disputed; not imported by app code.
  - `PYSEC-2025-183` (PyJWT) — supplier-disputed; mitigated by `JWT_SECRET_KEY` (the `SIMPLE_JWT` `SIGNING_KEY` PyJWT signs with), validated `>=50` chars fail-fast at settings import in **all** environments (`settings.py:658`).
- Unblocks the repo-wide **Backend Python Security Scan**, which was failing on every PR (including docs-only) after these CVEs were disclosed against the live advisory DB.

## Why

The scan is a gate on all PRs; newly disclosed CVEs against pinned versions broke it across the board. Only `idna` had a real fix — the other four have no upstream patch (or are supplier-disputed) and are not reachable through app code.

## Follow-up filed

While verifying the full test suite, found a **pre-existing, unrelated** drf-spectacular schema break: `ForumPostImageSerializer` references non-existent `ForumPostImage` fields (`caption`, `uploaded_at`), broken since PR #262. Filed as **todo 090 (p3)** rather than bundling it here.

## Test plan

- [x] `idna 3.15` confirmed latest on PyPI (`pip index versions idna`).
- [x] `pip-audit -r requirements.txt --ignore-vuln …×5` → `No known vulnerabilities found, 5 ignored` (exit 0) — the exact CI gating command, run locally.
- [x] `python manage.py test apps --noinput` → `Ran 628 tests`, `OK (skipped=11)`, exit 0 (no regression from the idna bump).
- [ ] Confirm the **Backend Python Security Scan** check passes green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)