### PR TITLE
docs: codify findings from the dev-account security sweep

### DIFF
--- a/.claude/agents/security-reviewer.md
+++ b/.claude/agents/security-reviewer.md
@@ -31,6 +31,7 @@ Review only the files passed to you. Do not read the full repo. You run in paral
 - [ ] No API keys, passwords, tokens, or secret keys in committed files — check for patterns: `sk-`, `AIza`, `-----BEGIN`, assignment to `KEY`, `SECRET`, `TOKEN`, `PASSWORD`
 - [ ] `SECRET_KEY` must be ≥50 chars and must NOT contain: `django-insecure`, `change-me`, `test`, `dev`, `local`
 - [ ] `.env` files must not be committed — verify `.gitignore` covers `backend/.env`, `*.env`
+- [ ] No account creation in deploy-time paths — migrations must not `call_command()` or `create_user`/`create_superuser`; seed/demo/E2E management commands must raise `CommandError` when `settings.DEBUG` is False and never hardcode a password (byline-only accounts use `set_unusable_password()`)
 
 **File Upload (BLOCKER)**
 

--- a/docs/LEARNINGS.md
+++ b/docs/LEARNINGS.md
@@ -416,3 +416,14 @@ This file is append-only. New entries are added by main Claude after each code r
 
 **Rule**: After editing ANY codegen-backed Dart source (`@riverpod`, `@freezed`, or one with `part '*.g.dart'`), regenerate with `build_runner` and commit the `.g.dart` in the same change. Local analyze/test cannot detect a stale `.g.dart`; CI's codegen gate will block the merge.
 **Agent**: flutter-dart-reviewer
+
+## Security sweep (2026-06-10 additions)
+
+### [2026-06-10] A data migration that `call_command()`s a seed command minted a superuser with a hardcoded password on every deploy
+
+**Mistake**: Blog migration `0004_auto_20250819_1922` used `RunPython` → `call_command("migrate_care_guides_to_blog")`. That command, when the author user was missing, silently created superuser `plant_care_admin` / `temp_password_change_immediately`. Because Railway's start command runs `manage.py migrate --noinput` on **every deploy**, this was a standing account-creation path in production for ~10 months — gated only by the accident that prod had zero `PlantCareGuide` rows (the command early-returns at count 0). Three more known-credential creators shipped alongside: `create_sample_blog_posts.py` (superuser `admin`/`admin123`), `create_test_user` (`e2e@test.com`, known password), `create_demo_blog_posts` (staff `plant_blogger`, known password) — all runnable in prod with one `railway run`. A second trap: `migrations/RunPython` calling a management command executes the command's *current* code on every fresh `migrate` (CI test DBs, new environments), not a snapshot of what it did in Aug 2025.
+
+**Fix**: Migration 0004 forward is now a documented no-op (its destructive reverse — deleting blog posts — became `RunPython.noop` too); the command raises `CommandError` instead of creating an author; all three seed commands are DEBUG-gated; demo author gets `set_unusable_password()`; `create_sample_blog_posts.py` and a stray git-tracked `web/backend/` duplicate were deleted. Regression tests assert each guard AND that the dangerous accounts are never created. Verified prod via `railway ssh` shell query: 1 user total, none of the suspect accounts.
+
+**Rule**: Never create accounts or set passwords in a migration or any deploy-time path. Data migrations never `call_command()` — inline with `apps.get_model()`, and no-op them once served. Seed/demo/E2E commands must raise `CommandError` when `settings.DEBUG` is False.
+**Agent**: security-reviewer

--- a/docs/rules/database.md
+++ b/docs/rules/database.md
@@ -28,3 +28,8 @@ Compact checklist auto-injected before edits. Long-form:
   `Harvest` is the reverse (`id` PK, no `uuid`). `pk` always resolves to the real
   primary key. (2026-06-02 audit: shipped twice via endpoints with no test — pair
   every aggregate rewrite with an endpoint test + `assertNumQueries`.)
