### PR TITLE
fix(mobile): inject uuidProvider into PlantIdentificationService for testable DI

### DIFF
--- a/docs/reviews/2026-05-07-1641-full-review-COMPLETED.md
+++ b/docs/reviews/2026-05-07-1641-full-review-COMPLETED.md
@@ -58,6 +58,7 @@
 - [x] #49 blog-viewsets-listing-view-int-cast → todo 072 (completed 2026-05-09)
 - [x] #44 blog-viewsets-by-category-loop-n1 → todo 073 (completed 2026-05-09)
 - [x] #45 blog-viewsets-by-category-per-query → todo 073 (completed 2026-05-09)
+- [x] #332 plant-identification-service-uuid-constructor-dead-code (repaired — replaced hardcoded Uuid with ref-based uuidProvider and added unit test, 2026-06-03)
 
 ---
 
@@ -2247,11 +2248,11 @@
 - **Rule:** Riverpod 3.x — new providers must use Notifier class with @riverpod annotation
 - **Suggested fix:** Convert PlantIdentificationService to use @riverpod with a generated *.g.dart part file.
 
-**#332** Line 17: PlantIdentificationService extends Notifier but takes a Uuid via constructor; the manual NotifierProvider uses the no-arg `.new` tear-off, so the injected Uuid is always the default and the parameter is dead code outside direct instantiation.
+**#332** ~~Line 17: PlantIdentificationService extends Notifier but takes a Uuid via constructor; the manual NotifierProvider uses the no-arg `.new` tear-off, so the injected Uuid is always the default and the parameter is dead code outside direct instantiation.~~ **REPAIRED 2026-06-03**
 
 - **Reviewer:** flutter-dart-reviewer
 - **Rule:** Riverpod 3.x — Notifier subclasses must rely on ref-based DI, not constructor args
-- **Suggested fix:** Drop the constructor parameter and read a `uuidProvider` (override-able in tests) inside the methods that need it.
+- **Fix applied:** Removed hardcoded `final Uuid _uuid = const Uuid()` field, added top-level `uuidProvider = Provider<Uuid>((ref) => const Uuid())`, and updated `identifyPlant` to read `ref.read(uuidProvider).v4()` for fallback ID generation. Added `test/services/plant_identification_service_test.dart` verifying override works.
 
 ### `web/src/components/diagnosis/StreamFieldEditor.tsx`
 

--- a/plant_community_mobile/lib/services/plant_identification_service.dart
+++ b/plant_community_mobile/lib/services/plant_identification_service.dart
@@ -6,6 +6,9 @@ import '../models/plant.dart';
 import 'api_service.dart';
 import 'firebase_storage_service.dart';
 
+/// Injectable UUID generator. Override in tests for deterministic IDs.
+final uuidProvider = Provider<Uuid>((ref) => const Uuid());
+
 /// Provider for plant identification orchestration.
 final plantIdentificationServiceProvider =
     NotifierProvider<PlantIdentificationService, void>(
@@ -13,13 +16,7 @@ final plantIdentificationServiceProvider =
     );
 
 /// Coordinates image upload and backend plant identification.
