### PR TITLE
fix(deploy): build React app before Cloudflare deploy (fixes blank-screen prod)

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -10,7 +10,11 @@
     // index.html that loads /src/main.jsx (404 in prod -> blank screen).
     // The Workers Builds trigger runs `cd web && npm ci && npm run build`
     // first, which produces web/dist/.
-    "directory": "web/dist"
+    "directory": "web/dist",
+    // React Router SPA: serve index.html (200) for non-asset paths so deep
+    // links / refresh on client-side routes (/forum, /blog/...) work instead
+    // of 404ing.
+    "not_found_handling": "single-page-application"
   },
   "compatibility_flags": [
     "nodejs_compat"

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -6,7 +6,11 @@
     "enabled": true
   },
   "assets": {
-    "directory": "web"
+    // Vite build output, NOT the source dir. `web/` source has a dev-only
+    // index.html that loads /src/main.jsx (404 in prod -> blank screen).
+    // The Workers Builds trigger runs `cd web && npm ci && npm run build`
+    // first, which produces web/dist/.
+    "directory": "web/dist"
   },
   "compatibility_flags": [
     "nodejs_compat"


### PR DESCRIPTION
## Problem

Visiting the production Worker URL (`plantidcommunity.william-tower.workers.dev`) showed a **blank screen**.

Root cause (confirmed empirically — prod served a 352-byte `index.html` whose `/src/main.jsx` returned 404):

1. The Worker is an **assets-only** deployment, but `wrangler.jsonc` pointed `assets.directory` at the Vite **source** dir `web/`.
2. `web/dist` is gitignored, and **both Workers Builds triggers had an empty `build_command`** — so CI never ran `vite build` and uploaded the raw source.
3. The source `index.html` loads `/src/main.jsx` (Vite dev placeholder) → 404 in prod → `#root` never mounts → blank.

## Fix (two coordinated changes)

**This PR (repo):** `assets.directory` → `web/dist` (the build output).

**Already applied via the Cloudflare API (Workers Builds triggers):** `build_command` on both triggers set to `cd web && npm ci && npm run build`, so `web/dist` exists at deploy time.

| Trigger | Branch | build_command (now) | deploy_command (unchanged) |
|---------|--------|---------------------|----------------------------|
| Deploy default branch | `main` | `cd web && npm ci && npm run build` | `npx wrangler deploy` (promotes to prod) |
| Deploy non-prod branches | `*` ≠ `main` | `cd web && npm ci && npm run build` | `npx wrangler versions upload` (preview) |

The two changes must land together: pointing at `web/dist` without the build step would make deploy read a nonexistent dir. The build_command was set first, so merging this is safe.

## Verification

On merge, the `main` trigger will build `web/dist` and `wrangler deploy` will promote it. Expected: prod `index.html` references hashed `/assets/index-*.js` and the SPA mounts. Will confirm against the live URL after the deploy completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)