### PR TITLE
docs(todos): 217 — record the CI test-coverage gap

### DIFF
--- a/todos/217-pending-p2-admin-render-smoke-coverage.md
+++ b/todos/217-pending-p2-admin-render-smoke-coverage.md
@@ -40,6 +40,19 @@ Observed while diagnosing the `/cms/login/` 500 (2026-06-06):
   that calls every project `insert_global_admin_css/js` hook the way Wagtail
   does. That guards the *hook* class but not the *full admin render* (templates,
   static, middleware, SSL redirect).
+- **That hotfix test does NOT run in CI.** CI runs `python -m pytest` with
+  `ENABLE_FORUM=False` (so `apps.forum_integration` is left out of
+  `INSTALLED_APPS` — settings.py:169/199-201) AND `pytest.ini` carries
+  `--ignore=apps/forum_integration/tests`. The test only executes under a local
+  `manage.py test` with forum enabled, so **forum admin regressions are
+  effectively un-CI-guarded today.**
+- **The prod 500 was the BLOG hooks, not forum.** `ENABLE_FORUM` defaults False,
+  so forum hooks weren't even loaded in prod; the crash came from
+  `apps.blog.wagtail_hooks` (blog is always installed). The forum-hook part of
+  the fix was precautionary. Implication: **blog (always-installed) admin
+  regressions ARE CI-testable; forum ones are not** without a forum-enabled CI
+  job. (The PR #352 logging test was deliberately placed in `apps/blog/tests/`
+  for exactly this reason — it runs in CI; a forum-located test would not.)
 
 ## Recommended Action
 
@@ -49,6 +62,9 @@ Observed while diagnosing the `/cms/login/` 500 (2026-06-06):
      `SECURE_SSL_REDIRECT`) returns 200, and
    - authenticated `GET /cms/` (a superuser fixture) returns 200/302, not 500.
    This exercises templates + global hooks + static resolution end to end.
+   **Placement matters:** put it in an always-installed, non-ignored app (e.g.
+   `apps/blog/tests/`) so CI's pytest collects it — NOT `apps/forum_integration/tests`
+   (ignored, and forum is off in CI).
 2. **Reconcile `requirements-dev.txt`** with `requirements.txt`: either bump its
    Django (and the drifted siblings) to the prod versions, or remove the
    divergent pins and document why dev intentionally differs. One source of
@@ -56,6 +72,11 @@ Observed while diagnosing the `/cms/login/` 500 (2026-06-06):
 3. **Optional CI guard:** assert the installed Django matches the pin (a one-line
    `python -c "import django; assert django.VERSION[:2] == (6, 0)"` step), or a
    small version-matrix, so a future dev/prod split is caught loudly.
+4. **Decide forum admin-hook coverage.** With `ENABLE_FORUM=False` in CI, forum
+   hooks never load, so the hotfix's forum test can't run there. Either (a) add a
+   forum-enabled CI job/marker that un-ignores `apps/forum_integration/tests` and
+   sets `ENABLE_FORUM=True`, or (b) accept that forum admin hooks are only
+   locally verifiable and document that decision. Don't leave it implicit.
 
 ## Technical Details
 
@@ -76,8 +97,21 @@ Observed while diagnosing the `/cms/login/` 500 (2026-06-06):
 - [ ] `requirements-dev.txt` either matches `requirements.txt`'s Django (+ the
       drifted siblings) or its divergence is removed/documented as deliberate.
 - [ ] (Optional) CI fails loudly if the installed Django diverges from the pin.
+- [ ] The smoke test lives in a CI-collected location (not
+      `apps/forum_integration/tests`), and a decision on forum admin-hook
+      coverage (forum-enabled CI job vs documented local-only) is recorded.
 
 ## Work Log
+
+### 2026-06-06 - CI coverage gap documented
+
+- Discovered while doing the logging fix (PR #352): CI runs `python -m pytest`
+  with `ENABLE_FORUM=False` and `pytest.ini --ignore=apps/forum_integration/tests`,
+  so the hotfix's admin-hooks test (in `forum_integration/tests`) **never runs in
+  CI** — it only ran locally via `manage.py test`. Added findings + a 4th
+  recommended action (decide forum coverage) + an acceptance criterion on test
+  placement. Also clarified the prod 500 was the always-installed **blog** hooks,
+  not forum (forum is off by default).
 
 ### 2026-06-06 - Filed
 


### PR DESCRIPTION
## What

Updates **todo 217** with a concrete gap found while doing the logging fix (#352). Doc-only.

## The gap

The admin-hooks regression test added in #349 (`apps/forum_integration/tests/test_admin_hooks.py`) **does not run in CI**:
- CI runs `python -m pytest` with **`ENABLE_FORUM=False`** → `apps.forum_integration` isn't in `INSTALLED_APPS` (settings.py:169/199-201).
- `pytest.ini` carries **`--ignore=apps/forum_integration/tests`**.

So that test only executes under a local `manage.py test` with forum enabled. Forum admin regressions are effectively un-CI-guarded today.

Also clarified: the prod 500 was the **always-installed blog hooks**, not forum (forum is off by default), so the forum-hook part of the hotfix was precautionary.

## Changes to 217

- **Findings:** the CI exclusion + the blog-vs-forum clarification (and that PR #352's logging test was placed in `apps/blog/tests/` precisely so CI runs it).
- **Recommended Action:** placement guidance on the smoke test (always-installed, non-ignored app), plus a new item 4 — *decide* forum coverage (forum-enabled CI job vs documented local-only).
- **Acceptance Criteria:** the smoke test must live in a CI-collected location + a forum-coverage decision is recorded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)