### PR TITLE
fix: correct formatter commit SHA in .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -3,4 +3,5 @@
 # Or set permanently: git config blame.ignoreRevsFile .git-blame-ignore-revs
 
 # style: apply black + isort formatter repo-wide (2026-05-31)
-6041c70
+# (squash-merged as fc85fd7 on main — use this SHA, not the pre-merge 6041c70)
+fc85fd7


### PR DESCRIPTION
## Summary

PR #311 was squash-merged, so the formatter commit SHA recorded in `.git-blame-ignore-revs` (`6041c70`) no longer exists in `main`'s linear history. `git blame --ignore-revs-file` silently skips unknown SHAs, making the file a no-op.

Replaces `6041c70` with `fc85fd7` (the squash commit on `main`).

## Test plan

- [ ] `git log --oneline main | grep fc85fd7` confirms the SHA exists
- [ ] `git blame --ignore-revs-file .git-blame-ignore-revs backend/apps/blog/models.py` skips the style commit and shows logical authors

🤖 Generated with [Claude Code](https://claude.com/claude-code)