### PR TITLE
fix(mobile): regenerate Riverpod codegen after audit provider changes

### DIFF
--- a/plant_community_mobile/lib/config/theme_provider.g.dart
+++ b/plant_community_mobile/lib/config/theme_provider.g.dart
@@ -44,7 +44,7 @@ final class ThemeModeNotifierProvider
   }
 }
 
-String _$themeModeNotifierHash() => r'c25cc35849763c2ff04fb95c7c4edb61f0b97cdb';
+String _$themeModeNotifierHash() => r'590b983d12c36c28681142df4064781ff4cc34b3';
 
 /// Theme mode notifier that manages theme state.
 

--- a/plant_community_mobile/lib/core/routing/app_router.g.dart
+++ b/plant_community_mobile/lib/core/routing/app_router.g.dart
@@ -52,4 +52,4 @@ final class AppRouterProvider
   }
 }
 
-String _$appRouterHash() => r'aeb7d723a681a9d171837eddde30d09a24fa8a3a';
+String _$appRouterHash() => r'1d0c45d3a582d2e1dfe7c80fedde422123240deb';

--- a/plant_community_mobile/lib/services/auth_service.g.dart
+++ b/plant_community_mobile/lib/services/auth_service.g.dart
@@ -107,7 +107,7 @@ final class AuthServiceProvider
   }
 }
 
-String _$authServiceHash() => r'71f85ce9d0f7e178728adc24be993a6b105f70c5';
+String _$authServiceHash() => r'5a072f4f25af353441c4f874f14cbd96d23e1ef4';
 
 /// Authentication service that handles Firebase Auth + Django JWT
 ///


### PR DESCRIPTION
## Summary

Follow-up to #285. That PR edited three `@riverpod` source files (theme_provider H24, app_router H27, auth_service H23) but did not regenerate the matching `.g.dart` files, leaving stale `_$...Hash()` values. This turned the **"Ensure generated code is committed"** step of the Flutter CI red on `main`.

Regenerated with `build_runner`; the only changes are the three provider source-hash strings. The new hashes match exactly what CI computed (`590b983`, `1d0c45d`, `5a072f4`).

## Test plan

- [x] `flutter analyze` + `dart format` pass (pre-commit)
- [ ] CI "Ensure generated code is committed" step is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)