### PR TITLE
feat(review): auto-capture candidate triggers from code review

### DIFF
--- a/.claude/agents/code-review-orchestrator.md
+++ b/.claude/agents/code-review-orchestrator.md
@@ -21,11 +21,13 @@ You are the code review orchestrator for the plant_id_community project. Your on
 ## Phase 1 — Triage
 
 Run this exact command and capture the output:
+
 ```bash
 git diff --name-only HEAD
 ```
 
 If that returns nothing (clean working tree), run:
+
 ```bash
 git diff --name-only HEAD~1
 ```
@@ -50,6 +52,7 @@ Map each changed file to domain agents using this routing table:
 Deduplicate: each agent ID appears only once in the final list.
 
 Return a JSON block:
+
 ```json
 {
   "changed_files": ["list of files"],
@@ -67,6 +70,21 @@ Batch label: incremental-<short SHA from git rev-parse --short HEAD> (<reviewer-
 Files:
   - <file path 1>
   - <file path 2>
+
+Additionally, attach an optional "trigger_signature" to any finding that is a
+RECURRING mistake with a precise textual signature — a specific decorator,
+import, call, or code shape that appears in the written code. Omit it for
+signature-less findings; never guess one.
+
+  "trigger_signature": {
+    "id": "<stable-kebab-id>",
+    "path_glob": ["<repo-relative fnmatch glob>"],
+    "content_present": "<regex matched on newly-written code — REQUIRED>",
+    "content_absent": "<optional regex; suppress when the fix is already present>",
+    "message": "<one-line warning + the fix>",
+    "pattern_ref": "<optional path to a pattern doc>",
+    "domains": ["<optional domain labels>"]
+  }
 ```
 
 Each reviewer returns its findings JSON (per its `## Output Format (Review Mode)` section). Main Claude collects all results and re-invokes this orchestrator for Phase 2 with the merged JSON.
@@ -99,9 +117,26 @@ Present:
 Repair CRITICAL + HIGH + MEDIUM findings? (yes / no / select numbers)
 ```
 
+## Phase 2.5 — Capture write-time triggers
+
+After merging/deduplicating findings, register candidate write-time triggers from
+any finding that carries a `trigger_signature`. Tell main Claude to write the
+merged findings JSON array to a temp file and pipe it through the capture helper:
+
+```bash
+python3 scripts/inject/capture_from_review.py /tmp/review-findings.json
+```
+
+This appends `severity: candidate` (provisional, prunable) triggers to
+`docs/rules/triggers.json`, so the same mistakes are flagged at write-time in
+future sessions. The helper is idempotent (dedup on id), validates regexes, drops
+dangling `pattern_ref`s, and skips signatures without a `content_present`. Print
+its one-line summary to the user. Capture is non-fatal — if it errors, continue.
+
 ## Phase 3 — Repair
 
 If user confirms repair:
+
 - Group findings to repair by file. For each file, pick the repair owner: re-evaluate the routing table from Phase 1 against that file path; the first matching agent that's also present in any of the file's findings' `agents` arrays is the owner. Tell main Claude to dispatch the owner in repair mode with the file path and the list of findings (line + description) for that file.
 - The dispatch prompt for repair mode:
 
@@ -115,6 +150,7 @@ Findings:
 ```
 
 Substitute the placeholders before dispatch.
+
 - The reviewer returns `{file, edits: [{old_string, new_string}, ...], unrepaired?: [{line, reason}]}`. Main Claude applies each edit via the Edit tool. For each entry in `unrepaired`, print to the user: `⚠️ Unrepaired (manual): <file>:<line> — <reason>` and append the entry to `todos/YYYY-MM-DD-review.md` under a `## Unrepaired Findings` heading so it isn't lost.
 - Confirm each repair to the user.
 
@@ -124,6 +160,7 @@ Tell main Claude to write all LOW/INFO findings to:
 `todos/YYYY-MM-DD-review.md`
 
 Format:
