### PR TITLE
fix(harness): cd to repo root before running .claude hooks

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,13 +6,13 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash .claude/hooks/inject-patterns.sh",
+            "command": "cd \"$(git rev-parse --show-toplevel 2>/dev/null || echo '.')\" && bash .claude/hooks/inject-patterns.sh",
             "timeout": 10,
             "statusMessage": "Loading binding rules for this file..."
           },
           {
             "type": "command",
-            "command": "bash .claude/hooks/guard-worktree-isolation.sh",
+            "command": "cd \"$(git rev-parse --show-toplevel 2>/dev/null || echo '.')\" && bash .claude/hooks/guard-worktree-isolation.sh",
             "timeout": 10,
             "statusMessage": "Checking worktree isolation..."
           }
@@ -23,7 +23,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash .claude/hooks/kimi-review.sh",
+            "command": "cd \"$(git rev-parse --show-toplevel 2>/dev/null || echo '.')\" && bash .claude/hooks/kimi-review.sh",
             "timeout": 180,
             "statusMessage": "Running kimi-review on staged changes..."
           }


### PR DESCRIPTION
## Summary
Each PreToolUse hook command in `.claude/settings.json` (`inject-patterns`, `guard-worktree-isolation`, `kimi-review`) now `cd`s to the git repo root before executing:

```
cd "$(git rev-parse --show-toplevel 2>/dev/null || echo '.')" && bash .claude/hooks/<hook>.sh
```

This makes the relative `.claude/hooks/*.sh` paths resolve regardless of the directory a tool call is invoked from (subdirectories, git worktrees), instead of silently failing to find the hook script. Falls back to `.` when not in a git repo.

No behavior change to the hooks themselves — only their working directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)