### PR TITLE
fix(wrangler): point assets.directory to web/dist

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -6,7 +6,7 @@
     "enabled": true
   },
   "assets": {
-    "directory": "web"
+    "directory": "web/dist"
   },
   "compatibility_flags": [
     "nodejs_compat"


### PR DESCRIPTION
One-line fix: `"web"` → `"web/dist"` so Cloudflare Workers serves the compiled bundle rather than raw source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)