### PR TITLE
chore: track pre-existing CI failures as todos 136 and 137

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -3,4 +3,5 @@
 # Or set permanently: git config blame.ignoreRevsFile .git-blame-ignore-revs
 
 # style: apply black + isort formatter repo-wide (2026-05-31)
-6041c70
+# (squash-merged as fc85fd7 on main — use this SHA, not the pre-merge 6041c70)
+fc85fd7

--- a/todos/136-pending-p2-add-cve-2026-31236-to-pip-audit-ignore.md
+++ b/todos/136-pending-p2-add-cve-2026-31236-to-pip-audit-ignore.md
@@ -1,0 +1,51 @@
+---
+status: pending
+priority: p2
+issue_id: "136"
+tags: [security, ci, dependencies]
+dependencies: []
+estimated_effort: "30 minutes"
+---
+
+# Add CVE-2026-31236 (llm 0.27.1) to pip-audit ignore list or upgrade
+
+## Problem
+
+The Backend Python Security Scan CI job is failing on every PR because `llm 0.27.1`
+has a new advisory (`CVE-2026-31236`) that is not yet in the pip-audit suppression
+list. This blocks the Security Scan Summary check and creates noise on every PR.
+
+Discovered: 2026-05-31 via `gh run view` on PR #312.
+
+## Findings
+
+```text
+Found 1 known vulnerability, ignored 1 in 1 package
+Name    Version  ID             Fix Versions
+----    -------  -------------- ------------
+llm     0.27.1   CVE-2026-31236
+```
+
+The existing suppressed advisories are in the CI workflow's `pip-audit` invocation
+(`.github/workflows/*.yml`). Each suppression is documented with a rationale comment.
+
+## Recommended Action
+
+1. Look up CVE-2026-31236 to determine if a patched `llm` version exists.
+   - If a fix exists: upgrade `llm` in `backend/requirements.txt`.
+   - If no fix exists: add `--ignore-vuln CVE-2026-31236` to the pip-audit command
+     in the security scan workflow, with a comment explaining reachability and
+     the condition for removal.
+2. Verify the CI job goes green.
+
+## Acceptance Criteria
+
+- [ ] `Backend Python Security Scan` CI check passes on a new PR.
+- [ ] Either `llm` is upgraded past the patched version, or the CVE is documented
+      in the workflow's suppression block with a rationale and removal condition.
+
+## Work Log
+
+### 2026-05-31 - Created
+
+Surfaced while investigating CI failures blocking auto-merge of PR #312.

--- a/todos/137-pending-p2-fix-diagnosisservice-test-failures.md
+++ b/todos/137-pending-p2-fix-diagnosisservice-test-failures.md
@@ -1,0 +1,58 @@
+---
+status: pending
+priority: p2
+issue_id: "137"
+tags: [testing, frontend, ci]
+dependencies: []
+estimated_effort: "2-4 hours"
+---
+
+# Fix diagnosisService.test.ts failures in web CI
+
+## Problem
+
+The `Type-check, lint, and unit/component tests` CI job is failing on every PR
+due to test failures in `web/src/services/diagnosisService.test.ts`. This is a
+pre-existing failure — it also fails on `main`.
+
+Discovered: 2026-05-31 via `gh run view` on PR #312.
+
+## Findings
+
+Failing tests (all in `diagnosisService.test.ts`):
+
+- `fetchDiagnosisCards > should fetch diagnosis cards with default options`
+- `createDiagnosisCard > should create a new diagnosis card`
+- `createDiagnosisCard > should handle validation errors`
+- `updateDiagnosisCard > should update a diagnosis card`
+- `deleteDiagnosisCard > should delete a diagnosis card`
+- `deleteDiagnosisCard > should handle delete errors`
+- `toggleFavorite > should toggle favorite status`
+- `createReminder > should create a new reminder`
+- `snoozeReminder > should snooze a reminder with default/custom hours`
+- `cancelReminder > should cancel a reminder`
+- `acknowledgeReminder > should acknowledge a sent reminder`
+- `deleteReminder > should delete / handle errors`
+
+Root cause unknown — needs investigation. Likely a mismatch between the service's
+API shape and the test's mock expectations (e.g. URL, response structure, auth
+headers) introduced when `diagnosisService` was last modified.
+
+## Recommended Action
+
+1. Run `cd web && npx vitest run src/services/diagnosisService.test.ts` locally
+   and capture the full failure output.
+2. Compare the service's actual request shape against the test mocks.
+3. Fix either the service (if it regressed) or the tests (if they drifted from
+   the current API contract).
+
+## Acceptance Criteria
+
+- [ ] `npx vitest run src/services/diagnosisService.test.ts` exits 0 locally.
+- [ ] `Type-check, lint, and unit/component tests` CI job passes on a new PR.
+
+## Work Log
+
+### 2026-05-31 - Created
+
+Surfaced while investigating CI failures blocking auto-merge of PR #312.


### PR DESCRIPTION
## Summary

Adds two pending todo files for pre-existing CI failures discovered while reviewing PR #311/#312:

- **136** [p2]: Add `CVE-2026-31236` (`llm 0.27.1`) to pip-audit ignore list or upgrade — Backend Python Security Scan failing on every PR
- **137** [p2]: Fix `diagnosisService.test.ts` failures — Type-check/lint/unit CI job failing on every PR

Neither failure is caused by recent changes; both existed on `main` before the formatter PRs. Tracking them so they don't get lost.

## Test plan

- [ ] `ls todos/136* todos/137*` shows both files on main after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)