### PR TITLE
fix(ci): run Harness CI on every PR (unblock path-filtered required check)

### DIFF
--- a/.github/workflows/harness-ci.yml
+++ b/.github/workflows/harness-ci.yml
@@ -1,7 +1,13 @@
 name: Harness CI
 
-# Run the harness's own test suite on every PR or push that touches the harness
-# itself (.claude/hooks/, scripts/inject/, or docs/rules/).
+# Runs the harness's own test suite.
+#   - pull_request to main/develop: ALWAYS (no path filter). This job is a
+#     REQUIRED status check; a path-filtered required check deadlocks every PR
+#     that doesn't touch the harness — GitHub waits forever for a check that
+#     never reports. The tests are fast and exercise repo-resident harness code,
+#     so running them on every PR is cheap and keeps the required check honest.
+#   - push to main/develop: only when the harness itself changes (.claude/hooks/,
+#     scripts/inject/, docs/rules/, or this workflow).
 #
 # Local equivalent (run from repo root):
 #   bash .claude/hooks/test-inject-patterns.sh && \
@@ -21,11 +27,6 @@ name: Harness CI
       - '.github/workflows/harness-ci.yml'
   pull_request:
     branches: [main, develop]
-    paths:
-      - '.claude/hooks/**'
-      - 'scripts/inject/**'
-      - 'docs/rules/**'
-      - '.github/workflows/harness-ci.yml'
 
 jobs:
   harness-tests:


### PR DESCRIPTION
## Problem

The **Hook self-tests and Python inject tests** job (`Harness CI`, `.github/workflows/harness-ci.yml`) is a **required** status check in `main` branch protection, but the workflow was **path-filtered** to `.claude/hooks/**`, `scripts/inject/**`, `docs/rules/**`, and the workflow file itself.

Any PR that doesn't touch those paths never triggers the job → GitHub waits forever for a required check that never reports → the PR is permanently `BLOCKED` (even with every other check green). Hit on **#341** (a todo-sweep PR with no harness changes).

## Fix

Remove the `paths:` filter from the **`pull_request`** trigger so the harness tests run and report on every PR to `main`/`develop`. The tests are fast and exercise repo-resident harness code (independent of the PR diff), so running them unconditionally is cheap and keeps the required check honest. The **`push`** trigger stays path-filtered (post-merge runs only matter when the harness changes).

## Notes
- This PR touches `harness-ci.yml`, so Harness CI runs on it (self-validating) — it should not be blocked.
- After merge, #341 (and any future non-harness PR) will get the harness check and stop deadlocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)