### PR TITLE
fix(security): bump PyJWT 2.12.1 → 2.13.0 to clear 4 disclosed CVEs

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -50,7 +50,7 @@ jobs:
           # PYSEC-2026-89  (Markdown 3.8.1): no upstream fix (OSV: all versions affected); markdown not imported by app code; DoS path unreachable.
           # PYSEC-2026-97  (nltk 3.9.4):     no upstream fix (already latest); filestring() path traversal not called by app code.
           # PYSEC-2024-277 (joblib 1.5.2):   supplier-disputed; not imported by app code.
-          # PYSEC-2025-183 (PyJWT 2.12.1):   supplier-disputed; mitigated by JWT_SECRET_KEY (the SIMPLE_JWT SIGNING_KEY PyJWT signs with), validated >=50 chars fail-fast at settings import in ALL environments (settings.py:658).
+          # PYSEC-2025-183 (PyJWT 2.13.0):   supplier-disputed; mitigated by JWT_SECRET_KEY (the SIMPLE_JWT SIGNING_KEY PyJWT signs with), validated >=50 chars fail-fast at settings import in ALL environments (settings.py:658).
           # CVE-2026-31236 (llm 0.27.1):     no upstream fix per OSV/PyPI advisory; llm is a wagtail-ai transitive dep, not imported directly by app code. Remove when a patched llm release ships.
           pip-audit -r requirements.txt \
             --ignore-vuln CVE-2026-42304 \

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -157,7 +157,7 @@ pycparser==2.23
 pydantic==2.13.3
 pydantic_core==2.46.3
 Pygments==2.20.0
-PyJWT==2.12.1
+PyJWT==2.13.0
 pyOpenSSL==26.2.0
 pyparsing==3.2.5
 pytest==9.0.3

--- a/todos/203-in_progress-p2-pyjwt-cves-security-scan.md
+++ b/todos/203-in_progress-p2-pyjwt-cves-security-scan.md
@@ -1,5 +1,5 @@
 ---
-status: pending
+status: in_progress
 priority: p2
 issue_id: "203"
 tags: [security, dependencies, ci, backend]
@@ -77,11 +77,11 @@ not merely a scan-hygiene nuisance.
 
 ## Acceptance Criteria
 
-- [ ] `backend/requirements.txt` pins `PyJWT==2.13.0` (or newer).
-- [ ] `pip-audit -r backend/requirements.txt` (with current suppression flags) exits 0 locally.
-- [ ] No new `--ignore-vuln` entry was added for PYSEC-2026-175/177/178/179 (they are fixed, not suppressed).
-- [ ] Backend test suite passes, including `apps.users` JWT token issue/refresh/verify.
-- [ ] `Backend Python Security Scan` + `Security Scan Summary` are green on the fix PR.
+- [x] `backend/requirements.txt` pins `PyJWT==2.13.0` (or newer).
+- [x] `pip-audit -r backend/requirements.txt` (with current suppression flags) exits 0 locally.
+- [x] No new `--ignore-vuln` entry was added for PYSEC-2026-175/177/178/179 (they are fixed, not suppressed).
+- [x] Backend test suite passes, including `apps.users` JWT token issue/refresh/verify.
+- [ ] `Backend Python Security Scan` + `Security Scan Summary` are green on the fix PR. *(pending PR push + CI)*
 
 ## Work Log
 
@@ -91,6 +91,57 @@ not merely a scan-hygiene nuisance.
   check was this backend dependency scan, unrelated to the frontend change.
   Diagnosed the 4 new fixable pyjwt advisories and confirmed the prior-day green
   `main` run. Created as a backend follow-up.
