### PR TITLE
chore(deps): bump Django 6.0.5 → 6.0.6 (security release)

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -37,7 +37,7 @@ decorator==5.2.1
 defusedxml==0.7.1
 distro==1.9.0
 dj-database-url==3.1.2
-Django==6.0.5
+Django==6.0.6
 django-ai-core==0.1.5
 django-allauth==65.16.1
 django-appconf==1.2.0


### PR DESCRIPTION
## What

Bumps `backend/requirements.txt`: `Django==6.0.5` → `Django==6.0.6`. One line.

## Why

`pip-audit` (the **Backend Python Security Scan** CI job) flags 5 Low-severity advisories against Django 6.0.5, all fixed in **6.0.6** — the [Django security release dated 2026-06-03](https://www.djangoproject.com/weblog/2026/jun/03/security-releases/), which landed after the pin was set:

| CVE / PYSEC | Component | Issue |
|-------------|-----------|-------|
| CVE-2026-6873 / PYSEC-2026-197 | `get_signed_cookie()` | Salt-derivation collision across contexts |
| CVE-2026-7666 / PYSEC-2026-198 | SMTP `EMAIL_USE_TLS` | Failed STARTTLS could send mail unencrypted |
| CVE-2026-8404 / PYSEC-2026-199 | cache middleware / `cache_page` | Case-sensitive `Cache-Control` caches private responses |
| CVE-2026-35193 / PYSEC-2026-200 | cache middleware / `cache_page` | Cached authorized responses without varying on `Authorization` |
| CVE-2026-48587 / PYSEC-2026-201 | `UpdateCacheMiddleware` | Whitespace in `Vary` defeats wildcard detection |

All **severity Low**. 6.0.6 is a patch release on the same 6.0 line (security-only, no API changes), so regression risk is minimal and the full CI suite validates it.

## Exposure in this app (checked)

Currently low-to-none, but fixed anyway as live-testing hygiene:
- `get_signed_cookie` — **not used**.
- 3 cache CVEs — **not reachable**: caching is via django-redis services (`cache.get/set`), not Django's response-cache middleware; `cache_page` is only imported in `apps/users/views.py`, never applied; `UpdateCacheMiddleware` isn't in `MIDDLEWARE`.
- SMTP TLS — prod uses the console email backend (SMTP unset), so inactive now; becomes relevant once real SMTP is wired (`EMAIL_USE_TLS` defaults `True`).

Restoring the gate to green also means a *future* real CVE won't be hidden behind a perpetually-red check.

## Scope

- CI audits only `requirements.txt`, so this single line clears the **Backend Python Security Scan**.
- `requirements-dev.txt`'s stale `Django==5.2.7` pin is **out of scope** here — tracked in **todo 217** (dev/prod pin reconciliation + admin-render smoke coverage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)