### PR TITLE
chore: gitignore .devin/ agent workflow configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -180,6 +180,9 @@ pids/
 !.claude/settings.json
 # .claude/settings.local.json stays ignored — it holds per-developer overrides
 
+# Devin AI agent workflow configs — per-developer local tooling, not shared
+.devin/
+
 # CLAUDE.md contains project-specific context and may include sensitive info
 # Use CLAUDE.md.example as template
 CLAUDE.md


### PR DESCRIPTION
## What

Resolves two orphaned (untracked) items in source control:

- **`.devin/`** — Devin AI's `todo-sweep` / `todo-resume` / `todo-next` / `todo-batch` workflow configs. These mirror the repo's Claude Code todo skills and are per-developer local agent tooling, not shared config. Now gitignored alongside the local `.claude/*` bits.
- **`plantid-live-homepage.png`** — a stray 101KB homepage screenshot at the repo root, unreferenced anywhere in the codebase. Deleted (it was untracked, so nothing to commit for the removal).

## Why

Keeps `git status` clean and treats Devin's local workflow configs the same way the repo already treats per-developer `.claude/` tooling.

## Diff

One line added to `.gitignore`:
```
+ # Devin AI agent workflow configs — per-developer local tooling, not shared
+ .devin/
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)