### PR TITLE
fix(railway): silence collectstatic to stop log-rate container kill

### DIFF
--- a/backend/railway.json
+++ b/backend/railway.json
@@ -4,7 +4,7 @@
     "builder": "NIXPACKS"
   },
   "deploy": {
-    "startCommand": "python manage.py migrate --noinput && python manage.py collectstatic --noinput && gunicorn plant_community_backend.wsgi:application --bind 0.0.0.0:$PORT --workers 2 --timeout 120",
+    "startCommand": "python manage.py migrate --noinput && python manage.py collectstatic --noinput --verbosity 0 && gunicorn plant_community_backend.wsgi:application --bind 0.0.0.0:$PORT --workers 2 --timeout 120",
     "restartPolicyType": "ON_FAILURE",
     "restartPolicyMaxRetries": 5
   }


### PR DESCRIPTION
## Problem
The Railway backend deploy built fine but **crashed on startup**, with the deploy log showing:
> `Railway rate limit of 500 logs/sec reached for replica … Stopping Container`

`migrate` succeeds (DB connection works), then `collectstatic` runs with `CompressedManifestStaticFilesStorage`, which prints a line per processed file. Wagtail's admin assets are thousands of files → >500 log lines/sec → Railway drops messages and kills the container before gunicorn binds the port (→ 502 "Application failed to respond").

## Fix
Add `--verbosity 0` to the `collectstatic` step in `backend/railway.json` so it runs silently.

## Notes
- Single-line, surgical change to the start command.
- Railway auto-redeploys `main` on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)