+
+### 2026-06-02 - Started by completing-todos skill (run 2026-06-02-1833)
+
+- Picked up by automated workflow on branch `fix/pyjwt-2.13.0-security-cves`.
+- Orientation confirmed: `backend/requirements.txt:160` pins `PyJWT==2.12.1`;
+  `djangorestframework_simplejwt==5.5.1` requires only `pyjwt>=1.7.1` (no upper
+  bound) so 2.13.0 is compatible; the `CVE-2026-31236` suppression already landed
+  on `main` (`security-scan.yml:54,61`) so no rebase/coordination conflict; the
+  4 PYSEC-2026-17x advisories are NOT in the workflow `--ignore-vuln` list.
+
+### 2026-06-02 - Local verification (criteria 1–4 passed)
+
+- **Criterion 1 (pin):** `grep "^PyJWT==" backend/requirements.txt` → `160:PyJWT==2.13.0`.
+- **Criterion 2 (pip-audit clean):** ran with the exact six CI `--ignore-vuln`
+  flags from `security-scan.yml:56-61` against `backend/requirements.txt` →
+  `No known vulnerabilities found, 2 ignored` / `PIP_AUDIT_EXIT=0`. The four
+  PYSEC-2026-175/177/178/179 advisories no longer appear — fixed by 2.13.0.
+- **Criterion 3 (no over-suppression):** `grep -E "PYSEC-2026-17[5789]"
+  .github/workflows/security-scan.yml` → none present. The fixed advisories were
+  cleared by the bump, not papered over with new ignore flags.
+- **Criterion 4 (JWT tests):** `python manage.py test apps.users --noinput` →
+  `Ran 99 tests in 15.107s / OK`. Run explicitly exercised token issue/refresh
+  (valid, invalid, rotation, last_login, CSRF, missing-token), JWT cookie
+  set/verify, and the Firebase→Django auth suite. PyJWT is used only by
+  SIMPLE_JWT sign/verify, so `apps.users` is the comprehensive coverage for this
+  bump; the full backend suite runs via CI `backend-tests` on the PR.
+- **Criterion 5** remains open pending PR push + `Backend Python Security Scan` /
+  `Security Scan Summary` reporting green on the PR.
+
+### 2026-06-02 - Code review (security/dependency lens)
+
+- Verdict: **APPROVE, nothing blocking.** Independent review confirmed (primary
+  source): no direct PyJWT API usage anywhere in `backend/` app code (only
+  `simplejwt`'s `TokenError` wrapper) — the new CVEs concern `PyJWKClient`/JWK/URI
+  paths the app (HS256 + string `SIGNING_KEY`) never exercises; the PYSEC-2025-183
+  `JWT_SECRET_KEY` >=50-char fail-fast guard (`settings.py`) is intact and untouched.
+
+#### Known issues (non-blocking)
+
+- **LOW — FIXED in this PR:** `security-scan.yml:53` suppression comment said
+  `(PyJWT 2.12.1)`, made stale by this bump → updated to `(PyJWT 2.13.0)`.
+  Did **not** remove the `--ignore-vuln PYSEC-2025-183` flag (reviewer's optional
+  "cleaner" suggestion): it is currently vestigial on 2.13.0 but keeping it is the
+  advisory-DB-resilient choice — suppressed-vs-fixed status shifts over time (this
+  todo is itself proof), and the flag is harmless while matched-to-nothing.
+- **INFO — out of scope:** `requirements-dev.txt:124` still pins `PyJWT==2.10.1`
+  (inside the affected range of the 4 CVEs). Not gated — CI installs only
+  `requirements.txt` (`backend-ci.yml:56,164`; `security-scan.yml` audits only
+  `requirements.txt`) — and that dev file is already broadly stale vs prod. Left
+  for a separate dependency-hygiene follow-up; bumping only its PyJWT line would be
+  an arbitrary touch on an already-divergent file.
 
 ## Notes
 

--- a/todos/archive/203-completed-p2-pyjwt-cves-security-scan.md
+++ b/todos/archive/203-completed-p2-pyjwt-cves-security-scan.md
@@ -1,5 +1,5 @@
 ---
-status: in_progress
+status: completed
 priority: p2
 issue_id: "203"
 tags: [security, dependencies, ci, backend]
@@ -81,7 +81,7 @@ not merely a scan-hygiene nuisance.
 - [x] `pip-audit -r backend/requirements.txt` (with current suppression flags) exits 0 locally.
 - [x] No new `--ignore-vuln` entry was added for PYSEC-2026-175/177/178/179 (they are fixed, not suppressed).
 - [x] Backend test suite passes, including `apps.users` JWT token issue/refresh/verify.
-- [ ] `Backend Python Security Scan` + `Security Scan Summary` are green on the fix PR. *(pending PR push + CI)*
+- [x] `Backend Python Security Scan` + `Security Scan Summary` are green on the fix PR.
 
 ## Work Log
 
@@ -142,6 +142,17 @@ not merely a scan-hygiene nuisance.
   `requirements.txt`) — and that dev file is already broadly stale vs prod. Left
   for a separate dependency-hygiene follow-up; bumping only its PyJWT line would be
   an arbitrary touch on an already-divergent file.
