### PR TITLE
docs: codify session learnings + fix stale wrangler deploy doc

### DIFF
--- a/docs/LEARNINGS.md
+++ b/docs/LEARNINGS.md
@@ -362,3 +362,19 @@ This file is append-only. New entries are added by main Claude after each code r
 **Fix**: Added `propagate=False` to the `django` logger, matching its siblings. Regression test in `apps/blog/tests/` (a CI-collected, always-installed location — `apps/forum_integration/tests` is `--ignore`d by pytest) asserts all three project loggers set `propagate=False`.
 **Rule**: A logger that defines its own `handlers` must also set `propagate=False` when `root` carries the same handlers, or every record double-emits. Don't diagnose double logging as "two console handlers" when those handlers have mutually-exclusive `require_debug_true/false` filters.
 **Agent**: django-drf-reviewer
+
+---
+
+## Tooling / Agents (2026-06-06 additions)
+
+### [2026-06-06] A path-filtered workflow cannot be a required status check — it deadlocks unrelated PRs
+
+**Mistake**: `mobile-ci.yml` (the Flutter `analyze`/`test`/build job) is path-filtered to `plant_community_mobile/**`, and is NOT in `main`'s required status checks — so a Flutter-only PR can merge with a failing `flutter test` (it's gated only by backend/web/harness checks). The obvious fix — "just add it to required checks" — is itself a trap: GitHub treats a required check with **no reported status** as pending forever, and a path-filtered workflow reports nothing on PRs whose diff doesn't match its `paths:`. So requiring it would permanently BLOCK every non-mobile PR (docs, backend, web). `harness-ci.yml:4-8` documents this exact trap and deliberately runs its required job on every PR (justified there because the harness tests are fast; Flutter's ~6.5 min run is not).
+**Fix**: Tracked in todo 219. Recommended pattern: a lightweight **always-run gate job** (no path filter) that detects whether mobile files changed, conditionally runs/awaits the heavy Flutter job, and **always reports a status** — make the gate the required check. Avoids both the deadlock and paying Flutter CI cost on every PR.
+**Rule**: A required status check MUST report a status on 100% of PRs to `main`. Never mark a path-filtered (`on.pull_request.paths:`) workflow as required — gate via an always-run job that emits success for out-of-scope PRs instead.
+
+### [2026-06-06] Squash-merged branches are invisible to `git branch -d` and pile up; detect via PR state, not diffs
+
+**Mistake**: A local branch list had grown to 37, ~92% of which were dead. Squash-merging a PR collapses the branch's commits into one new commit on `main` with a different SHA, so `git branch -d` (and `git branch --merged`) never recognize the original branch as merged — it lingers indefinitely. Worse, `git diff main..<branch>` is actively misleading for a branch that's many commits behind `main`: the diff is dominated by `main`'s *newer* work appearing as "deletions," which reads as huge unmerged value when the branch is actually superseded (one branch showed −1722 lines but its PR was already merged).
+**Fix**: Detect superseded branches by **PR state + landed artifacts**, not by diffing: `gh pr list --state all --head <branch>` (merged/closed?), and confirm the deliverables (e.g. archived todos, the squash commit) are in `main`. For squash detection without a PR, collapse the branch to a single tree-commit on its merge-base and `git cherry main <commit>` (a `-` means patch-present in `main`). Pruned 37 → relevant branches this way.
+**Rule**: Don't trust `git branch -d`/`--merged` or 2-dot diffs to decide if a branch is safe to delete in a squash-merge repo. Confirm the PR merged/closed and its content landed in `main`, then `git branch -D`. Periodically prune, or enable auto-delete-on-merge, so squash debris doesn't accumulate.

--- a/plant_community_mobile/docs/patterns/riverpod.md
+++ b/plant_community_mobile/docs/patterns/riverpod.md
@@ -21,6 +21,48 @@ ref.listen(authProvider, (prev, next) {
 
 ---
 
+## Testable Dependency Injection (plain `Provider`)
+
+Not every provider needs `@riverpod` codegen. For a simple injectable dependency
+(a UUID generator, a clock, a random source), expose it as a plain `Provider<T>`
+and read it via `ref` inside the consumer. This is the idiomatic way to make a
+`Notifier` testable: a `Notifier` is built via the no-arg `.new` tear-off, so it
+**cannot** take constructor params — inject through a provider instead, never a
+field or constructor arg.
+
+```dart
+// lib/services/plant_identification_service.dart
+/// Injectable UUID generator. Override in tests for deterministic IDs.
+final uuidProvider = Provider<Uuid>((ref) => const Uuid());
+
+class PlantIdentificationService extends Notifier<void> {
+  // No `final Uuid _uuid` field — read it through ref instead.
+  @override
+  void build() {}
+
+  Plant _toPlant(Map<String, dynamic> json) => Plant(
+    id: _stringValue(json, ['id']) ?? ref.read(uuidProvider).v4(), // fallback ID
+    // ...
+  );
+}
+```
+
+Override it in tests with `overrideWithValue` (works on plain `Provider`):
+
+```dart
+final container = ProviderContainer(
+  overrides: [uuidProvider.overrideWithValue(const _MockUuid())], // deterministic
+);
+addTearDown(container.dispose);
+```
+
+Reserve `@riverpod` codegen for `Notifier`/`AsyncNotifier` state and async data
+providers (see below). A trivial value provider as a generated part-file is
+overkill — `apiServiceProvider` in `api_service.dart` follows this same plain-
+`Provider` convention.
+
+---
+
 ## Code Generation Workflow
 
 1. Annotate the provider class with `@riverpod`

--- a/web/CLAUDE.md
+++ b/web/CLAUDE.md
@@ -34,7 +34,7 @@ npm run deploy    # wrangler deploy — push to Cloudflare
 npm run preview   # wrangler dev — local Workers emulation
 ```
 
-The `assets.directory` points at the `web/` folder, so run `npm run build` inside `web/` first, then `npm run deploy` from root.
+The `assets.directory` points at `web/dist` (the Vite build output — **not** the `web/` source dir, whose dev-only `index.html` loads `/src/main.jsx` and 404s/blanks in prod). So run `npm run build` inside `web/` first to produce `web/dist/`, then `npm run deploy` from root.
 
 ## CI
 


### PR DESCRIPTION
## Summary

Docs-only follow-up to today's session (branch cleanup, PR #332/#357 merges, #339 close, todo 219).

1. **`web/CLAUDE.md` — bug fix.** The deploy section claimed `assets.directory` points at the `web/` folder; it actually points at **`web/dist`** (`wrangler.jsonc:13`), and pointing at the `web/` source would 404/blank in prod (per wrangler's own comment). Found while closing the obsolete PR #339.
2. **`docs/LEARNINGS.md` — 2 Tooling/Agents entries.**
   - A **path-filtered workflow can't be a required status check** — it deadlocks unrelated PRs (the mobile-ci gap → todo 219).
   - **Squash-merged branches** are invisible to `git branch -d`/`--merged` and 2-dot diffs mislead when a branch is behind — detect via PR state + landed artifacts (pruned 37 → relevant this way).
3. **`riverpod.md` — testable-DI pattern.** Plain `Provider<T>` + `overrideWithValue` for injectable dependencies (the `uuidProvider` from PR #357), which the `@riverpod`-centric doc didn't cover.

No code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)