### PR TITLE
fix(web): a11y polish — AA contrast, ClayButton feedback, body bg, dark-mode toggle

### DIFF
--- a/web/src/components/layout/Header.test.tsx
+++ b/web/src/components/layout/Header.test.tsx
@@ -26,6 +26,7 @@ vi.mock('../../utils/logger', () => ({
 describe('Header', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    localStorage.clear(); // reset persisted theme mode so each test starts at the light default
     vi.mocked(authService.getStoredUser).mockReturnValue(null);
     vi.mocked(authService.getCurrentUser).mockResolvedValue(null);
   });
@@ -402,6 +403,24 @@ describe('Header', () => {
 
       const nav = container.querySelector('nav');
       expect(nav).toHaveClass('sticky', 'top-0', 'z-50');
+    });
+  });
+
+  describe('Theme Toggle', () => {
+    it('renders a dark-mode toggle that offers dark mode at the light default', () => {
+      renderWithRouter(<Header />);
+
+      // Desktop + mobile toggles share the action label.
+      expect(screen.getAllByLabelText('Switch to dark mode').length).toBeGreaterThan(0);
+    });
+
+    it('flips the toggle label after clicking', () => {
+      renderWithRouter(<Header />);
+
+      const toggle = screen.getAllByLabelText('Switch to dark mode')[0];
+      fireEvent.click(toggle);
+
+      expect(screen.getAllByLabelText('Switch to light mode').length).toBeGreaterThan(0);
     });
   });
 });

--- a/web/src/components/layout/Header.test.tsx
+++ b/web/src/components/layout/Header.test.tsx
@@ -414,13 +414,16 @@ describe('Header', () => {
       expect(screen.getAllByLabelText('Switch to dark mode').length).toBeGreaterThan(0);
     });
 
-    it('flips the toggle label after clicking', () => {
+    it('flips the toggle label and aria-pressed after clicking', () => {
       renderWithRouter(<Header />);
 
       const toggle = screen.getAllByLabelText('Switch to dark mode')[0];
+      expect(toggle).toHaveAttribute('aria-pressed', 'false');
+
       fireEvent.click(toggle);
 
       expect(screen.getAllByLabelText('Switch to light mode').length).toBeGreaterThan(0);
+      expect(toggle).toHaveAttribute('aria-pressed', 'true');
     });
   });
 });