+
+### 2026-06-02 - Completed by completing-todos skill (run 2026-06-02-1833)
+
+- PR #326 (`fix/pyjwt-2.13.0-security-cves`) opened against `main`.
+- Verification: all 5 acceptance criteria passed. Criterion 5 confirmed on the PR —
+  `Backend Python Security Scan` **pass** (1m2s), `Security Scan Summary` **pass**,
+  and `Run backend test suite (pytest, postgres + redis)` **pass** (5m43s, full
+  backend suite). Every PR check green.
+- Review: 2 findings, 0 blocking — 1 LOW fixed in-PR (stale workflow comment),
+  1 INFO left as out-of-scope dependency-hygiene follow-up (`requirements-dev.txt`
+  PyJWT==2.10.1).
 
 ## Notes
 


### PR DESCRIPTION
## Summary

Fixes the failing **Backend Python Security Scan** (`pip-audit -r requirements.txt`). Four pyjwt advisories — **PYSEC-2026-175 / 177 / 178 / 179** — were disclosed against the pinned `PyJWT==2.12.1`, turning the scan red on *every* PR (first observed on #324, a frontend-only change). `2.13.0` is the upstream fix, so this is a **version bump, not a suppression** — no `--ignore-vuln` entries were added for these four.

Resolves todo **203**.

## Changes
- `backend/requirements.txt`: `PyJWT==2.12.1` → `PyJWT==2.13.0`
- `.github/workflows/security-scan.yml`: refresh the now-stale PyJWT version in the PYSEC-2025-183 suppression comment (`2.12.1` → `2.13.0`). The `--ignore-vuln PYSEC-2025-183` flag itself is **kept** (supplier-disputed, advisory-DB status shifts over time).

## Verification (local)
- ✅ `pip-audit -r backend/requirements.txt` with the existing 6 ignore flags → `No known vulnerabilities found, 2 ignored`, **exit 0**. The four PYSEC-2026-17x advisories are gone.
- ✅ `python manage.py test apps.users --noinput` → **Ran 99 tests, OK** — token refresh/verify, JWT cookie auth, Firebase→Django exchange.
- ✅ `djangorestframework-simplejwt==5.5.1` requires `pyjwt>=1.7.1` (no upper bound) — compatible.
- ✅ No direct PyJWT API usage in app code (only via simplejwt); the PYSEC-2025-183 `JWT_SECRET_KEY` ≥50-char fail-fast guard is untouched.

## Out of scope
- `requirements-dev.txt` still pins `PyJWT==2.10.1` (not gated — CI installs only `requirements.txt`; that dev file is already broadly stale). Left for a dependency-hygiene follow-up.

## Acceptance gate
This very check — **Backend Python Security Scan** — must go green on this PR before merge. (It is *not* a required check, so merge will be held manually until it reports green.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)