### PR TITLE
fix(logging): stop django.* records double-emitting via root

### DIFF
--- a/backend/apps/blog/tests/test_logging_config.py
+++ b/backend/apps/blog/tests/test_logging_config.py
@@ -1,0 +1,28 @@
+"""Regression test: project loggers must not double-emit through root.
+
+`settings.LOGGING` attaches the same handlers (`console`/`console_prod`) to the
+`django`, `apps`, and `plant_community_backend` loggers AND to `root`. If one of
+those loggers also propagates to `root`, every record it handles is emitted
+twice. The `django` logger was missing `propagate=False` (fixed 2026-06-06),
+so all `django.*` records (request/server/security/db) double-logged in prod.
+
+This lives in `apps.blog.tests` (not forum) because the logging config is global
+and blog is always installed + run by CI's pytest (forum tests are ignored).
+"""
+
+import logging
+
+from django.test import SimpleTestCase
+
+
+class LoggerPropagationTests(SimpleTestCase):
+    def test_project_loggers_do_not_propagate_to_root(self):
+        # Each carries its own handlers; propagating to root (same handlers)
+        # would double every record.
+        for name in ("django", "apps", "plant_community_backend"):
+            with self.subTest(logger=name):
+                self.assertFalse(
+                    logging.getLogger(name).propagate,
+                    f"{name} logger must set propagate=False, or its records "
+                    f"double-emit via root (which carries the same handlers).",
+                )

--- a/backend/plant_community_backend/settings.py
+++ b/backend/plant_community_backend/settings.py
@@ -937,6 +937,10 @@ LOGGING = {
             "handlers": ["console", "console_prod"]
             + (["file"] if ENABLE_FILE_LOGGING else []),
             "level": "INFO",
+            # Without this, django.* records emit once here AND again via root
+            # (which has the same handlers) — double logging. Match the sibling
+            # loggers below, which already set propagate=False.
+            "propagate": False,
         },
         "plant_community_backend": {
             "handlers": ["console", "console_prod"]


### PR DESCRIPTION
## What

One-line logging fix: add `propagate: False` to the `django` logger in `settings.py`, plus a regression test. Part of **todo 216 item 4** (logging hygiene).

## The real bug (vs. the todo's framing)

The todo described "duplicate `console`/`console_prod` handlers, every line logged twice." On inspection that framing is **wrong**: `console` (filter `require_debug_true`) and `console_prod` (filter `require_debug_false`) are **mutually exclusive** — only one fires depending on `DEBUG`. They're the dev-vs-prod formatter split; collapsing them would break it. **Not touched.**

The actual duplication: the `django` logger has its own handlers **and** lacked `propagate: False`, so every `django.*` record (request / server / security / db) was emitted once by the `django` logger and **again** by `root` (same handlers) — doubled in both dev and prod. Its siblings `apps` and `plant_community_backend` already set `propagate: False`; `django` was simply missed. Fix = match them.

## Test

`apps/blog/tests/test_logging_config.py` asserts the three project loggers all have `propagate=False`. Placed in **blog** (always installed, **not** in pytest's ignore list) so CI actually runs it — `apps/forum_integration/tests` is `--ignore`d and CI runs with `ENABLE_FORUM=False`. Fail-first: before this change `getLogger("django").propagate` is `True`. Verified: `1 passed` via `python -m pytest`.

## Scope

- The other half of item 4 — **`ENABLE_FILE_LOGGING=False`** in prod (stop writes to Railway's ephemeral disk) — is a Railway env var, set separately (code default left `True` so local dev is unaffected).
- PII log audit is a separate verification step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)