-///
-/// A Riverpod [Notifier] is always built via the no-arg `.new` tear-off, so it
-/// must not declare constructor parameters. Override the provider with a mock
-/// subclass in tests instead.
 class PlantIdentificationService extends Notifier<void> {
-  final Uuid _uuid = const Uuid();
-
   @override
   void build() {
     // Stateless orchestration service.
@@ -71,7 +68,7 @@ class PlantIdentificationService extends Notifier<void> {
       }
 
       return Plant(
-        id: _stringValue(responseData, ['id']) ?? _uuid.v4(),
+        id: _stringValue(responseData, ['id']) ?? ref.read(uuidProvider).v4(),
         name: name,
         scientificName: scientificName,
         description:

--- a/plant_community_mobile/test/services/plant_identification_service_test.dart
+++ b/plant_community_mobile/test/services/plant_identification_service_test.dart
@@ -1,0 +1,135 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:plant_community_mobile/services/api_service.dart';
+import 'package:plant_community_mobile/services/firebase_storage_service.dart';
+import 'package:plant_community_mobile/services/plant_identification_service.dart';
+import 'package:uuid/uuid.dart';
+
+void main() {
+  group('PlantIdentificationService', () {
+    test('falls back to uuidProvider when API omits id', () async {
+      final container = ProviderContainer(
+        overrides: [
+          apiServiceProvider.overrideWith((ref) => _NoIdApiService()),
+          firebaseStorageServiceProvider.overrideWith(
+            () => _MockFirebaseStorageService(),
+          ),
+          uuidProvider.overrideWithValue(const _MockUuid()),
+        ],
+      );
+
+      addTearDown(container.dispose);
+
+      final service = container.read(
+        plantIdentificationServiceProvider.notifier,
+      );
+
+      final plant = await service.identifyPlant('/test/image.jpg');
+
+      expect(plant.id, 'mock-uuid-42');
+      expect(plant.name, 'Test Plant');
+      expect(plant.scientificName, 'Testus plantus');
+    });
+  });
+}
+
+/// Mock API service that returns a valid response without an `id` field,
+/// forcing the service to fall back to uuidProvider for the plant ID.
+class _NoIdApiService extends ApiService {
+  _NoIdApiService() : super(baseUrl: 'http://localhost:8000/api/v1');
+
+  @override
+  String get baseUrl => 'http://localhost:8000/api/v1';
+
+  @override
+  void setAuthToken(String? token) {}
+
+  @override
+  Future<Response> uploadFile(
+    String path, {
+    required String filePath,
+    String fieldName = 'image',
+    Map<String, dynamic>? data,
+    void Function(int sent, int total)? onSendProgress,
+  }) async {
+    return Response(
+      requestOptions: RequestOptions(path: path),
+      statusCode: 200,
+      data: {
+        'name': 'Test Plant',
+        'scientific_name': 'Testus plantus',
+        'description': 'A test plant for unit testing.',
+        'care_instructions': ['Water occasionally'],
+      },
+    );
+  }
+
+  @override
+  Future<Response> get(
+    String path, {
+    Map<String, dynamic>? queryParameters,
+    Options? options,
+  }) => throw UnimplementedError();
+
+  @override
+  Future<Response> post(
+    String path, {
+    dynamic data,
+    Map<String, dynamic>? queryParameters,
+    Options? options,
+  }) => throw UnimplementedError();
+
+  @override
+  Future<Response> put(
+    String path, {
+    dynamic data,
+    Map<String, dynamic>? queryParameters,
+    Options? options,
+  }) => throw UnimplementedError();
+
+  @override
+  Future<Response> patch(
+    String path, {
+    dynamic data,
+    Map<String, dynamic>? queryParameters,
+    Options? options,
+  }) => throw UnimplementedError();
+
+  @override
+  Future<Response> delete(
+    String path, {
+    dynamic data,
+    Map<String, dynamic>? queryParameters,
+    Options? options,
+  }) => throw UnimplementedError();
+}
+
+/// Minimal mock Firebase Storage service for unit tests.
+class _MockFirebaseStorageService extends FirebaseStorageService {
+  @override
+  Future<String> uploadPlantImage(
+    String filePath, {
+    Function(double progress)? onProgress,
+  }) async {
+    return 'https://firebase.storage/mock.jpg';
+  }
+
+  @override
+  Future<void> deletePlantImage(String imageUrl) async {}
+}
+
+/// Deterministic UUID mock that always returns the same v4 value.
+class _MockUuid implements Uuid {
+  const _MockUuid();
+
+  @override
+  String v4({
+    @Deprecated('use config instead. Removal in 5.0.0')
+    Map<String, dynamic>? options,
+    dynamic config,
+  }) => 'mock-uuid-42';
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}


### PR DESCRIPTION
## Summary

Replaces the hardcoded `final Uuid _uuid` field in `PlantIdentificationService` with an injectable Riverpod provider, so fallback ID generation can be overridden deterministically in tests.

- Adds `uuidProvider = Provider<Uuid>((ref) => const Uuid())` — a **plain** provider (no `@riverpod` annotation, so no codegen/`build_runner` step required)
- Removes the hardcoded `_uuid` field from the `Notifier` subclass
- `identifyPlant` now uses `ref.read(uuidProvider).v4()` for fallback IDs
- Adds a unit test verifying a `uuidProvider` override produces deterministic IDs

## Why this is a standalone PR

This commit was originally stranded on the `web-tint-badge-contrast` branch alongside unrelated a11y work. That a11y work merged via **#332** (squash); this Flutter fix is the only remaining unique commit, so it's been cherry-picked onto fresh `main` and given a properly-scoped branch/PR.

> Note: the commit subject's `fix(#332)` refers to **review finding #332** in `docs/reviews/2026-05-07-1641-full-review.md`, *not* PR #332 (the GitHub auto-link is a coincidental number collision). The finding is marked repaired in the review doc as part of this change.

## Test plan

- `cd plant_community_mobile && flutter test test/services/plant_identification_service_test.dart`
- New test overrides `uuidProvider` and asserts deterministic fallback IDs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)