+- **Data migrations must be self-contained — never `call_command()` from
+  `RunPython`.** The command's *current* code re-runs on every fresh `migrate`
+  in every future environment (CI test DBs, new prod), long after the one-time
+  intent has passed. Inline the operation with `apps.get_model()`; once a
+  one-time data migration has served its purpose, make it a documented no-op.

--- a/docs/rules/security.md
+++ b/docs/rules/security.md
@@ -17,3 +17,8 @@ Compact checklist auto-injected before edits. Long-form: `backend/docs/patterns/
   `dangerouslySetInnerHTML` with unsanitized content.
 - **Auth-sensitive code is never delegated** to the cheap worker — review by hand.
 - Redact PII (emails, tokens) from logs; GDPR redaction applies to Firebase auth.
+- **Never create user accounts in migrations or any other deploy-time path.**
+  Blog migration 0004 auto-created superuser `plant_care_admin` with a hardcoded
+  password on every `migrate` until 2026-06-10. Dev/demo/E2E seed commands must
+  refuse to run in production (`if not settings.DEBUG: raise CommandError(...)`),
+  and byline-only accounts get `set_unusable_password()` — never a literal password.

--- a/docs/rules/triggers.json
+++ b/docs/rules/triggers.json
@@ -172,5 +172,37 @@
     "source": "codify: docs/codify-session-and-todo216",
     "added": "2026-06-06",
     "severity": "warn"
+  },
+  {
+    "id": "migration-no-account-creation",
+    "domains": [
+      "database",
+      "security"
+    ],
+    "path_glob": [
+      "backend/apps/*/migrations/*.py"
+    ],
+    "content_present": "call_command|create_superuser|create_user\\(|set_password",
+    "message": "Migrations must never create accounts or call management commands — RunPython re-runs the command's CURRENT code on every fresh migrate (blog 0004 minted a hardcoded-password superuser on every deploy). Inline with apps.get_model(); no-op served one-time migrations.",
+    "pattern_ref": "docs/rules/security.md",
+    "source": "codify: fix/dev-account-creators",
+    "added": "2026-06-10",
+    "severity": "warn"
+  },
+  {
+    "id": "seed-command-debug-gate",
+    "domains": [
+      "security"
+    ],
+    "path_glob": [
+      "backend/apps/*/management/commands/*.py"
+    ],
+    "content_present": "password\\s*=\\s*[\"']",
+    "content_absent": "settings\\.DEBUG",
+    "message": "Seed/demo/E2E command with a literal password and no DEBUG gate — add `if not settings.DEBUG: raise CommandError(...)` at the top of handle(), and use set_unusable_password() for byline-only accounts.",
+    "pattern_ref": "docs/rules/security.md",
+    "source": "codify: fix/dev-account-creators",
+    "added": "2026-06-10",
+    "severity": "warn"
   }
 ]


### PR DESCRIPTION
## Summary

Codification of the lessons from PR #368 (deploy-time account creation with hardcoded passwords), per the /codify workflow:

- **docs/LEARNINGS.md** — dated incident entry: migration 0004's `RunPython → call_command()` was a standing superuser-creation path on every deploy for ~10 months, saved only by prod having zero `PlantCareGuide` rows; plus the three prod-runnable seed commands.
- **docs/rules/security.md** — never create accounts in migrations or deploy-time paths; DEBUG-gate seed/demo/E2E commands; `set_unusable_password()` for byline-only accounts.
- **docs/rules/database.md** — data migrations never `call_command()`: RunPython executes the command's *current* code on every fresh `migrate`; inline with `apps.get_model()` and no-op served one-time migrations.
- **.claude/agents/security-reviewer.md** — checklist item under Secrets & Configuration (BLOCKER).
- **docs/rules/triggers.json** — two write-time JIT triggers: `migration-no-account-creation` (account/command calls in `migrations/*.py`) and `seed-command-debug-gate` (literal password in a management command with no `settings.DEBUG` gate). Trigger index validates (34/34 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)