### PR TITLE
feat(inject): capture loop — capture_trigger.py + /codify handoff (v1.1)

### DIFF
--- a/docs/superpowers/specs/2026-05-29-jit-mistake-injection-design.md
+++ b/docs/superpowers/specs/2026-05-29-jit-mistake-injection-design.md
@@ -365,5 +365,22 @@ Built and verified on branch `feat/jit-mistake-injection`:
   deduped domain rules, ratelimit suppression, kill switch, and malformed-input
   degradation all verified. ⏳ awaiting user apply.
 
-Deferred to v1.1 / follow-ups (per Sequencing): `capture_trigger.py` + `/codify`
-capture, the `test-inject-patterns.sh` hook-test extension, and the LSP todo.
+## Implementation status — v1.1 capture (2026-05-29)
+
+Built and verified on branch `feat/jit-injection-capture` (spine merged to main
+via #298):
+
+- `scripts/inject/capture_trigger.py` — appends a trigger to `triggers.json`;
+  strict dedup-on-`id` (idempotent), canonical key order, validates required
+  fields + regex, drops a non-resolving `pattern_ref` with a warning. `--severity
+  warn` for `/codify` (human-curated), default `candidate` for review automation. ✅
+- `scripts/inject/test_capture_trigger.py` — 13 tests (build/validate, dedup,
+  update, captured-then-matches end-to-end, pattern_ref resolution, CLI). ✅
+- `scripts/inject/codify-capture-step.md` — handoff doc to add Step 5b + the
+  Step 6 `git add` change to the (self-mod-blocked) `/codify` skill. ⏳ awaiting
+  user apply.
+
+Remaining follow-ups: auto-*wire* `capture_trigger.py` into the review path
+(kimi-review / reviewers calling it with `--severity candidate` — the script
+already supports it); the `test-inject-patterns.sh` hook-test extension; and the
+LSP todo.

--- a/scripts/inject/capture_trigger.py
+++ b/scripts/inject/capture_trigger.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Append a just-in-time mistake trigger to docs/rules/triggers.json.
+
+Closes the loop: a caught mistake becomes a write-time warning for future
+sessions. Two callers:
+  - /codify (manual, human-curated): pass --severity warn.
+  - review automation (auto): default --severity candidate (provisional,
+    prunable later; still injects immediately).
+
+Dedup is strict on `id` (idempotent: re-capturing an existing id is a no-op
+unless --update). Invalid regex or a missing required field is rejected. A
+pattern_ref that does not resolve to a file is dropped (with a warning) rather
+than shipped dangling.
+
+Env: INJECT_TRIGGERS_FILE overrides the index path (used by tests).
+"""
+import argparse
+import datetime
+import json
+import os
+import re
+import sys
+
+# Canonical key order for a trigger entry (matches the hand-written seed file).
+_ORDER = [
+    "id", "domains", "path_glob", "content_present", "content_absent",
+    "message", "pattern_ref", "source", "added", "severity",
+]
+
+
+def default_root():
+    return os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+def build_trigger(id, message, path_glob, *, domains=None, content_present=None,
+                  content_absent=None, pattern_ref=None, source=None, added=None,
+                  severity="candidate"):
+    """Assemble a validated trigger dict in canonical key order. Raises ValueError."""
+    if not id:
+        raise ValueError("trigger id is required")
+    if not message:
+        raise ValueError("trigger message is required")
+    if not path_glob or not isinstance(path_glob, list):
+        raise ValueError("path_glob must be a non-empty list")
+    for key, pat in (("content_present", content_present), ("content_absent", content_absent)):
+        if pat:
+            try:
+                re.compile(pat)
+            except re.error as e:
+                raise ValueError("invalid regex in {}: {}".format(key, e))
+    if severity not in ("warn", "info", "candidate"):
+        raise ValueError("severity must be warn|info|candidate, got {!r}".format(severity))
+
+    fields = {
+        "id": id,
+        "domains": domains or None,
+        "path_glob": path_glob,
+        "content_present": content_present or None,
+        "content_absent": content_absent or None,
+        "message": message,
+        "pattern_ref": pattern_ref or None,
+        "source": source or None,
+        "added": added or datetime.date.today().isoformat(),
+        "severity": severity,
+    }
+    return {k: fields[k] for k in _ORDER if fields[k] is not None}
+
+
+def resolve_pattern_ref(ref, project_root):
+    """Return (kept_ref_or_None, warning_or_None). Drops refs that don't resolve."""
+    if not ref:
+        return None, None
+    if os.path.isfile(os.path.join(project_root, ref)):
+        return ref, None
+    return None, "pattern_ref does not resolve, dropping: {}".format(ref)
+
+
+def load(path):
+    try:
+        with open(path) as fh:
+            data = json.load(fh)
+        return data if isinstance(data, list) else []
+    except (OSError, ValueError):
+        return []
+
+
+def save(path, triggers):
+    with open(path, "w") as fh:
+        json.dump(triggers, fh, indent=2, ensure_ascii=False)
+        fh.write("\n")
+
+
+def capture(path, trigger, update=False):
+    """Append `trigger` to the index at `path`. Returns added|exists|updated."""
+    triggers = load(path)
+    for i, existing in enumerate(triggers):
+        if existing.get("id") == trigger["id"]:
+            if not update:
+                return "exists"
+            triggers[i] = trigger
+            save(path, triggers)
+            return "updated"
+    triggers.append(trigger)
+    save(path, triggers)
+    return "added"
+
+
+def _split_domains(value):
+    if not value:
+        return None
+    return [d.strip() for d in value.split(",") if d.strip()]
+
+
+def main(argv=None):
+    p = argparse.ArgumentParser(description="Append a JIT mistake trigger.")
+    p.add_argument("--id", required=True)
+    p.add_argument("--message", required=True)
+    p.add_argument("--path-glob", action="append", required=True, dest="path_glob",
+                   help="repeatable; repo-relative fnmatch glob")
+    p.add_argument("--domains", help="comma-separated")
+    p.add_argument("--content-present", dest="content_present")
+    p.add_argument("--content-absent", dest="content_absent")
+    p.add_argument("--pattern-ref", dest="pattern_ref")
+    p.add_argument("--source")
+    p.add_argument("--added")
+    p.add_argument("--severity", default="candidate", choices=["warn", "info", "candidate"])
+    p.add_argument("--update", action="store_true")
+    p.add_argument("--project-root", default=default_root())
+    args = p.parse_args(argv)
+
+    pattern_ref, warn = resolve_pattern_ref(args.pattern_ref, args.project_root)
+    if warn:
+        sys.stderr.write("warning: " + warn + "\n")
+
+    try:
+        trigger = build_trigger(
+            id=args.id, message=args.message, path_glob=args.path_glob,
+            domains=_split_domains(args.domains),
+            content_present=args.content_present, content_absent=args.content_absent,
+            pattern_ref=pattern_ref, source=args.source, added=args.added,
+            severity=args.severity,
+        )
+    except ValueError as e:
+        sys.stderr.write("error: {}\n".format(e))
+        return 2
+
+    triggers_file = os.environ.get("INJECT_TRIGGERS_FILE") or os.path.join(
+        args.project_root, "docs", "rules", "triggers.json"
+    )
+    status = capture(triggers_file, trigger, update=args.update)
+    sys.stdout.write("{}: {} ({})\n".format(status, trigger["id"], triggers_file))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/inject/codify-capture-step.md
+++ b/scripts/inject/codify-capture-step.md
@@ -1,0 +1,72 @@
+# Handoff: add a capture step to the `/codify` skill
+
+`.claude/skills/codify/SKILL.md` is blocked by the self-mod classifier, so this
+change is applied by hand. Two edits — insert a new **Step 5b**, and amend the
+**Step 6** `git add` line.
+
+This is the manual half of the JIT-injection capture loop ("Both"): when codify
+writes a rule/learning that has a textual signature, it also registers a
+write-time trigger so the mistake is caught in the editor next time, not only in
+review.
+
+---
+
+## 1. Insert this as a new step, after "Step 5 — Write the codification" and before "Step 6 — Commit"
+
+```markdown
+## Step 5b — Emit a write-time trigger (only if the finding has a textual signature)
+
+For any rule/learning you just codified that has a **clear, regex-matchable
+signature** — a specific decorator, import, function call, or code shape that
+appears in the code being written — also register a just-in-time trigger so it
+fires at write-time, not only in review:
+
+\```bash
+python3 scripts/inject/capture_trigger.py \
+  --id <kebab-id> \
+  --domains <d1,d2> \
+  --path-glob '<repo-relative fnmatch glob>' \
+  --content-present '<regex matched against the NEW edit fragment>' \
+  --content-absent '<regex on the RESULTING file that suppresses when the fix is present>' \
+  --message '<one-line warning + the fix>' \
+  --pattern-ref <path/to/pattern-doc.md> \
+  --source "codify: $(git branch --show-current)" \
+  --severity warn
+\```
+
+Rules:
+- Use `--severity warn` here (human-curated). Leave `candidate` for review automation.
+- Do this ONLY when a real signature exists. A signature-less lesson stays prose —
+  forcing it into a trigger manufactures false positives and erodes trust in the
+  whole system (per the spec's seeding rule).
+- `--content-present` matches the new fragment ("are you introducing X?");
+  `--content-absent` matches the resulting file ("...and is the fix missing?").
+  Omit `--content-absent` if there is no clean "already-fixed" marker.
+- `--pattern-ref` must resolve to a real file; capture_trigger drops it with a
+  warning if it doesn't (no dangling pointers).
+- After capturing, run `python3 scripts/inject/test_match_triggers.py` to confirm
+  the index still validates. For a high-traffic trigger, add a positive AND a
+  negative fixture to `scripts/inject/test_match_triggers.py` before committing.
+```
+
+---
+
+## 2. Amend "Step 6 — Commit"
+
+Add `docs/rules/triggers.json` to the staged files whenever Step 5b captured a
+trigger:
+
+```bash
+git add docs/rules/<domain>.md docs/LEARNINGS.md docs/rules/triggers.json .claude/agents/<agent>.md
+```
+
+---
+
+## Notes
+
+- The automatic half of "Both" (review automation calling `capture_trigger.py`
+  with `--severity candidate`) is the fast-follow — the script already supports it
+  via the default severity; only the wiring into the review path remains.
+- `capture_trigger.py` is dedup-safe on `id` (idempotent) and rejects invalid
+  regex / missing required fields, so a bad codify invocation fails loudly rather
+  than corrupting the index.

--- a/scripts/inject/test_capture_trigger.py
+++ b/scripts/inject/test_capture_trigger.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""Tests for capture_trigger — appends a trigger to docs/rules/triggers.json.
+
+Run: python3 scripts/inject/test_capture_trigger.py
+"""
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, HERE)
+import capture_trigger as ct  # noqa: E402
+import match_triggers as mt  # noqa: E402
+
+SCRIPT = os.path.join(HERE, "capture_trigger.py")
+
+
+def tmp_index(entries):
+    fd, path = tempfile.mkstemp(suffix=".json")
+    with os.fdopen(fd, "w") as fh:
+        json.dump(entries, fh)
+    return path
+
+
+class TestBuildTrigger(unittest.TestCase):
+    def test_minimal_valid(self):
+        t = ct.build_trigger(
+            id="x-y", message="do the thing", path_glob=["backend/**/x.py"]
+        )
+        self.assertEqual(t["id"], "x-y")
+        self.assertEqual(t["severity"], "candidate")  # default
+        self.assertEqual(t["path_glob"], ["backend/**/x.py"])
+
+    def test_canonical_key_order_and_omits_empty(self):
+        t = ct.build_trigger(
+            id="a", message="m", path_glob=["p"], domains=["api"], severity="warn"
+        )
+        keys = list(t.keys())
+        # canonical order, and no None-valued optionals present
+        self.assertEqual(keys[0], "id")
+        self.assertIn("severity", keys)
+        self.assertNotIn("content_present", keys)  # omitted, not None
+        self.assertNotIn("pattern_ref", keys)
+
+    def test_missing_message_rejected(self):
+        with self.assertRaises(ValueError):
+            ct.build_trigger(id="a", message="", path_glob=["p"])
+
+    def test_missing_path_glob_rejected(self):
+        with self.assertRaises(ValueError):
+            ct.build_trigger(id="a", message="m", path_glob=[])
+
+    def test_invalid_regex_rejected(self):
+        with self.assertRaises(ValueError):
+            ct.build_trigger(id="a", message="m", path_glob=["p"], content_present="(unclosed")
+
+
+class TestCapture(unittest.TestCase):
+    def test_appends_new(self):
+        path = tmp_index([])
+        try:
+            status = ct.capture(path, ct.build_trigger(id="new", message="m", path_glob=["p"]))
+            self.assertEqual(status, "added")
+            data = ct.load(path)
+            self.assertEqual([t["id"] for t in data], ["new"])
+        finally:
+            os.remove(path)
+
+    def test_dedup_skips_existing(self):
+        path = tmp_index([])
+        try:
+            t = ct.build_trigger(id="dup", message="m", path_glob=["p"])
+            self.assertEqual(ct.capture(path, t), "added")
+            self.assertEqual(ct.capture(path, t), "exists")
+            self.assertEqual(len(ct.load(path)), 1)
+        finally:
+            os.remove(path)
+
+    def test_update_overwrites(self):
+        path = tmp_index([])
+        try:
+            ct.capture(path, ct.build_trigger(id="u", message="old", path_glob=["p"]))
+            ct.capture(path, ct.build_trigger(id="u", message="new", path_glob=["p"]), update=True)
+            data = ct.load(path)
+            self.assertEqual(len(data), 1)
+            self.assertEqual(data[0]["message"], "new")
+        finally:
+            os.remove(path)
+
+    def test_captured_trigger_then_matches(self):
+        """End-to-end: a captured trigger actually fires in the matcher."""
+        path = tmp_index([])
+        try:
+            ct.capture(path, ct.build_trigger(
+                id="no-print", message="no bare print()", path_glob=["backend/**/*.py"],
+                content_present=r"^\s*print\(", severity="warn",
+            ))
+            idx = ct.load(path)
+            hits = mt.find_matches(
+                "Write",
+                {"file_path": "backend/apps/x/util.py", "content": "    print('hi')\n"},
+                idx, None,
+            )
+            self.assertIn("no-print", [h["id"] for h in hits])
+        finally:
+            os.remove(path)
+
+
+class TestResolvePatternRef(unittest.TestCase):
+    def test_existing_ref_kept(self):
+        root = os.path.dirname(os.path.dirname(HERE))  # repo root
+        ref = "backend/docs/patterns/architecture/rate-limiting.md"
+        kept, warn = ct.resolve_pattern_ref(ref, root)
+        self.assertEqual(kept, ref)
+        self.assertIsNone(warn)
+
+    def test_missing_ref_dropped_with_warning(self):
+        root = os.path.dirname(os.path.dirname(HERE))
+        kept, warn = ct.resolve_pattern_ref("backend/docs/patterns/nope.md", root)
+        self.assertIsNone(kept)
+        self.assertIsNotNone(warn)
+
+
+class TestCLI(unittest.TestCase):
+    def _run(self, args, triggers_file):
+        env = dict(os.environ)
+        env["INJECT_TRIGGERS_FILE"] = triggers_file
+        return subprocess.run(
+            [sys.executable, SCRIPT] + args, capture_output=True, text=True, env=env
+        )
+
+    def test_cli_adds_then_dedups(self):
+        path = tmp_index([])
+        try:
+            args = [
+                "--id", "cli-x", "--message", "msg", "--path-glob", "backend/**/x.py",
+                "--domains", "api", "--severity", "warn", "--added", "2026-05-29",
+            ]
+            p1 = self._run(args, path)
+            self.assertEqual(p1.returncode, 0, p1.stderr)
+            self.assertEqual([t["id"] for t in ct.load(path)], ["cli-x"])
+            # second run: still one entry (dedup)
+            p2 = self._run(args, path)
+            self.assertEqual(p2.returncode, 0, p2.stderr)
+            self.assertEqual(len(ct.load(path)), 1)
+        finally:
+            os.remove(path)
+
+    def test_cli_missing_required_fails(self):
+        path = tmp_index([])
+        try:
+            p = self._run(["--id", "no-msg", "--path-glob", "p"], path)
+            self.assertNotEqual(p.returncode, 0)
+        finally:
+            os.remove(path)
+
+    def test_cli_invalid_regex_returns_2_and_leaves_index_unchanged(self):
+        # Guards the build_trigger ValueError -> main returns 2 propagation, so a
+        # later refactor can't silently swallow the error and exit 0.
+        path = tmp_index([])
+        try:
+            p = self._run(
+                ["--id", "bad", "--message", "m", "--path-glob", "p",
+                 "--content-present", "(unclosed"],
+                path,
+            )
+            self.assertEqual(p.returncode, 2)
+            self.assertEqual(ct.load(path), [])
+        finally:
+            os.remove(path)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Builds on the v1 spine (#298). Closes the loop so a caught mistake becomes a future write-time warning.

## What this adds

- **`scripts/inject/capture_trigger.py`** — appends a trigger to `docs/rules/triggers.json`. Strict dedup-on-`id` (idempotent), canonical key order, validates required fields + regex, drops a non-resolving `pattern_ref` with a warning (no dangling pointers). `--severity warn` for `/codify` (human-curated); default `candidate` for review automation (injects immediately, prunable later).
- **`scripts/inject/test_capture_trigger.py`** — 14 tests: build/validate, dedup, update, captured-then-matches end-to-end, pattern_ref resolution, and CLI (add+dedup, missing-required → non-zero, invalid-regex → exit 2 + index unchanged).
- **`scripts/inject/codify-capture-step.md`** — handoff to add Step 5b + the Step 6 `git add` change to the self-mod-blocked `/codify` skill (apply by hand).

## Manual step after merge

Apply the codify change per `scripts/inject/codify-capture-step.md` (the skill is `.claude/`-blocked).

## Testing

`python3 scripts/inject/test_capture_trigger.py` → 14 passing. Matcher suite still green (34). A review WARNING about CLI exit-code propagation was closed with a regression test; a TOCTOU WARNING was assessed as not applicable to a single-shot CLI.

## Deferred (fast-follow)

Auto-*wire* `capture_trigger.py` into the review path (kimi-review / reviewers calling it with `--severity candidate` — the script already supports it). Plus the `test-inject-patterns.sh` hook-test extension and the LSP todo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)