### PR TITLE
fix(settings): correct PlantNet API key min length (32→20)

### DIFF
--- a/backend/plant_community_backend/settings.py
+++ b/backend/plant_community_backend/settings.py
@@ -1319,7 +1319,9 @@ def validate_environment():
     # ========================================
     api_key_checks = [
         ("PLANT_ID_API_KEY", PLANT_ID_API_KEY, 32, "Plant.id API"),
-        ("PLANTNET_API_KEY", PLANTNET_API_KEY, 32, "PlantNet API (fallback provider)"),
+        # PlantNet keys are ~26 chars (e.g. "2b10…"), so 32 wrongly rejects a
+        # valid key. Keep a low floor that still catches obviously-truncated keys.
+        ("PLANTNET_API_KEY", PLANTNET_API_KEY, 20, "PlantNet API (fallback provider)"),
     ]
 
     for key_name, key_value, min_length, description in api_key_checks:


### PR DESCRIPTION
## Problem
The Railway deploy crash-looped. The deploy log showed:
> `CRITICAL ENVIRONMENT CONFIGURATION ERRORS`
> `1. PLANTNET_API_KEY appears invalid (too short: 26 chars, minimum 32).`

`validate_environment()` (run on **every** management command, gated on `DEBUG=False`) required PlantNet keys ≥32 chars. Real PlantNet keys are ~26 (`2b10…`), so a valid key fails the check → the function raises → migrate/collectstatic/gunicorn all exit before binding the port (the repeated multi-line error block is also what tripped Railway's log-rate limit).

## Fix
Lower the PlantNet minimum to 20 — still catches obviously-truncated keys, accepts real ones. Plant.id/Kindwise keys are longer and keep the 32 floor.

Only affects production (`DEBUG=False`); local dev was unaffected, which is why it surfaced only on deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)