+
 ```markdown
 # Review Findings — YYYY-MM-DD
 

--- a/docs/superpowers/specs/2026-05-29-jit-mistake-injection-design.md
+++ b/docs/superpowers/specs/2026-05-29-jit-mistake-injection-design.md
@@ -380,7 +380,16 @@ via #298):
   Step 6 `git add` change to the (self-mod-blocked) `/codify` skill. ⏳ awaiting
   user apply.
 
-Remaining follow-ups: auto-*wire* `capture_trigger.py` into the review path
-(kimi-review / reviewers calling it with `--severity candidate` — the script
-already supports it); the `test-inject-patterns.sh` hook-test extension; and the
+## Implementation status — review-path auto-capture (2026-05-29)
+
+Done (branch `feat/review-trigger-capture`): reviewers may attach a
+`trigger_signature` to a finding (code-review-orchestrator dispatch prompt), and a
+new orchestrator **Phase 2.5** pipes merged findings to
+`scripts/inject/capture_from_review.py`, which appends `severity: candidate`
+triggers. Reuses `capture_trigger.py`; safe by construction (candidate + prunable,
+dedup-on-id, regex-validated, skips signatures without `content_present`, non-fatal
+on IO error). 15 tests. The kimi-review commit gate was deliberately *not* wired
+(every-commit volume = noise); on-demand orchestrator review only.
+
+Remaining follow-ups: the `test-inject-patterns.sh` hook-test extension; and the
 LSP todo.

--- a/scripts/inject/capture_from_review.py
+++ b/scripts/inject/capture_from_review.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Turn code-review findings into candidate write-time triggers.
+
+The code-review orchestrator pipes its merged findings JSON here (stdin or a file
+arg). For each finding carrying a `trigger_signature` (which the reviewer that
+found it emits only when a clean textual signature exists), this appends a
+`severity: candidate` trigger to docs/rules/triggers.json so the same mistake is
+flagged at write-time in future sessions.
+
+Safe by construction: candidates are provisional + prunable, dedup is strict on
+id, regexes are validated, and a signature without a `content_present` is skipped
+(a path-only review trigger would fire on every edit to that path — pure noise).
+Malformed input is non-fatal: exits 0, index untouched.
+
+Input shapes accepted (liberal):
+  - a list of findings
+  - a list of reviewer results ({agent, batch_label, findings: [...]})
+  - a dict with a top-level "findings" array
+
+Env: INJECT_TRIGGERS_FILE overrides the index path (used by tests).
+"""
+import json
+import os
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, HERE)
+import capture_trigger as ct  # noqa: E402
+
+
+def extract_findings(data):
+    """Normalise assorted review payloads into a flat list of finding dicts."""
+    if isinstance(data, dict):
+        data = data.get("findings", [])
+    if not isinstance(data, list):
+        return []
+    findings = []
+    for item in data:
+        if not isinstance(item, dict):
+            continue
+        if isinstance(item.get("findings"), list):
+            # reviewer-result object: flatten, propagating attribution
+            label = item.get("batch_label") or item.get("agent")
+            for f in item["findings"]:
+                if isinstance(f, dict):
+                    if label and "batch_label" not in f:
+                        f = dict(f, batch_label=label)
+                    findings.append(f)
+        else:
+            findings.append(item)
+    return findings
+
+
+def _source(finding):
+    label = finding.get("batch_label") or finding.get("agent") or "orchestrator"
+    return "review: {}".format(label)
+
+
+def process(findings, triggers_path, severity="candidate"):
+    """Capture a candidate trigger for each finding with a usable trigger_signature."""
+    results = {"captured": [], "exists": [], "skipped": [], "errors": []}
+    project_root = ct.default_root()
+    for f in findings:
+        if not isinstance(f, dict):
+            continue
+        ts = f.get("trigger_signature")
+        if not isinstance(ts, dict):
+            continue
+        if not ts.get("content_present"):
+            results["skipped"].append(
+                {"id": ts.get("id"), "reason": "no content_present (would fire on every edit to the path)"}
+            )
+            continue
+        pattern_ref, warn = ct.resolve_pattern_ref(ts.get("pattern_ref"), project_root)
+        if warn:
+            sys.stderr.write("capture_from_review: {} ({})\n".format(warn, ts.get("id")))
+        try:
+            trigger = ct.build_trigger(
+                id=ts.get("id") or "",
+                message=ts.get("message") or f.get("description") or "review finding",
+                path_glob=ts.get("path_glob") or [],
+                domains=ts.get("domains"),
+                content_present=ts.get("content_present"),
+                content_absent=ts.get("content_absent"),
+                pattern_ref=pattern_ref,
+                source=_source(f),
+                severity=severity,
+            )
+        except ValueError as e:
+            results["errors"].append({"id": ts.get("id"), "error": str(e)})
+            continue
+        try:
+            status = ct.capture(triggers_path, trigger)
+        except Exception as e:  # IO/permission failure must not abort the review
+            results["errors"].append({"id": trigger["id"], "error": "capture failed: {}".format(e)})
+            continue
+        results["captured" if status == "added" else "exists"].append(trigger["id"])
+    return results
+
+
+def _summary(results):
+    lines = []
+    if results["captured"]:
+        lines.append("captured {} candidate trigger(s): {}".format(
+            len(results["captured"]), ", ".join(results["captured"])))
+    if results["exists"]:
+        lines.append("{} already present (no-op): {}".format(
+            len(results["exists"]), ", ".join(results["exists"])))
+    if results["skipped"]:
+        lines.append("{} skipped (no content signature): {}".format(
+            len(results["skipped"]), ", ".join(str(s.get("id")) for s in results["skipped"])))
+    if results["errors"]:
+        lines.append("{} error(s): {}".format(
+            len(results["errors"]),
+            "; ".join("{}: {}".format(e.get("id"), e.get("error")) for e in results["errors"])))
+    if not lines:
+        lines.append("no trigger_signature findings — nothing captured")
+    return "\n".join(lines)
+
+
+def main(argv=None):
+    argv = sys.argv[1:] if argv is None else argv
+    try:
+        raw = open(argv[0]).read() if argv else sys.stdin.read()
+        data = json.loads(raw)
+    except Exception as e:
+        sys.stderr.write("capture_from_review: could not read findings JSON ({}); nothing captured\n".format(e))
+        return 0
+    triggers_path = os.environ.get("INJECT_TRIGGERS_FILE") or os.path.join(
+        ct.default_root(), "docs", "rules", "triggers.json"
+    )
+    results = process(extract_findings(data), triggers_path)
+    sys.stdout.write(_summary(results) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/inject/test_capture_from_review.py
+++ b/scripts/inject/test_capture_from_review.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""Tests for capture_from_review — turns review findings into candidate triggers.
+
+Run: python3 scripts/inject/test_capture_from_review.py
+"""
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, HERE)
+import capture_from_review as cfr  # noqa: E402
+import capture_trigger as ct  # noqa: E402
+
+SCRIPT = os.path.join(HERE, "capture_from_review.py")
+
+
+def tmp_index():
+    fd, path = tempfile.mkstemp(suffix=".json")
+    with os.fdopen(fd, "w") as fh:
+        fh.write("[]")
+    return path
+
+
+def sig(**kw):
+    base = {
+        "id": "drf-action-no-ratelimit",
+        "path_glob": ["backend/**/*_views.py"],
+        "content_present": r"@action\b",
+        "message": "New @action without a ratelimit",
+    }
+    base.update(kw)
+    return base
+
+
+def finding(**kw):
+    f = {"severity": "high", "file": "backend/apps/forum_integration/api_views.py",
+         "line": 12, "description": "endpoint missing ratelimit"}
+    f.update(kw)
+    return f
+
+
+class TestProcess(unittest.TestCase):
+    def test_captures_candidate_from_signature(self):
+        path = tmp_index()
+        try:
+            res = cfr.process([finding(trigger_signature=sig())], path)
+            self.assertEqual(res["captured"], ["drf-action-no-ratelimit"])
+            data = ct.load(path)
+            self.assertEqual(len(data), 1)
+            self.assertEqual(data[0]["severity"], "candidate")
+            self.assertTrue(data[0]["source"].startswith("review"))
+        finally:
+            os.remove(path)
+
+    def test_finding_without_signature_ignored(self):
+        path = tmp_index()
+        try:
+            res = cfr.process([finding()], path)
+            self.assertEqual(res["captured"], [])
+            self.assertEqual(ct.load(path), [])
+        finally:
+            os.remove(path)
+
+    def test_signature_without_content_present_skipped(self):
+        path = tmp_index()
+        try:
+            s = sig()
+            del s["content_present"]
+            res = cfr.process([finding(trigger_signature=s)], path)
+            self.assertEqual(res["captured"], [])
+            self.assertEqual(len(res["skipped"]), 1)
+            self.assertEqual(ct.load(path), [])
+        finally:
+            os.remove(path)
+
+    def test_bad_regex_is_error_not_captured(self):
+        path = tmp_index()
+        try:
+            res = cfr.process([finding(trigger_signature=sig(content_present="(unclosed"))], path)
+            self.assertEqual(res["captured"], [])
+            self.assertEqual(len(res["errors"]), 1)
+            self.assertEqual(ct.load(path), [])
+        finally:
+            os.remove(path)
+
+    def test_duplicate_id_dedups(self):
+        path = tmp_index()
+        try:
+            res = cfr.process(
+                [finding(trigger_signature=sig()), finding(trigger_signature=sig())], path
+            )
+            self.assertEqual(res["captured"], ["drf-action-no-ratelimit"])
+            self.assertEqual(res["exists"], ["drf-action-no-ratelimit"])
+            self.assertEqual(len(ct.load(path)), 1)
+        finally:
+            os.remove(path)
+
+    def test_idempotent_second_run(self):
+        path = tmp_index()
+        try:
+            cfr.process([finding(trigger_signature=sig())], path)
+            res = cfr.process([finding(trigger_signature=sig())], path)
+            self.assertEqual(res["captured"], [])
+            self.assertEqual(res["exists"], ["drf-action-no-ratelimit"])
+        finally:
+            os.remove(path)
+
+    def test_message_falls_back_to_description(self):
+        path = tmp_index()
+        try:
+            s = sig()
+            del s["message"]
+            cfr.process([finding(description="my desc", trigger_signature=s)], path)
+            self.assertEqual(ct.load(path)[0]["message"], "my desc")
+        finally:
+            os.remove(path)
+
+    def test_capture_io_failure_is_recorded_not_raised(self):
+        # triggers_path pointing at a directory makes ct.capture's write fail;
+        # the helper must record an error and keep going, never crash the review.
+        d = tempfile.mkdtemp()
+        try:
+            res = cfr.process([finding(trigger_signature=sig())], d)
+            self.assertEqual(res["captured"], [])
+            self.assertEqual(len(res["errors"]), 1)
+        finally:
+            os.rmdir(d)
+
+    def test_empty_id_recorded_as_error(self):
+        path = tmp_index()
+        try:
+            res = cfr.process([finding(trigger_signature=sig(id=""))], path)
+            self.assertEqual(res["captured"], [])
+            self.assertEqual(len(res["errors"]), 1)
+            self.assertEqual(ct.load(path), [])
+        finally:
+            os.remove(path)
+
+    def test_source_includes_batch_label(self):
+        path = tmp_index()
+        try:
+            cfr.process(
+                [finding(batch_label="incremental-abc123 (django-drf-reviewer)",
+                         trigger_signature=sig())],
+                path,
+            )
+            self.assertIn("abc123", ct.load(path)[0]["source"])
+        finally:
+            os.remove(path)
+
+
+class TestExtractFindings(unittest.TestCase):
+    def test_plain_list_of_findings(self):
+        out = cfr.extract_findings([finding(trigger_signature=sig())])
+        self.assertEqual(len(out), 1)
+
+    def test_reviewer_result_objects_flattened(self):
+        data = [
+            {"agent": "django-drf-reviewer", "batch_label": "b1",
+             "findings": [finding(trigger_signature=sig())]},
+            {"agent": "security-reviewer", "batch_label": "b2", "findings": []},
+        ]
+        out = cfr.extract_findings(data)
+        self.assertEqual(len(out), 1)
+        # batch_label propagated onto the finding for source attribution
+        self.assertEqual(out[0].get("batch_label"), "b1")
+
+    def test_dict_with_findings(self):
+        out = cfr.extract_findings({"findings": [finding(trigger_signature=sig())]})
+        self.assertEqual(len(out), 1)
+
+
+class TestCLI(unittest.TestCase):
+    def test_stdin_pipe_captures(self):
+        path = tmp_index()
+        try:
+            env = dict(os.environ)
+            env["INJECT_TRIGGERS_FILE"] = path
+            payload = json.dumps([finding(trigger_signature=sig())])
+            p = subprocess.run([sys.executable, SCRIPT], input=payload,
+                               capture_output=True, text=True, env=env)
+            self.assertEqual(p.returncode, 0, p.stderr)
+            self.assertEqual(len(ct.load(path)), 1)
+            self.assertIn("captured", p.stdout.lower())
+        finally:
+            os.remove(path)
+
+    def test_malformed_stdin_is_nonfatal(self):
+        path = tmp_index()
+        try:
+            env = dict(os.environ)
+            env["INJECT_TRIGGERS_FILE"] = path
+            p = subprocess.run([sys.executable, SCRIPT], input="not json",
+                               capture_output=True, text=True, env=env)
+            # Non-fatal: exits 0, index untouched
+            self.assertEqual(p.returncode, 0, p.stderr)
+            self.assertEqual(ct.load(path), [])
+        finally:
+            os.remove(path)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Closes the last fast-follow of JIT mistake injection: the review path now feeds the trigger index automatically.

## How it works

1. **Reviewers emit the signature.** The code-review orchestrator's dispatch prompt asks each reviewer to attach an optional `trigger_signature` (id / path_glob / `content_present` / `content_absent` / message / pattern_ref / domains) to a finding **only when it has a precise textual signature**. The model that finds the issue is the only thing that can reliably articulate the regex — so it does.
2. **Phase 2.5 captures.** After findings merge/dedup, the orchestrator pipes them to `scripts/inject/capture_from_review.py`, which appends `severity: candidate` triggers to `docs/rules/triggers.json`.

## Why this shape

- **Orchestrator, not the commit gate.** Wiring into every-commit kimi-review would fire candidates constantly (noise). On-demand review = fewer, richer findings.
- **`scripts/kimi-review` untouched** — it's drift-locked; editing it breaks the pre-commit engine check.
- **Logic outside `.claude/`.** The orchestrator edit is tiny (dispatch instruction + one phase); all logic lives in the testable `capture_from_review.py`.

## Safety (candidates can't become noise)

`severity: candidate` (provisional, prunable), dedup-on-id (idempotent), regexes validated, signatures without a `content_present` skipped (a path-only review trigger would fire on every edit = noise), and IO failures are non-fatal so a bad capture never aborts a review.

## Testing

`scripts/inject/test_capture_from_review.py` — 15 tests (capture/ignore/skip/error, dedup + idempotency, message+source fallback, reviewer-result flattening, CLI stdin + malformed-input non-fatal, capture-IO-failure recorded-not-raised). Full inject suite green (match 34 · capture 14 · from-review 15). Verified the orchestrator's exact Phase 2.5 command end-to-end against a temp index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)