### PR TITLE
harness: activate JIT injection hook + codify capture handoff

### DIFF
--- a/.claude/hooks/inject-patterns.sh
+++ b/.claude/hooks/inject-patterns.sh
@@ -4,8 +4,23 @@
 # Rules live in docs/rules/<domain>.md (short by design). Long-form detail stays
 # in the per-stack */docs/patterns/ libraries — this hook only surfaces the
 # compact checklists plus a discipline preamble.
+#
+# PROPOSED v1 (just-in-time mistake injection). Changes vs current:
+#   1. Kill switch: INJECT_PATTERNS_DISABLE=1 exits early (no commit needed).
+#   2. Discipline preamble is now read from docs/rules/_discipline.md (editable
+#      without touching .claude/), not an inline heredoc.
+#   3. Content-matched recurring-mistake warnings via scripts/inject/match_triggers.py
+#      — injected only when a trigger matches the code being written.
+#   4. Domain-rule checklists are deduped once per session (session_id) to kill
+#      banner blindness. Discipline + matched mistakes are NEVER deduped.
+#
+# This file is .claude self-mod-blocked, so it ships as a handoff artifact. Apply:
+#   cp scripts/inject/inject-patterns.sh.proposed .claude/hooks/inject-patterns.sh
 # Tests: .claude/hooks/test-inject-patterns.sh
 set -uo pipefail
+
+# (1) Kill switch: instant disable with no commit (mirrors SKIP_KIMI_REVIEW=1).
+[[ -n "${INJECT_PATTERNS_DISABLE:-}" ]] && exit 0
 
 INPUT=$(cat)
 
@@ -13,6 +28,10 @@ TOOL_NAME=$(printf '%s' "$INPUT" | jq -re '.tool_name' 2>/dev/null) || exit 0
 FILE_PATH=$(printf '%s' "$INPUT" | jq -re '.tool_input.file_path' 2>/dev/null) || exit 0
 
 [[ "$TOOL_NAME" == "Edit" || "$TOOL_NAME" == "Write" || "$TOOL_NAME" == "MultiEdit" ]] || exit 0
+
+# session_id drives per-session dedup of the domain-rule tier (confirmed
+# PreToolUse stdin field). Empty on parse failure → dedup disabled (always inject).
+SESSION_ID=$(printf '%s' "$INPUT" | jq -re '.session_id' 2>/dev/null) || SESSION_ID=""
 
 # Resolve paths relative to project root (two levels up from .claude/hooks/)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -85,23 +104,38 @@ trap 'rm -f "$TMPFILE"' EXIT
 
 printf '=== Pre-write context for %s ===\n' "$FILE_PATH" >> "$TMPFILE"
 
-cat >> "$TMPFILE" <<'EOF'
+# (2) Always-on discipline floor, read from an editable data file. Never deduped.
+printf '\n' >> "$TMPFILE"
+cat "$RULES_DIR/_discipline.md" >> "$TMPFILE" 2>/dev/null
 
-[DISCIPLINE — applies before any edit]
-- Think before coding. State your assumptions out loud. If the request is ambiguous, ask. If a simpler approach exists, push back. Stop when you are confused, name what is unclear, do not just pick one interpretation and run.
-- Simplicity first. Write the minimum code that solves the problem. No speculative abstractions. No flexibility nobody asked for. The test: would a senior engineer call this overcomplicated.
-- Surgical changes. Touch only what the task requires. Do not improve neighboring code. Do not refactor what is not broken. Every changed line should trace back to the request.
-- Goal-driven execution. Turn vague instructions into verifiable targets before writing a line. "Add validation" becomes "write tests for invalid inputs, then make them pass."
-EOF
+# (3) Content-matched recurring-mistake warnings. Fires only on a real match;
+# can never break the hook's JSON (stderr discarded, non-zero exit absorbed,
+# final output escaped by jq --arg below).
+MATCH_OUT=""
+if command -v python3 >/dev/null 2>&1; then
+  MATCH_OUT=$(printf '%s' "$INPUT" \
+    | python3 "$PROJECT_ROOT/scripts/inject/match_triggers.py" 2>/dev/null) \
+    || MATCH_OUT=""
+fi
+if [ -n "$MATCH_OUT" ]; then
+  printf '\n[RECENT MISTAKES — matched this edit]\n%s\n' "$MATCH_OUT" >> "$TMPFILE"
+fi
 
