### PR TITLE
134: document web coverage thresholds as advisory/local-only

### DIFF
--- a/todos/archive/134-completed-p3-enforce-or-drop-web-coverage-thresholds.md
+++ b/todos/archive/134-completed-p3-enforce-or-drop-web-coverage-thresholds.md
@@ -1,6 +1,6 @@
 ---
 name: enforce-or-drop-web-coverage-thresholds
-status: pending
+status: completed
 priority: p3
 created: 2026-05-30
 tags: [harness, ci, web, testing, coverage]
@@ -22,7 +22,7 @@ Surfaced in the PR #307 self-review as a low-severity finding.
 
 ## Acceptance criteria
 
-- [ ] Make a deliberate decision and record it:
+- [x] Make a deliberate decision and record it:
   - **Option A — enforce:** add a coverage step to `web-ci.yml` (e.g.
     `npm run test:coverage -- --run`) so the 80% threshold actually gates PRs.
     First confirm current coverage is ≥80% (run `npm run test:coverage` in `web/`)
@@ -31,7 +31,11 @@ Surfaced in the PR #307 self-review as a low-severity finding.
   - **Option B — dev-only:** keep CI on the fast no-coverage run and add a comment
     in `vitest.config.ts` noting the thresholds are advisory/local-only, so the
     config doesn't imply enforcement it doesn't have.
-- [ ] Whichever option: no config that claims a threshold the pipeline doesn't apply.
+  Decision: **Option B**. Coverage measured at Stmts 79.44% / Branches 76.84% /
+  Functions 75.38% / Lines 80.89% — three metrics below 80%, so enforcing now
+  would immediately break CI. Comment added to `web/vitest.config.ts`.
+- [x] Whichever option: no config that claims a threshold the pipeline doesn't apply.
+  `vitest.config.ts` now documents thresholds as advisory/local-only.
 
 ## Notes
 
@@ -39,3 +43,20 @@ Workflow + config files are not under `.claude/` — editable directly. If choos
 Option A, watch CI runtime (coverage instrumentation is slower than a bare run).
 Relates to todo 126 (the web-ci workflow this refines) and todo 127 (harness/CI
 gating).
+
+## Work Log
+
+### 2026-05-31 - Started by completing-todos skill (run 2026-05-31-1516)
+
+- Picked up by automated workflow.
+- Ran `npm run test:coverage -- --run` in `web/`. Results:
+  Statements 79.44%, Branches 76.84%, Functions 75.38%, Lines 80.89%.
+  Three of four metrics are below the 80% threshold, so Option A as-is would
+  immediately break CI. Presented findings to user.
+- **Decision: Option B** — keep CI on the fast bare run; add a comment to
+  `vitest.config.ts` marking thresholds as advisory/local-only.
+
+### 2026-05-31 - Completed by completing-todos skill (run 2026-05-31-1516)
+
+- Verification: both acceptance criteria passed — decision recorded, comment added.
+- Review: 0 findings — comment-only change, no logic.

--- a/web/.prettierignore
+++ b/web/.prettierignore
@@ -1,0 +1,3 @@
+coverage/
+dist/
+node_modules/

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -27,7 +27,9 @@ export default defineConfig({
         '**/vite.config.{js,ts}',
         '**/vitest.config.{js,ts}',
       ],
-      // Thresholds for failing tests if coverage is too low
+      // Advisory thresholds — enforced locally when running `npm run test:coverage`
+      // but NOT checked in CI (web-ci.yml runs `vitest --run` without --coverage).
+      // Treat these as a local development signal, not a merge gate.
       thresholds: {
         lines: 80,
         functions: 80,


### PR DESCRIPTION
## Summary

- Measured current coverage: Stmts 79.44% / Branches 76.84% / Functions 75.38% / Lines 80.89% — three of four metrics are below the declared 80% threshold
- **Decision: Option B** — keep CI on the fast bare `vitest --run` (no `--coverage`); add a comment to `web/vitest.config.ts` making clear the thresholds are advisory/local-only, not a CI gate
- Adds `web/.prettierignore` to exclude generated `coverage/` and `dist/` output (they're git-ignored but Prettier had no ignore file of its own, causing the pre-commit hook to fail on generated report files)

## Test plan

- [ ] `npm run test -- --run` in `web/` passes (no coverage overhead in CI)
- [ ] `npm run test:coverage -- --run` in `web/` shows thresholds enforced locally with the comment in place
- [ ] `web/.prettierignore` prevents Prettier from scanning `coverage/` output

🤖 Generated with [Claude Code](https://claude.com/claude-code)