### PR TITLE
docs: Cloudflare Workers deployment and cookie-auth convention

### DIFF
--- a/web/CLAUDE.md
+++ b/web/CLAUDE.md
@@ -22,6 +22,19 @@ npm run test:e2e:ui   # Playwright UI — best for debugging E2E failures
 - **TypeScript strictness** — `strict: false` for now. Avoid `any`; use `unknown` for truly unknown types. New types go in `src/types/`.
 - **User-generated HTML** — always sanitize with `DOMPurify` before rendering. Never set `dangerouslySetInnerHTML` with raw user input.
 - **CSRF** — include `X-CSRFToken` header and `credentials: 'include'` on all mutating requests to the backend.
+- **Auth is cookie-based** — the session cookie is set by Django on login; do not send an `Authorization: Bearer` header. `diagnosisService` and all other services authenticate via cookie only.
+
+## Deployment
+
+The React app is deployed to **Cloudflare Workers** as a static-assets site. Config is in `wrangler.jsonc` at the repo root.
+
+```bash
+# From repo root (not web/)
+npm run deploy    # wrangler deploy — push to Cloudflare
+npm run preview   # wrangler dev — local Workers emulation
+```
+
+The `assets.directory` points at the `web/` folder, so run `npm run build` inside `web/` first, then `npm run deploy` from root.
 
 ## CI
 


### PR DESCRIPTION
## Summary

- Add `## Deployment` section to `web/CLAUDE.md`: documents the `wrangler.jsonc` config added by the CF bot (#283), the `deploy`/`preview` scripts in root `package.json`, and the build-then-deploy sequence
- Add one-liner auth convention: auth is cookie-based; no `Authorization: Bearer` header — anchors the `diagnosisService` `getAuthHeaders` removal (#306) as a project-wide rule

## Test plan

- [ ] Confirm `wrangler.jsonc` exists at repo root and matches the documented config
- [ ] Confirm `package.json` at repo root has `deploy` and `preview` scripts

🤖 Generated with [Claude Code](https://claude.com/claude-code)