### PR TITLE
feat(lsp): LSP integration — agents, skill shadow, CLAUDE.md

### DIFF
--- a/.claude/agents/django-drf-reviewer.md
+++ b/.claude/agents/django-drf-reviewer.md
@@ -13,7 +13,7 @@ Dispatched automatically by orchestrator — not called directly by user.
 
 model: sonnet
 color: blue
-tools: Read, Glob, Grep, Bash
+tools: Read, Glob, Grep, Bash, LSP
 ---
 
 # Django/DRF Reviewer
@@ -28,7 +28,29 @@ You do NOT review: Wagtail page models or blog app files (those go to wagtail-re
 
 ## Review Mode — Checklist
 
-Work through each item for every changed file. Find the exact line number for each issue (Grep can help). Emit findings in the structured format defined in "## Output Format (Review Mode)" below — do not write prose.
+Work through each item for every changed file. Emit findings in the structured format defined in "## Output Format (Review Mode)" below — do not write prose.
+
+### LSP Workflow (run before the checklist)
+
+For each changed file:
+
+**Step A — enumerate symbols:**
+
+Call `documentSymbol` on the file to get all symbols with their positions. Use this list to find line/character values for the LSP calls below. If LSP returns an error or empty/inconclusive result, fall back to Grep for that file.
+
+**Step B — targeted LSP calls:**
+
+| Checklist item | LSP call |
+|---|---|
+| `get_permissions()` calls `super()` | `outgoingCalls` from `get_permissions` → look for the DRF base `get_permissions` in the resolved call targets (the resolved parent method, not the token "super") |
+| New constant actually used (dead code check) | `findReferences` on the constant → reference count > 0 confirms it is not orphaned |
+
+**Django ORM note:** pyright cannot statically resolve Django's `objects` manager
+(it is metaclass-injected). `outgoingCalls` returns empty for `.objects.filter()`,
+`.objects.get()`, etc. For all queryset optimization checks (`select_related`,
+`prefetch_related`, N+1 via `SerializerMethodField`), use Grep — not LSP.
+
+Use Grep as fallback for any LSP call that returns an error or an empty/inconclusive result.
 
 **Permissions & Security**
 

--- a/.claude/agents/react-typescript-reviewer.md
+++ b/.claude/agents/react-typescript-reviewer.md
@@ -13,7 +13,7 @@ Dispatched automatically by orchestrator for web frontend changes.
 
 model: sonnet
 color: cyan
-tools: Read, Glob, Grep, Bash
+tools: Read, Glob, Grep, Bash, LSP
 ---
 
 # React/TypeScript Reviewer
@@ -30,6 +30,24 @@ Review only the files passed to you. Do not read the full repo.
 - Test runner: Vitest (492 tests), E2E: Playwright (107 tests)
 - Dev server: port 5174 (NOT 5173)
 - Backend CORS configured for port 5174
+
+## LSP Workflow (run before the checklist)
+
+For each changed file:
+
+**Step A — enumerate symbols:**
+
+Call `documentSymbol` on the file to get all symbols with their positions. Use this list to find line/character values for the LSP calls below. If LSP returns an error or empty/inconclusive result, fall back to Grep for that file.
+
+**Step B — targeted LSP calls:**
+
+| Checklist item | LSP call |
+|---|---|
+| Changed prop/interface: all consumers updated | `findReferences` on the interface definition → verify each reference site handles the change |
+| Hook return type matches consumption | `hover` at the hook call site → compare resolved return type to how it is used |
+| Import resolves (no phantom types) | `goToDefinition` on each import → confirms it lands on a real definition |
+
+Use Grep as fallback for any LSP call that returns an error or empty/inconclusive result.
 
 ## Review Mode — Checklist
 

--- a/.claude/skills/systematic-debugging/SKILL.md
+++ b/.claude/skills/systematic-debugging/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: systematic-debugging
+description: Use when encountering any bug, test failure, or unexpected behavior, before proposing fixes
+---
+
+# Systematic Debugging
+
+> *Extends the official `superpowers:systematic-debugging` skill with LSP-powered
+> evidence gathering for this project's Python and TypeScript codebases. The four
+> phases and all iron laws from the official skill apply unchanged.*
+
+## Overview
+
+Random fixes waste time and create new bugs. Quick patches mask underlying issues.
+
+**Core principle:** ALWAYS find root cause before attempting fixes. Symptom fixes are failure.
+
+**Violating the letter of this process is violating the spirit of debugging.**
+
+## The Iron Law
+
+```text
+NO FIXES WITHOUT ROOT CAUSE INVESTIGATION FIRST
+```
+
+If you haven't completed Phase 1, you cannot propose fixes.
+
+## When to Use
+
+Use for ANY technical issue: test failures, bugs in production, unexpected behavior,
+performance problems, build failures, integration issues.
+
+## The Four Phases
+
+### Phase 1: Root Cause Investigation
+
+**BEFORE attempting ANY fix:**
+
+1. Read error messages carefully — stack traces, line numbers, error codes.
+2. Reproduce consistently — can you trigger it reliably?
+3. Check recent changes — git diff, recent commits, new dependencies.
+4. **Gather evidence with LSP (Python + TypeScript files):**
+
+   At the function where the error surfaces:
+
+```text
+a. documentSymbol(filePath) → scan the returned symbol list for the target function → get {line, character}
+b. incomingCalls({filePath, line, character}) → who actually calls this?
+   (replaces grep-based "who calls X?" chains — no text noise)
+c. hover({filePath, line, character of suspicious argument})
+   → reveals resolved type; type mismatches show here before the stack trace does
+```
+
+   If LSP returns an error or inconclusive result, fall back to grep + Read, then continue with step 5.
+
+1. Trace data flow — where does the bad value originate? Keep tracing up until
+   you find the source. Fix at source, not at symptom.
+
+### Phase 2: Pattern Analysis
+
+1. Find working examples — locate similar working code.
+2. Compare against references — read the reference implementation completely.
+3. Identify differences — list every difference, however small.
+4. Understand dependencies — config, environment, assumptions.
+
+### Phase 3: Hypothesis and Testing
+
+**Scientific method:**
+
+1. **Form single hypothesis** — "I think X is the root cause because Y."
+2. **Before acting, scope the change with LSP:**
+
+```text
+a. findReferences({filePath, line, character of symbol to modify})
+   → how many files reference this? A wide blast radius needs a wider fix.
+b. outgoingCalls({filePath, line, character of suspect function})
+   → any unexpected DB or network call reachable from here?
+   Treat unexpected calls as new facts — widen the blast-radius estimate before forming a hypothesis.
+```
+
+   If LSP returns empty/inconclusive, use grep to estimate blast radius instead.
+
+1. **Test minimally** — the SMALLEST possible change, one variable at a time.
+2. **Verify before continuing** — did it work? Yes → Phase 4. No → new hypothesis.
+3. **When you don't know** — say so, don't pretend.
+
+### Phase 4: Implementation
+
+1. Create failing test case (use `superpowers:test-driven-development`).
+2. Implement single fix — address the root cause identified.
+3. Verify fix — test passes, no other tests broken.
+4. **If 3+ fixes failed:** question the architecture. Stop and discuss before
+   attempting more fixes.
+
+## Red Flags — STOP and Return to Phase 1
+
+- "Quick fix for now, investigate later"
+- "Just try changing X and see if it works"
+- "I don't fully understand but this might work"
+- Proposing solutions before tracing data flow
+- "One more fix attempt" when already tried 2+
+
+## Supporting Techniques
+
+- `root-cause-tracing.md` (official skill) — trace bugs backward through call stack
+- `defense-in-depth.md` (official skill) — validate at multiple layers
+- `lsp-intelligence` skill — full LSP operation catalogue and usage rules
+
+**Related skills:**
+
+- `superpowers:test-driven-development` — for creating the failing test (Phase 4)
+- `superpowers:verification-before-completion` — verify fix worked before claiming success

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,9 +25,28 @@ Multi-platform plant identification app. Backend (Django + Wagtail) at port 8000
 
 See platform-specific `CLAUDE.md` files in `backend/`, `web/`, and `plant_community_mobile/` for commands and conventions.
 
+## Code Intelligence (LSP)
+
+pyright-lsp (Python) and typescript-language-server (TypeScript/JS) are active.
+Use them for symbol-level intelligence instead of grep wherever possible.
+
+**Three rules:**
+
+1. **Reach for LSP before grep for symbol lookups.** `documentSymbol` to enumerate
+   a file's API, `findReferences` to find call sites, `hover` for resolved types.
+   Use grep for text patterns, strings, comments, and dynamic names.
+
+2. **Compose, don't choose.** Standard pattern: `documentSymbol` → get position →
+   targeted LSP call. LSP needs a position; grep finds it cheaply.
+
+3. **Graceful fallback.** If LSP returns an error or empty/inconclusive result,
+   fall back to grep. Don't stall on LSP availability.
+
+See the `lsp-intelligence` skill for the full operation catalogue.
+
 ## Critical Gotchas
 
-Six non-obvious bugs that have already caused real failures:
+Seven non-obvious bugs that have already caused real failures:
 
 **1. ViewSet `get_permissions()` must call `super()` for `@action` endpoints**
 If you override `get_permissions()` without calling `super().get_permissions()` for custom actions, action-level `permission_classes` are silently ignored — a security hole. See `backend/docs/patterns/architecture/viewsets.md`.
@@ -46,6 +65,13 @@ Use `psycopg2.sql.Identifier()` + a whitelist. F-strings concatenate directly in
 
 **6. Test DB stale after migration changes**
 If the test DB predates a migration change, Django raises `FieldError`. Fix: pass `--noinput` to force a fresh rebuild: `python manage.py test apps.foo --noinput`.
+
+**7. LSP requires file position, not symbol name**
+You cannot call `findReferences("get_permissions")` — you need the file path and
+the exact line/character where the symbol is defined. Always get position from
+`documentSymbol` first, or from a prior `Read` (the line number column is `line`;
+count characters from the start of the line for `character`, or pass `documentSymbol`
+results through directly).
 
 ## Pattern Library
 


### PR DESCRIPTION
## Summary

- Adds LSP workflow blocks to `django-drf-reviewer` and `react-typescript-reviewer` (uses `documentSymbol` + targeted `findReferences`/`outgoingCalls`/`hover`; documents that Django ORM is not statically resolved by pyright)
- Creates `.claude/skills/systematic-debugging/SKILL.md` — project-local shadow of the official skill with LSP evidence-gathering steps in Phase 1 and 3
- Adds `## Code Intelligence (LSP)` section + gotcha #7 to `CLAUDE.md`

These changes were built and reviewed in session but landed on a branch that was squash-merged before being pushed; restored here as a clean PR against main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)