### PR TITLE
fix(forum): searchForum — forward page params, derive has_next from result count

### DIFF
--- a/web/src/services/forumService.ts
+++ b/web/src/services/forumService.ts
@@ -282,9 +282,11 @@ export async function reorderPostImages(
 // ---------------------------------------------------------------------------
 
 export async function searchForum(options: SearchForumOptions): Promise<SearchForumResponse> {
-  const { q } = options;
+  const { q, page = 1, page_size = 20 } = options;
   if (!q || q.trim() === '') throw new Error('Search query is required');
   const params = new URLSearchParams({ q: q.trim() });
+  if (page > 1) params.set('page', String(page));
+  if (page_size !== 20) params.set('page_size', String(page_size));
   const data = await authenticatedFetch<{ topics: BackendTopic[]; posts: BackendPost[] }>(
     `${FORUM_BASE}/search/?${params}`
   );
@@ -298,9 +300,9 @@ export async function searchForum(options: SearchForumOptions): Promise<SearchFo
     posts,
     total_threads: threads.length,
     total_posts: posts.length,
-    has_next_threads: false,
-    has_next_posts: false,
-    page: 1,
-    page_size: threads.length + posts.length,
+    has_next_threads: threads.length >= 10,
+    has_next_posts: posts.length >= 10,
+    page,
+    page_size: page_size ?? threads.length + posts.length,
   } as SearchForumResponse;
 }

--- a/web/src/services/forumService.ts
+++ b/web/src/services/forumService.ts
@@ -300,8 +300,8 @@ export async function searchForum(options: SearchForumOptions): Promise<SearchFo
     posts,
     total_threads: threads.length,
     total_posts: posts.length,
-    has_next_threads: threads.length >= 10,
-    has_next_posts: posts.length >= 10,
+    has_next_threads: threads.length >= page_size,
+    has_next_posts: posts.length >= page_size,
     page,
     page_size: page_size ?? threads.length + posts.length,
   } as SearchForumResponse;


### PR DESCRIPTION
Clean re-do of #293 — cherry-picks just the two real commits (`f098576`, `c85164b`) onto current `main`. The original #293 branch was stale (forked pre-#290, carried 45 already-merged commits and would have resurrected `todos/095-pending`), so this isolates the actual fix.

## Change (`web/src/services/forumService.ts`, +7/-5)

`searchForum` now forwards `page`/`page_size` to the backend (previously dropped) and derives `has_next_*` from the result count instead of hardcoding `false`.

## Reviewed — known minor caveats (non-blocking)

- `has_next_*: length >= page_size` is a heuristic; it shows a phantom "next page" on a full last page. Fine as an interim if the backend search endpoint returns no pagination metadata.
- `page_size: page_size ?? (...)` — `page_size` always has a default (20), so the `??` fallback is dead code. Harmless.

Supersedes #293 (close that one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)