### PR TITLE
docs: codify harness learnings (kimi-engine drift-lock + write-time trigger)

### DIFF
--- a/docs/LEARNINGS.md
+++ b/docs/LEARNINGS.md
@@ -313,3 +313,10 @@ This file is append-only. New entries are added by main Claude after each code r
 **Fix**: Verified the branch was a strict superset of the squash (only the squash commit was ahead on main), resolved `api_views.py` to the branch's evolved version, kept the branch's todo states, and removed the resurrected `pending` dupes.
 **Rule**: After a feature branch is squash-merged to main, rebase/reconcile before continuing — expect code conflicts (squashed vs evolved) AND resurrected completed-todo files. Before committing such a merge, grep for any `todos/<id>-pending-*` that also has a `todos/archive/<id>-*`.
 **Agent**: baseline
+
+### [2026-05-29] Harness: `scripts/kimi-review` is drift-locked; recurring mistakes now flagged at write-time
+
+**Mistake/Context**: Building review-time trigger capture (#298–302) surfaced a harness trap: `scripts/kimi-review` is a *vendored* copy of a canonical engine, and `scripts/check-kimi-engine.sh` runs in pre-commit and blocks the commit if the vendored copy drifts — so editing `scripts/kimi-review` directly breaks the commit gate.
+**Fix/Pattern**: To change the review engine, edit the canonical copy and run `scripts/sync-kimi-engine.sh`; never edit the vendored `scripts/kimi-review`. Separately, recurring mistakes are now flagged at write-time from `docs/rules/triggers.json` (matcher `scripts/inject/match_triggers.py`, injected by `.claude/hooks/inject-patterns.sh`); add one via `scripts/inject/capture_trigger.py`, or auto-capture from review via the code-review orchestrator's Phase 2.5 → `scripts/inject/capture_from_review.py`. Design: `docs/superpowers/specs/2026-05-29-jit-mistake-injection-design.md`.
+**Rule**: Never edit `scripts/kimi-review` directly (drift-checked vendored engine) — sync via `scripts/sync-kimi-engine.sh`. A recurring, signature-able mistake belongs in `triggers.json`, not only in a prose rule.
+**Agent**: —

--- a/docs/rules/triggers.json
+++ b/docs/rules/triggers.json
@@ -1,8 +1,15 @@
 [
   {
     "id": "drf-action-no-ratelimit",
-    "domains": ["api", "security"],
-    "path_glob": ["backend/**/views.py", "backend/**/viewsets.py", "backend/**/*_views.py"],
+    "domains": [
+      "api",
+      "security"
+    ],
+    "path_glob": [
+      "backend/**/views.py",
+      "backend/**/viewsets.py",
+      "backend/**/*_views.py"
+    ],
     "content_present": "@action\\b",
     "content_absent": "ratelimit|is_ratelimited|Ratelimited",
     "message": "New @action endpoint — confirm a rate limit applies. 5 forum actions shipped without one (todos 104-109).",
@@ -13,8 +20,13 @@
   },
   {
     "id": "migration-fstring-sql",
-    "domains": ["database", "security"],
-    "path_glob": ["backend/**/migrations/*.py"],
+    "domains": [
+      "database",
+      "security"
+    ],
+    "path_glob": [
+      "backend/**/migrations/*.py"
+    ],
     "content_present": "(RunSQL|cursor\\.execute|execute)\\(\\s*f[\"']",
     "content_absent": "sql\\.Identifier|psycopg2\\.sql",
     "message": "Raw SQL built with an f-string in a migration — f-strings concatenate table/column names with no escaping (injection). Use psycopg2.sql.Identifier() + a whitelist.",
@@ -25,8 +37,16 @@
   },
   {
     "id": "viewset-get-permissions-no-super",
-    "domains": ["api", "security"],
-    "path_glob": ["backend/**/views.py", "backend/**/viewsets.py", "backend/**/*_views.py", "backend/**/permissions.py"],
+    "domains": [
+      "api",
+      "security"
+    ],
+    "path_glob": [
+      "backend/**/views.py",
+      "backend/**/viewsets.py",
+      "backend/**/*_views.py",
+      "backend/**/permissions.py"
+    ],
     "content_present": "def get_permissions\\b",
     "content_absent": "super\\(\\)\\.get_permissions",
     "message": "Custom get_permissions() must delegate custom @action names to super().get_permissions(), or action-level permission_classes are silently ignored (security hole).",
@@ -37,8 +57,14 @@
   },
   {
     "id": "react-router-bare-import",
-    "domains": ["react", "typescript"],
-    "path_glob": ["web/**/*.tsx", "web/**/*.ts"],
+    "domains": [
+      "react",
+      "typescript"
+    ],
+    "path_glob": [
+      "web/**/*.tsx",
+      "web/**/*.ts"
+    ],
     "content_present": "from [\"']react-router[\"']",
     "message": "Import router hooks from 'react-router-dom', not 'react-router' — the bare package silently crashes at runtime (Cannot read properties of undefined).",
     "pattern_ref": "web/docs/patterns/react-typescript.md",
@@ -48,8 +74,13 @@
   },
   {
     "id": "wagtail-signal-hasattr-pagetype",
-    "domains": ["wagtail"],
-    "path_glob": ["backend/**/signals.py", "backend/apps/blog/*.py"],
+    "domains": [
+      "wagtail"
+    ],
+    "path_glob": [
+      "backend/**/signals.py",
+      "backend/apps/blog/*.py"
+    ],
     "content_present": "hasattr\\([^)]*[\"'][a-z]+page[\"']",
     "message": "Use isinstance(instance, BlogPostPage), not hasattr(...page...), for Wagtail page-type checks in signal handlers — multi-table inheritance makes hasattr unreliable.",
     "pattern_ref": "backend/docs/patterns/domain/wagtail.md",
@@ -59,13 +90,34 @@
   },
   {
     "id": "drf-nonatomic-counter",
-    "domains": ["api", "database"],
-    "path_glob": ["backend/**/services.py", "backend/**/models.py", "backend/**/views.py", "backend/**/*_views.py"],
+    "domains": [
+      "api",
+      "database"
+    ],
+    "path_glob": [
+      "backend/**/services.py",
+      "backend/**/models.py",
+      "backend/**/views.py",
+      "backend/**/*_views.py"
+    ],
     "content_present": "\\.\\w+_count\\s*\\+=",
     "content_absent": "F\\([\"']",
     "message": "Non-atomic increment of a model-field counter (obj.x_count += 1) races under concurrency. Use an F() expression: .update(x_count=F('x_count') + 1).",
     "pattern_ref": "backend/docs/patterns/performance/query-optimization.md",
     "source": "todos/archive 113, 116",
+    "added": "2026-05-29",
+    "severity": "warn"
+  },
+  {
+    "id": "kimi-review-engine-drift-locked",
+    "domains": [
+      "tooling"
+    ],
+    "path_glob": [
+      "scripts/kimi-review"
+    ],
+    "message": "scripts/kimi-review is a drift-checked vendored engine; editing it directly fails the pre-commit gate (check-kimi-engine.sh). Sync from canonical via scripts/sync-kimi-engine.sh instead.",
+    "source": "codify: chore/codify-harness-learnings",
     "added": "2026-05-29",
     "severity": "warn"
   }


### PR DESCRIPTION
`/codify` output for the JIT-injection session. The branch diff that triggered it (the agent markdownlint cleanup, #303) was formatting-only with no structural lesson, but the session surfaced one durable shared-repo learning worth preserving:

- **LEARNINGS.md** (Tooling/Agents): `scripts/kimi-review` is a drift-checked *vendored* engine — editing it directly fails the pre-commit gate (`check-kimi-engine.sh`); sync via `scripts/sync-kimi-engine.sh`. Plus a pointer to the new write-time mistake-injection system.
- **triggers.json**: a `severity: warn` guardrail (`kimi-review-engine-drift-locked`) that fires at write-time on any edit to `scripts/kimi-review`. Path-only and near-zero noise (that file is edited rarely). Verified it fires on `scripts/kimi-review` and not on sibling scripts; 34 index tests pass.

Dog-fooding the system this session built: a real harness trap is now a write-time warning, not just a prose note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)