--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -85,6 +85,7 @@ export default function Header() {
               type="button"
               onClick={toggleMode}
               aria-label={themeLabel}
+              aria-pressed={mode === 'dark'}
               title={themeLabel}
               className="p-2 rounded-lg text-ink-2 hover:text-primary hover:bg-surface transition-colors"
             >
@@ -165,6 +166,7 @@ export default function Header() {
               type="button"
               onClick={toggleMode}
               aria-label={themeLabel}
+              aria-pressed={mode === 'dark'}
               className="flex items-center gap-2 w-full px-3 py-2 rounded-lg text-ink-2 hover:bg-surface font-medium transition-colors"
             >
               {mode === 'dark' ? <Sun className="w-4 h-4" /> : <Moon className="w-4 h-4" />}

--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -1,7 +1,8 @@
 import { useState } from 'react';
 import { Link, NavLink } from 'react-router-dom';
-import { Menu, X, User, Settings as SettingsIcon } from 'lucide-react';
+import { Menu, X, User, Settings as SettingsIcon, Sun, Moon } from 'lucide-react';
 import { useAuth } from '../../contexts/AuthContext';
+import { useTheme } from '../../contexts/ThemeContext';
 import UserMenu from './UserMenu';
 
 /**
@@ -19,6 +20,8 @@ import UserMenu from './UserMenu';
 export default function Header() {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const { user, isAuthenticated, logout } = useAuth();
+  const { mode, toggleMode } = useTheme();
+  const themeLabel = mode === 'dark' ? 'Switch to light mode' : 'Switch to dark mode';
 
   const toggleMenu = () => setIsMenuOpen(!isMenuOpen);
   const closeMenu = () => setIsMenuOpen(false);
@@ -78,6 +81,15 @@ export default function Header() {
 
           {/* Desktop Auth Actions */}
           <div className="hidden md:flex items-center gap-4">
+            <button
+              type="button"
+              onClick={toggleMode}
+              aria-label={themeLabel}
+              title={themeLabel}
+              className="p-2 rounded-lg text-ink-2 hover:text-primary hover:bg-surface transition-colors"
+            >
+              {mode === 'dark' ? <Sun className="w-5 h-5" /> : <Moon className="w-5 h-5" />}
+            </button>
             {isAuthenticated ? (
               <UserMenu />
             ) : (
@@ -147,6 +159,17 @@ export default function Header() {
             >
               Community
             </NavLink>
+
+            {/* Theme toggle */}
+            <button
+              type="button"
+              onClick={toggleMode}
+              aria-label={themeLabel}
+              className="flex items-center gap-2 w-full px-3 py-2 rounded-lg text-ink-2 hover:bg-surface font-medium transition-colors"
+            >
+              {mode === 'dark' ? <Sun className="w-4 h-4" /> : <Moon className="w-4 h-4" />}
+              {mode === 'dark' ? 'Light mode' : 'Dark mode'}
+            </button>
 
             {/* Mobile Auth Actions */}
             <div className="pt-4 border-t border-line">

--- a/web/src/components/ui/ClayButton.test.tsx
+++ b/web/src/components/ui/ClayButton.test.tsx
@@ -50,4 +50,16 @@ describe('ClayButton', () => {
     rerender(<ClayButton label="A" type="submit" />);
     expect(screen.getByRole('button')).toHaveAttribute('type', 'submit');
   });
+  it('primary variant exposes hover and active feedback', () => {
+    render(<ClayButton label="X" />);
+    const btn = screen.getByRole('button');
+    expect(btn).toHaveClass('hover:bg-clay/90');
+    expect(btn).toHaveClass('active:translate-y-px');
+  });
+  it('disabled state drops the interactive affordances', () => {
+    render(<ClayButton label="X" disabled />);
+    const btn = screen.getByRole('button');
+    expect(btn).not.toHaveClass('hover:bg-clay/90');
+    expect(btn).not.toHaveClass('active:translate-y-px');
+  });
 });

--- a/web/src/components/ui/ClayButton.tsx
+++ b/web/src/components/ui/ClayButton.tsx
@@ -13,9 +13,11 @@ export interface ClayButtonProps extends ButtonHTMLAttributes<HTMLButtonElement>
 }
 
 const VARIANT: Record<ClayVariant, string> = {
-  primary: 'bg-clay text-on-clay shadow-2',
-  secondary: 'bg-primary text-on-primary shadow-2',
-  outline: 'bg-transparent border border-primary text-primary',
+  primary: 'bg-clay text-on-clay shadow-2 hover:bg-clay/90 hover:shadow-3 active:translate-y-px',
+  secondary:
+    'bg-primary text-on-primary shadow-2 hover:bg-primary/90 hover:shadow-3 active:translate-y-px',
+  outline:
+    'bg-transparent border border-primary text-primary hover:bg-primary/10 active:translate-y-px',
 };
 const SIZE: Record<ClaySize, string> = {
   sm: 'px-4 py-2 text-sm',
@@ -38,7 +40,7 @@ export default function ClayButton({
   const isDisabled = disabled || loading;
   const classes = [
     'inline-flex items-center justify-center gap-2 rounded-pill font-semibold tracking-[0.25px]',
-    'min-h-[44px] transition-colors',
+    'min-h-[44px] transition duration-150',
     fullWidth && 'w-full',
     isDisabled ? 'bg-surface-3 text-ink-3/40 cursor-not-allowed' : VARIANT[variant],
     SIZE[size],

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -9,12 +9,12 @@
 /* ───────── Green Thumb semantic vars · :root = loam · light · cozy ───────── */
 :root {
   --gt-surface:#F6F0E2; --gt-surface-2:#ECE3CC; --gt-surface-3:#DDD0AE;
-  --gt-ink:#1F1A12; --gt-ink-2:#4A3F2C; --gt-ink-3:#7C6E55;
+  --gt-ink:#1F1A12; --gt-ink-2:#4A3F2C; --gt-ink-3:#6E624C;
   --gt-line:#D4C5A0; --gt-line-2:#BCA97E;
   --gt-primary:#4A7034; --gt-on-primary:#F6F0E2;
   --gt-secondary:#97B86A; --gt-tertiary:#E0B445;
   --gt-clay:#C9542A; --gt-on-clay:#FFF8EA;
-  --gt-leaf:#C2D680; --gt-berry:#C45577; --gt-sky:#6FA0AA;
+  --gt-leaf:#5E683E; --gt-berry:#A14662; --gt-sky:#456369;
   --gt-ok:#3F5D3F; --gt-warn:#C4A570; --gt-error:#B5451C;
   --gt-pad-card:16px; --gt-pad-screen:16px; --gt-gap:12px;
   --gt-shadow-1:0 1px 0 rgba(27,34,24,.04), 0 2px 6px rgba(27,34,24,.05);
@@ -25,12 +25,12 @@
 /* ───────── palette LIGHT blocks (forest is dark-only: this is its only set) ───────── */
 [data-palette="garden"] {
   --gt-surface:#F4F1E4; --gt-surface-2:#ECE7D2; --gt-surface-3:#DFD9BD;
-  --gt-ink:#102015; --gt-ink-2:#2E4233; --gt-ink-3:#5C6E5A;
+  --gt-ink:#102015; --gt-ink-2:#2E4233; --gt-ink-3:#596B57;
   --gt-line:#D2CCAE; --gt-line-2:#B8B391;
   --gt-primary:#2F6B3A; --gt-on-primary:#F4F1E4;
   --gt-secondary:#7FA66B; --gt-tertiary:#E5B84B;
   --gt-clay:#D86B2C; --gt-on-clay:#FFF8EA;
-  --gt-leaf:#A8CC6E; --gt-berry:#B8466A; --gt-sky:#6FA0AA;
+  --gt-leaf:#596C3A; --gt-berry:#AB4163; --gt-sky:#456369;
   --gt-ok:#3F5D3F; --gt-warn:#C4A570; --gt-error:#B5451C;
 }
 [data-palette="forest"] {
@@ -45,12 +45,12 @@
 }
 [data-palette="heritage"] {
   --gt-surface:#F0EBDB; --gt-surface-2:#E4DBC2; --gt-surface-3:#D3C9AC;
-  --gt-ink:#1A1F10; --gt-ink-2:#3A4128; --gt-ink-3:#756E50;
+  --gt-ink:#1A1F10; --gt-ink-2:#3A4128; --gt-ink-3:#655F45;
   --gt-line:#CFC4A2; --gt-line-2:#B8AC85;
   --gt-primary:#3D5A22; --gt-on-primary:#F0EBDB;
   --gt-secondary:#768B4E; --gt-tertiary:#C99B3A;
   --gt-clay:#B0481E; --gt-on-clay:#FFF8EA;
-  --gt-leaf:#A4B86E; --gt-berry:#B8466A; --gt-sky:#6FA0AA;
+  --gt-leaf:#59633B; --gt-berry:#9E3C5B; --gt-sky:#456369;
   --gt-ok:#3F5D3F; --gt-warn:#C4A570; --gt-error:#B5451C;
 }
 
@@ -59,7 +59,7 @@
    [data-palette="forest"] and clobber it (cascade bug). Forest needs none. ───────── */
 [data-palette="loam"][data-mode="dark"] {
   --gt-surface:#12100A; --gt-surface-2:#1C1810; --gt-surface-3:#272218;
-  --gt-ink:#F2EBD8; --gt-ink-2:#D4C8A4; --gt-ink-3:#8A7E60;
+  --gt-ink:#F2EBD8; --gt-ink-2:#D4C8A4; --gt-ink-3:#8E8265;
   --gt-line:#2E2818; --gt-line-2:#423A26;
   --gt-primary:#B8D680; --gt-on-primary:#12100A;
   --gt-secondary:#A3C26C; --gt-tertiary:#E8C76B;
@@ -141,7 +141,7 @@
 }
 .skip-nav:focus { top: 0; }
 
-@layer base { body { font-family: var(--font-sans); } }
+@layer base { body { font-family: var(--font-sans); background: var(--gt-surface); color: var(--gt-ink); } }
 
 @layer components {
   /* Bricolage Grotesque ships no italic face; italic is synthesized intentionally (matches the mobile Green Thumb identity). */

--- a/web/src/pages/BlogListPage.tsx
+++ b/web/src/pages/BlogListPage.tsx
@@ -344,8 +344,8 @@ export default function BlogListPage() {
                     onClick={() => handleCategoryFilter('')}
                     className={`block w-full text-left px-3 py-2 rounded-lg transition-colors ${
                       !category
-                        ? 'bg-primary/10 text-leaf font-medium'
-                        : 'hover:bg-surface-2 text-ink-2'
+                        ? 'bg-primary text-on-primary font-medium'
+                        : 'hover:bg-surface-3 text-ink-2'
                     }`}
                   >
                     All Categories

--- a/web/src/pages/BlogListPage.tsx
+++ b/web/src/pages/BlogListPage.tsx
@@ -356,8 +356,8 @@ export default function BlogListPage() {
                       onClick={() => handleCategoryFilter(cat.slug)}
                       className={`block w-full text-left px-3 py-2 rounded-lg transition-colors ${
                         category === cat.slug
-                          ? 'bg-primary/10 text-leaf font-medium'
-                          : 'hover:bg-surface-2 text-ink-2'
+                          ? 'bg-primary text-on-primary font-medium'
+                          : 'hover:bg-surface-3 text-ink-2'
                       }`}
                     >
                       {cat.name}

--- a/web/src/tests/utils.tsx
+++ b/web/src/tests/utils.tsx
@@ -10,6 +10,7 @@ import type { ReactElement } from 'react';
 import type { RenderOptions } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
 import { AuthProvider } from '../contexts/AuthContext';
+import { ThemeProvider } from '../contexts/ThemeContext';
 import type { BlogPost, StreamFieldBlock } from '@/types/blog';
 
 /**
@@ -18,9 +19,11 @@ import type { BlogPost, StreamFieldBlock } from '@/types/blog';
  */
 export function renderWithRouter(ui: ReactElement, options: Omit<RenderOptions, 'wrapper'> = {}) {
   return render(
-    <BrowserRouter>
-      <AuthProvider>{ui}</AuthProvider>
-    </BrowserRouter>,
+    <ThemeProvider>
+      <BrowserRouter>
+        <AuthProvider>{ui}</AuthProvider>
+      </BrowserRouter>
+    </ThemeProvider>,
     options
   );
 }


### PR DESCRIPTION
Follow-up to the Green Thumb web redesign (#324). Fixes the accessibility/finish issues surfaced in review and exposes the theming system to logged-out users.

## Changes

**1. WCAG AA contrast (token-level, `index.css`)**
The default light palettes shipped accent/muted-text tokens below AA. Replacement values were computed with a WCAG script and verified ≥4.5:1 live in-browser, on both `surface` and `surface-2`:

| token (loam light) | before | after | on surface-2 |
|---|---|---|---|
| `ink-3` muted body text | `#7C6E55` 3.89 | `#6E624C` | **4.67** |
| `berry` forum link | `#C45577` 3.34 | `#A14662` | **4.60** |
| `sky` blog link | `#6FA0AA` 2.25 | `#456369` | **5.07** |
| `leaf` (plain-text uses) | `#C2D680` | `#5E683E` | **4.66** |

Same treatment for garden/heritage light + a nudge to loam-dark `ink-3`. Dark palettes already passed (6–9:1) and are untouched.

**2. `ClayButton` interactive feedback** — added per-variant `hover:`/`active:` states and switched the dead `transition-colors` (it animated nothing) to `transition`. Disabled state correctly drops them.

**3. Body background** — `body` now paints `var(--gt-surface)`/`var(--gt-ink)` instead of `transparent`. Previously every page self-painted via section `bg-surface`; overscroll and any non-covering page showed white. Verified it tracks light↔dark.

**4. Dark-mode toggle (`Header`)** — sun/moon button (desktop icon + mobile row) wired to `ThemeContext`. The 24-combo theming matrix was previously only reachable via the auth-gated Settings page; logged-out visitors had no theme control at all, not even dark mode.

**Plus** — `BlogListPage` active category pill: the prior `text-leaf`-on-tint state couldn't be made AA-compliant by any text color (the tint defeats it), so it's now an accessible **filled** (white-on-green) active state with a working inactive hover.

## Verification
- `tsc --noEmit` ✅ · ESLint ✅ · **Vitest 693 pass** (4 added) ✅ · production build ✅
- Live browser: contrast probe (all ≥4.5), dark-mode round-trip, body-bg tracking
- `ThemeProvider` added to the shared test renderer (mirrors `main.tsx`) so Header tests resolve `useTheme`

## Known follow-up (NOT in this PR)
9 same-hue-tint status badges — `bg-{leaf,sky}/10 text-{leaf,sky}` in `DiagnosisCard`, `IdentificationResults` (main ID flow), `PostCard`, `ReminderManager`, `StreamFieldEditor`, `DiagnosisDetailPage` — remain below AA (~4.1 at `/10`, ~3.6 at `/20`). Token darkening **cannot** fix these because the background scales with the text; the fix is `text-{leaf,sky}` → `text-ink`. Flagged for a separate pass.

## Scope note
`leaf` (a 4th token) and the pill mechanism were changed beyond the originally-named berry/sky/ink-3 — both isolated and trivially revertable if undesired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)