+# (4) Domain-rule checklists, deduped once per session per domain.
 if [ -n "$DOMAINS" ]; then
   IFS=',' read -ra DOMAIN_LIST <<< "$DOMAINS"
   for DOMAIN in "${DOMAIN_LIST[@]}"; do
     RULES_FILE="$RULES_DIR/${DOMAIN}.md"
-    if [ -f "$RULES_FILE" ]; then
-      printf '\n[RULES — %s]\n' "$DOMAIN" >> "$TMPFILE"
-      cat "$RULES_FILE" >> "$TMPFILE"
+    [ -f "$RULES_FILE" ] || continue
+    MARKER=""
+    if [ -n "$SESSION_ID" ]; then
+      SAFE_ID=$(printf '%s' "$SESSION_ID" | tr -c 'A-Za-z0-9._-' '_')
+      MARKER="/tmp/inject-${SAFE_ID}-${DOMAIN}"
+      [ -f "$MARKER" ] && continue
     fi
+    printf '\n[RULES — %s]\n' "$DOMAIN" >> "$TMPFILE"
+    cat "$RULES_FILE" >> "$TMPFILE"
+    [ -n "$MARKER" ] && : > "$MARKER" 2>/dev/null || true
   done
 fi
 

--- a/scripts/inject/codify-SKILL.md.proposed
+++ b/scripts/inject/codify-SKILL.md.proposed
@@ -1,0 +1,168 @@
+---
+name: codify
+description: Use at the end of any session to extract and preserve patterns, learnings, and review rules discovered during the session's implementation work
+---
+
+# Codify
+
+You are running the codify workflow. Codify patterns, learnings, and agent rules
+from the current branch's implementation work. **Never skip steps.**
+
+## Step 1 — Assess the branch diff
+
+Run:
+
+```bash
+git diff main...HEAD --stat
+```
+
+Build a list of changed-file domains (read top-to-bottom, a path may match
+several rows):
+
+| Changed path matches                                    | Domain label(s)            |
+| -------------------------------------------------------- | -------------------------- |
+| `backend/apps/**/migrations/*`                           | `database`, `security`     |
+| `backend/apps/blog/**`                                   | `wagtail`, `api`           |
+| `backend/apps/**/serializers.py`, `**/api/**`            | `api`                      |
+| `backend/apps/**/views.py`, `**/viewsets.py`, `**/permissions.py` | `api`, `security` |
+| `backend/apps/**/models.py`                              | `database`, `security`     |
+| `backend/apps/**/tasks.py`, `**/celery*`                 | `celery`                   |
+| `backend/apps/**/cache*.py`, `**/signals.py`             | `caching`                  |
+| `backend/**/*.py` (other)                                | `security`                 |
+| `web/src/**/*.tsx`                                       | `react`, `typescript`      |
+| `web/src/**/*.ts`                                        | `typescript`               |
+| `plant_community_mobile/**/*.dart`                       | `flutter`                  |
+| `firebase/**`, `**/firebase*`                            | `firebase`, `security`     |
+| `**/tests/**`, `**/test_*.py`, `**/*.test.ts*`, `**/*.spec.ts*` | `testing`           |
+
+Combine all matched labels. If the diff is empty, output "Nothing to codify —
+no changes on this branch." and stop.
+
+## Step 2 — Run kimi-review on the branch diff
+
+The domain labels from Step 1 double as `docs/rules/` names. Run:
+
+```bash
+git diff main...HEAD | kimi-review --scope "session: $(git branch --show-current)" --profile plant_id --rules <comma-separated-domains>
+```
+
+**Store the full output in working context as `review_output`** — shell variables
+do not persist between Bash invocations. Also union in any kimi-review output that
+already appeared earlier in this session (the PreToolUse commit hook emits it).
+
+## Step 3 — Apply codification criteria
+
+**Codify if any one is true:**
+
+- The diff contains a workaround or constraint not documented in `docs/rules/`,
+  the `*/docs/patterns/` libraries, or `docs/LEARNINGS.md`.
+- The diff reveals a library gotcha or platform-specific behavior.
+- `review_output` contains a CRITICAL or WARNING finding — even if the fix is
+  already in the diff (a finding that required a repair is exactly the kind of
+  rule worth preserving).
+
+**Skip if all are true:**
+
+- The diff is a straightforward application of existing documented patterns.
+- All `review_output` findings are SUGGESTION-only.
+- The only changes are UI text, config values, or copy with no structural lesson.
+
+If nothing qualifies, output "Nothing to codify from this session." and stop.
+
+## Step 4 — Route each candidate
+
+For each codification candidate, pick the destination(s) by **nature of the
+finding**. A single finding may write to more than one target.
+
+| Finding nature                                                  | Destination |
+| ---------------------------------------------------------------- | ----------- |
+| One-line "always do X / never do Y" rule for an existing domain  | append a bullet to `docs/rules/<domain>.md` |
+| A reusable, multi-line pattern (code shape, approach, checklist) | the matching `*/docs/patterns/` doc — see table below |
+| A bug, incident, or hard-won gotcha with a root cause            | append an entry to `docs/LEARNINGS.md` (append-only log) |
+| A new repeatable review check                                   | the relevant review agent — see agent table below |
+
+**Pattern-doc locations** (append a section to the closest existing file; create
+a new file in the right subdirectory only if none fits):
+
+- Backend: `backend/docs/patterns/{security,architecture,domain,performance,api,testing}/`
+- Web: `web/docs/patterns/` (`react-typescript.md`, `tailwind.md`, `testing.md`)
+- Mobile: `plant_community_mobile/docs/patterns/` (`flutter-patterns.md`, `firebase-auth.md`, `riverpod.md`)
+- Firebase: `firebase/docs/patterns/` (`cloud-functions.md`, `firestore-rules.md`, `iam.md`)
+
+**Review-agent update routing** (only when the finding reveals a reusable check):
+
+| Finding domain  | Update agent(s)                                                     |
+| --------------- | ------------------------------------------------------------------- |
+| Security        | `.claude/agents/security-reviewer.md`                               |
+| Performance     | `.claude/agents/performance-reviewer.md`                            |
+| Django / DRF    | `.claude/agents/django-drf-reviewer.md`                             |
+| Wagtail         | `.claude/agents/wagtail-reviewer.md`                                |
+| API design      | `.claude/agents/api-design-reviewer.md`                             |
+| React / TS      | `.claude/agents/react-typescript-reviewer.md`                       |
+| Flutter         | `.claude/agents/flutter-dart-reviewer.md`, `flutter-firebase-reviewer.md` |
+| Firebase fns    | `.claude/agents/firebase-cloudfunction-reviewer.md`                 |
+| Celery / async  | `.claude/agents/celery-async-reviewer.md`                           |
+| Testing         | `.claude/agents/test-quality-reviewer.md`                           |
+
+## Step 5 — Write the codification
+
+- **`docs/rules/<domain>.md`** — append the bullet under the existing list. Keep
+  it one line, imperative, "always/never" phrased. Do not bloat the file; the
+  inject-patterns hook pastes it verbatim before every matching edit.
+- **`*/docs/patterns/` doc** — append a new `## <Pattern name>` section to the
+  closest existing file. Include a short rationale and a minimal code example.
+- **`docs/LEARNINGS.md`** — append a dated entry: what broke, the root cause, and
+  the fix. This file is the append-only incident log — never edit prior entries.
+- **Review agent** — add a checklist bullet (and a "Common Mistakes to Catch"
+  entry if it is a recurring gap).
+
+When unsure how to classify a finding, consult `.claude/agents/pattern-codifier.md`
+— it encodes this project's pattern-routing logic.
+
+## Step 5b — Emit a write-time trigger (only if the finding has a textual signature)
+
+For any rule/learning you just codified that has a **clear, regex-matchable
+signature** — a specific decorator, import, function call, or code shape that
+appears in the code being written — also register a just-in-time trigger so it
+fires at write-time, not only in review:
+
+```bash
+python3 scripts/inject/capture_trigger.py \
+  --id <kebab-id> \
+  --domains <d1,d2> \
+  --path-glob '<repo-relative fnmatch glob>' \
+  --content-present '<regex matched against the NEW edit fragment>' \
+  --content-absent '<regex on the RESULTING file that suppresses when the fix is present>' \
+  --message '<one-line warning + the fix>' \
+  --pattern-ref <path/to/pattern-doc.md> \
+  --source "codify: $(git branch --show-current)" \
+  --severity warn
+```
+
+Rules:
+
+- Use `--severity warn` here (human-curated). Leave `candidate` for review automation.
+- Do this ONLY when a real signature exists. A signature-less lesson stays prose —
+  forcing it into a trigger manufactures false positives and erodes trust in the
+  whole system.
+- `--content-present` matches the new fragment ("are you introducing X?");
+  `--content-absent` matches the resulting file ("...and is the fix missing?").
+  Omit `--content-absent` if there is no clean "already-fixed" marker.
+- `--pattern-ref` must resolve to a real file; `capture_trigger.py` drops it with
+  a warning if it doesn't (no dangling pointers).
+- After capturing, run `python3 scripts/inject/test_match_triggers.py` to confirm
+  the index still validates. For a high-traffic trigger, add a positive AND a
+  negative fixture to `scripts/inject/test_match_triggers.py` before committing.
+
+## Step 6 — Commit
+
+Stage each file you wrote explicitly — do not `git add` whole directories.
+
+```bash
+git add docs/rules/<domain>.md docs/LEARNINGS.md docs/rules/triggers.json .claude/agents/<agent>.md
+git commit -m "docs: codify findings from $(git branch --show-current)"
+```
+
+The pre-commit `kimi-review` gate re-runs on the staged diff; resolve any
+CRITICAL finding before the commit lands. Per project policy, never push to
+`main` directly — codification commits ride the feature branch / PR.


