### PR TITLE
docs(todos): track pyjwt CVE backend security-scan failure (203)

### DIFF
--- a/todos/203-pending-p2-pyjwt-cves-security-scan.md
+++ b/todos/203-pending-p2-pyjwt-cves-security-scan.md
@@ -1,0 +1,100 @@
+---
+status: pending
+priority: p2
+issue_id: "203"
+tags: [security, dependencies, ci, backend]
+dependencies: []
+---
+
+# Backend security scan red: 4 new pyjwt 2.12.1 CVEs (fix = bump to 2.13.0)
+
+## Problem
+
+The `Backend Python Security Scan` CI job (`pip-audit -r backend/requirements.txt`)
+started failing on **every** PR on 2026-06-02 — including frontend-only PRs (first
+observed on PR #324, the Green Thumb web migration, which changed zero Python) —
+because four `pyjwt` CVEs were newly disclosed against the pinned `PyJWT==2.12.1`.
+Unlike the previously-suppressed advisories, **these have a real upstream fix**
+(`pyjwt 2.13.0`), so the correct action is a version bump, not a suppression.
+
+This is not a regression from any single PR; the advisories were published against
+the live OSV/PyPI database while the pinned version stayed put. `pyjwt` is the JWT
+auth dependency (SIMPLE_JWT signs/verifies with it), so this is security-relevant,
+not merely a scan-hygiene nuisance.
+
+## Findings
+
+- `pip-audit` output (run `26837363493`, 2026-06-02) reported, after the existing
+  `--ignore-vuln` suppressions: `Found 4 known vulnerabilities, ignored 2 in 1 package`:
+
+  | Advisory | Package (pinned) | Fix version |
+  |----------|------------------|-------------|
+  | PYSEC-2026-175 | `pyjwt==2.12.1` | **2.13.0** |
+  | PYSEC-2026-177 | `pyjwt==2.12.1` | **2.13.0** |
+  | PYSEC-2026-178 | `pyjwt==2.12.1` | **2.13.0** |
+  | PYSEC-2026-179 | `pyjwt==2.12.1` | **2.13.0** |
+
+- These are **distinct** from the already-suppressed `PYSEC-2025-183` (pyjwt,
+  supplier-disputed, mitigated by the ≥50-char `JWT_SECRET_KEY` fail-fast at
+  `backend/<settings>.py`). Do not conflate; #203 is the fixable set.
+- The check is **not a required status check**: PR #324 auto-merged (`aee51fb`)
+  with this scan red. So it blocks nothing mechanically, but it leaves the security
+  gate red on all PRs and masks any *future* genuinely-blocking CVE.
+- The same workflow's **last green `main` run was the day before** (`f46898a`,
+  2026-06-01) — confirming the failure is a live-advisory-DB event, not code.
+- Adjacent suppression work appears to be in flight: an
+  `origin/fix/pip-audit-cve-2026-31236` branch was pruned around the same time
+  (likely merged). **Coordinate** so the pyjwt bump and any CVE-2026-31236
+  suppression don't conflict in `requirements.txt` / the workflow's `--ignore-vuln`
+  line. Discovered while reviewing PR #324 CI (2026-06-02).
+
+## Recommended Action
+
+1. On a **new backend branch** (never direct to `main` — JWT/auth-sensitive),
+   bump in `backend/requirements.txt`: `PyJWT==2.12.1` → `PyJWT==2.13.0`
+   (verify the exact case/pin format used in the file).
+2. Reinstall (`pip install -r backend/requirements.txt`) and run the **full backend
+   test suite** — auth/JWT paths especially: `python manage.py test apps.users
+   --noinput` plus the broader suite. Token issue/refresh/verify must still pass.
+3. Run `pip-audit -r backend/requirements.txt <existing --ignore-vuln flags>`
+   locally and confirm a **clean exit (0)** — the 4 PYSEC-2026-17x advisories
+   should disappear once on 2.13.0; do **not** add `--ignore-vuln` for them.
+4. Rebase onto latest `main` first if the `fix/pip-audit-cve-2026-31236` work has
+   landed, to avoid clobbering its suppression entries.
+5. Open a PR; confirm `Backend Python Security Scan` + `Security Scan Summary`
+   go green.
+
+## Technical Details
+
+- Failing jobs: `Backend Python Security Scan` → `Security Scan Summary`
+  (workflow under `.github/workflows/`; the `pip-audit … --ignore-vuln …` step).
+- Pin lives in `backend/requirements.txt`.
+- Suppression precedent + the disputed-pyjwt rationale are documented in
+  `todos/archive/089-completed-p2-backend-dependency-cves.md` and
+  `todos/archive/136-completed-p2-add-cve-2026-31236-to-pip-audit-ignore.md`.
+- JWT key-length fail-fast guard (the existing PYSEC-2025-183 mitigation) is in the
+  backend settings module — keep it; it is independent of this bump.
+
+## Acceptance Criteria
+
+- [ ] `backend/requirements.txt` pins `PyJWT==2.13.0` (or newer).
+- [ ] `pip-audit -r backend/requirements.txt` (with current suppression flags) exits 0 locally.
+- [ ] No new `--ignore-vuln` entry was added for PYSEC-2026-175/177/178/179 (they are fixed, not suppressed).
+- [ ] Backend test suite passes, including `apps.users` JWT token issue/refresh/verify.
+- [ ] `Backend Python Security Scan` + `Security Scan Summary` are green on the fix PR.
+
+## Work Log
+
+### 2026-06-02 - Filed
+
+- Surfaced while reviewing PR #324 (Green Thumb web migration) CI: the only red
+  check was this backend dependency scan, unrelated to the frontend change.
+  Diagnosed the 4 new fixable pyjwt advisories and confirmed the prior-day green
+  `main` run. Created as a backend follow-up.
+
+## Notes
+
+- **P2**: real security fix with an available upstream patch, but the check is
+  non-required so it isn't blocking merges today. Should be done promptly — a red
+  security gate normalizes ignoring it and hides the next blocking CVE.
+- Related: [089] (no-fix advisory suppressions), [136] (CVE-2026-31236 suppression).


### PR DESCRIPTION
Adds **todo 203** tracking the freshly-disclosed `pyjwt` 2.12.1 CVEs
(PYSEC-2026-175/177/178/179, fixed in 2.13.0) that turned the `Backend Python
Security Scan` red repo-wide on 2026-06-02.

Surfaced while reviewing PR #324 (Green Thumb web migration) — its only failing
check was this unrelated backend dependency CVE. The same scan passed on `main`
the day before (`f46898a`); `pip-audit` hits the live advisory DB, so the new
advisories now fail every PR regardless of code. The check is **non-required**,
so it blocks no merges, but it leaves the security gate red and masks the next
genuinely-blocking CVE.

Fix (deferred to the todo): bump `PyJWT==2.13.0` on a backend branch + run the
JWT test suite. Coordinate with the in-flight `fix/pip-audit-cve-2026-31236` work.

Docs-only (one todo file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)