### PR DESCRIPTION
Activates the just-in-time mistake-injection system shipped in #298 / #299.

## Changes

- **`.claude/hooks/inject-patterns.sh`** — apply the proposed engine (was shipped as `scripts/inject/inject-patterns.sh.proposed` in #298; self-mod-blocked so installed by hand and committed here). Adds: kill switch (`INJECT_PATTERNS_DISABLE=1`), discipline floor read from `docs/rules/_discipline.md`, content-matched mistake warnings via `match_triggers.py`, per-session domain-rule dedup. Verified byte-identical to the proposed file; matcher's 34 tests + the 16 existing `test-inject-patterns.sh` cases pass.
- **`scripts/inject/codify-SKILL.md.proposed`** — full proposed `/codify` skill (Step 5b emits a trigger via `capture_trigger.py`; Step 6 stages `triggers.json`). Diff-verified against the current skill: only those two changes differ.

## Remaining manual step (one line)

The `/codify` skill itself is self-mod-blocked. After this merges:

```bash
cp scripts/inject/codify-SKILL.md.proposed .claude/skills/codify/SKILL.md
```

(then commit it on a branch — same reason this hook change had to be hand-applied)

## Verify live

Edit any `backend/**/views.py`, add an `@action` with no ratelimit → a `[RECENT MISTAKES]` warning injects before the edit. The discipline floor now renders from `_discipline.md` (confirmed live this session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)