### PR TITLE
Harness audit fixes: forum path rot, trigger dedup + visibility, gated codify nag, audit todos

### DIFF
--- a/.claude/hooks/inject-patterns.sh
+++ b/.claude/hooks/inject-patterns.sh
@@ -47,6 +47,10 @@ add_domain() {
 [[ "$REL" == backend/apps/blog/* ]] && \
   { add_domain wagtail; add_domain api; add_domain security; }
 
+[[ "$REL" == backend/apps/forum/* || "$REL" == backend/apps/forum_host/* || \
+   "$REL" == backend/packages/wagtail_forum/* ]] && \
+  { add_domain forum; add_domain wagtail; }
+
 [[ "$REL" == */migrations/* ]] && \
   { add_domain database; add_domain security; }
 
@@ -108,8 +112,25 @@ if command -v python3 >/dev/null 2>&1; then
     | python3 "$PROJECT_ROOT/scripts/inject/match_triggers.py" 2>/dev/null) \
     || MATCH_OUT=""
 fi
+# Identical warning sets are injected once per session: the first fire stays in
+# the session context, so re-injecting on every matching edit is pure noise.
+TRIGGER_FIRED=""
 if [ -n "$MATCH_OUT" ]; then
-  printf '\n[RECENT MISTAKES — matched this edit]\n%s\n' "$MATCH_OUT" >> "$TMPFILE"
+  INJECT_TRIGGERS=1
+  if [ -n "$SESSION_ID" ]; then
+    SAFE_ID=$(printf '%s' "$SESSION_ID" | tr -c 'A-Za-z0-9._-' '_')
+    TRIG_HASH=$(printf '%s' "$MATCH_OUT" | cksum | cut -d' ' -f1)
+    TRIG_MARKER="/tmp/inject-${SAFE_ID}-trig-${TRIG_HASH}"
+    if [ -f "$TRIG_MARKER" ]; then
+      INJECT_TRIGGERS=0
+    else
+      : > "$TRIG_MARKER" 2>/dev/null || true
+    fi
+  fi
+  if [ "$INJECT_TRIGGERS" -eq 1 ]; then
+    printf '\n[RECENT MISTAKES — matched this edit]\n%s\n' "$MATCH_OUT" >> "$TMPFILE"
+    TRIGGER_FIRED=1
+  fi
 fi
 
 # (4) Domain-rule checklists, deduped once per session per domain.
@@ -146,5 +167,13 @@ if [ "$CONTEXT_SIZE" -gt "$THRESHOLD" ]; then
 fi
 
 CONTEXT=$(cat "$TMPFILE")
-jq -n --arg ctx "$CONTEXT" \
-  '{"hookSpecificOutput":{"hookEventName":"PreToolUse","additionalContext":$ctx}}'
+if [ -n "$TRIGGER_FIRED" ]; then
+  # Surface trigger fires to the user (the log alone is invisible; see
+  # scripts/inject/report_fires.py for aggregate counts).
+  SUMMARY=$(printf '%s' "$MATCH_OUT" | head -1 | cut -c1-160)
+  jq -n --arg ctx "$CONTEXT" --arg msg "Recurring-mistake trigger matched this edit: $SUMMARY" \
+    '{"hookSpecificOutput":{"hookEventName":"PreToolUse","additionalContext":$ctx},"systemMessage":$msg}'
+else
+  jq -n --arg ctx "$CONTEXT" \
+    '{"hookSpecificOutput":{"hookEventName":"PreToolUse","additionalContext":$ctx}}'
+fi

--- a/.claude/hooks/kimi-review.sh
+++ b/.claude/hooks/kimi-review.sh
@@ -47,6 +47,8 @@ while IFS= read -r file; do
   case "$file" in
     backend/apps/blog/*)
       add_pattern wagtail; add_pattern api; add_pattern security ;;
+    backend/apps/forum/*|backend/apps/forum_host/*|backend/packages/wagtail_forum/*)
+      add_pattern forum; add_pattern wagtail; add_pattern security ;;
     */migrations/*)
       add_pattern database; add_pattern security ;;
     */serializers.py)

--- a/.claude/hooks/test-inject-patterns.sh
+++ b/.claude/hooks/test-inject-patterns.sh
@@ -57,6 +57,15 @@ check "blog models → wagtail rules" \
   '{"tool_name":"Edit","tool_input":{"file_path":"backend/apps/blog/models.py"}}' \
   "RULES — wagtail"
 
+# forum (package + host app) → forum + wagtail
+check "wagtail_forum package → forum rules" \
+  '{"tool_name":"Edit","tool_input":{"file_path":"backend/packages/wagtail_forum/wagtail_forum/models/topics.py"}}' \
+  "RULES — forum"
+
+check "forum_host app → wagtail rules" \
+  '{"tool_name":"Edit","tool_input":{"file_path":"backend/apps/forum_host/settings.py"}}' \
+  "RULES — wagtail"
+
 # migrations → database + security
 check "migration → database rules" \
   '{"tool_name":"Edit","tool_input":{"file_path":"backend/apps/plant_identification/migrations/0001_initial.py"}}' \
@@ -126,6 +135,29 @@ check_empty "Read tool → no output" \
 # Missing file_path → no output
 check_empty "missing file_path → no output" \
   '{"tool_name":"Edit","tool_input":{}}'
+
+# Trigger warnings fire once per session: first matching edit emits a
+# systemMessage + RECENT MISTAKES block; an identical edit in the same session
+# is deduped. Relies on the react-router-bare-import trigger in
+# docs/rules/triggers.json; INJECT_FIRES_LOG=/dev/null keeps the real fire log
+# clean.
+TRIG_SESSION="inject-test-$$"
+TRIG_EVENT=$(jq -n --arg sid "$TRIG_SESSION" \
+  '{tool_name:"Write",session_id:$sid,tool_input:{file_path:"web/src/InjectTest.tsx",content:"import { useNavigate } from \"react-router\";\n"}}')
+rm -f "/tmp/inject-${TRIG_SESSION}-"* 2>/dev/null
+OUT1=$(printf '%s' "$TRIG_EVENT" | INJECT_FIRES_LOG=/dev/null bash "$HOOK" 2>/dev/null)
+OUT2=$(printf '%s' "$TRIG_EVENT" | INJECT_FIRES_LOG=/dev/null bash "$HOOK" 2>/dev/null)
+if echo "$OUT1" | grep -q "systemMessage" && echo "$OUT1" | grep -q "RECENT MISTAKES"; then
+  echo "PASS: trigger match → systemMessage + RECENT MISTAKES"; PASS=$((PASS + 1))
+else
+  echo "FAIL: trigger match → systemMessage + RECENT MISTAKES"; FAIL=$((FAIL + 1))
+fi
+if echo "$OUT2" | grep -q "RECENT MISTAKES"; then
+  echo "FAIL: repeat trigger in same session → deduped"; FAIL=$((FAIL + 1))
+else
+  echo "PASS: repeat trigger in same session → deduped"; PASS=$((PASS + 1))
+fi
+rm -f "/tmp/inject-${TRIG_SESSION}-"* 2>/dev/null
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -35,7 +35,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "echo '{\"systemMessage\": \"Run /codify if you discovered patterns worth preserving this session.\"}'",
+            "command": "cd \"$(git rev-parse --show-toplevel 2>/dev/null || echo '.')\" && git diff --quiet HEAD 2>/dev/null || echo '{\"systemMessage\": \"Run /codify if you discovered patterns worth preserving this session.\"}'",
             "timeout": 5
           }
         ]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ Multi-platform plant identification app. Backend (Django + Wagtail) at port 8000
 |-----------|------|
 | `backend/apps/plant_identification/` | Dual-provider plant ID API (Plant.id v3 + PlantNet) |
 | `backend/apps/blog/` | Wagtail CMS blog with AI content generation |
-| `backend/apps/forum_integration/` | Community forum — trust levels, spam detection, moderation |
+| `backend/packages/wagtail_forum/` | Community forum — reusable Wagtail-native package (host app: `apps/forum_host/`) |
 | `backend/apps/garden_calendar/` | Garden beds, plants, care tasks, harvests |
 | `backend/apps/users/` | JWT auth + Firebase token exchange |
 | `web/` | React 19 + TypeScript frontend (blog, forum, auth) |

--- a/docs/rules/forum.md
+++ b/docs/rules/forum.md
@@ -1,25 +1,17 @@
 # Forum — binding rules
 
-Compact checklist auto-injected before edits to `forum_integration/`. Long-form:
-`backend/docs/patterns/domain/forum.md`.
+Compact checklist auto-injected before edits to the forum code. Long-form:
+`backend/packages/wagtail_forum/README.md`.
 
-- **Real app is `forum_integration/`**, not `forum/`. Machina models come from
-  `machina.apps.forum.*` (third-party); our logic lives in `apps/forum_integration/`.
-- **Never hardcode trust-level thresholds** — always use `TrustLevelService.get_trust_level()`
-  or import from `apps/forum_integration/constants.py`. Hardcoded `timedelta(days=7)` etc.
-  diverge silently from the service definition.
-- **Spam keyword scoring uses `max()`, not `sum()`** — summing inflates the score
-  across categories. Use the highest category score.
-- **Detail `@action` endpoints must include the `uuid` lookup parameter** — omitting it
-  causes `CanUploadImages` and other trust-level permission classes to silently fail.
-  (Same as `get_permissions()` + `super()` rule in `docs/rules/api.md`.)
-- **`SpamDetectionService` caches internally** — do not wrap calls in your own cache.
-  Ensure Redis is running; a missing cache falls back to DB on every check.
+- **Forum code lives in three places** (django-machina and `apps/forum_integration/`
+  were fully retired, PR #362): the reusable package `backend/packages/wagtail_forum/`
+  (boards are Wagtail Pages; topics/posts are snippets; optional DRF API), the host
+  integration app `backend/apps/forum_host/`, and management commands in
+  `backend/apps/forum/management/`. The package core must import nothing
+  host-specific — use `settings.AUTH_USER_MODEL`, never a concrete user model.
 - **`ENABLE_FORUM` is evaluated at import time** — `@override_settings(ENABLE_FORUM=True)`
   cannot re-register apps mid-test. Use a subprocess with the env var set to test startup
-  paths that depend on `INSTALLED_APPS`.
-- Run `python manage.py warm_moderation_cache` post-deploy to avoid cold-start penalty on
-  the moderation dashboard.
+  paths that depend on `INSTALLED_APPS`. (It is `True` locally, `False` in CI.)
 - **Never use `or` as a numeric default where 0 is valid** — `(max_order or -1) + 1` fails
   when `max_order` is 0 because `0 or -1 == -1`. Use `(max_order if max_order is not None else -1) + 1`.
   Also, auto-assign logic in `save()` must be insert-only (`self.pk is None`), or it re-fires on UPDATE.

--- a/todos/226-pending-p2-consolidate-domain-routing-tables.md
+++ b/todos/226-pending-p2-consolidate-domain-routing-tables.md
@@ -1,0 +1,63 @@
+---
+status: pending
+priority: p2
+issue_id: "226"
+tags: [harness, hooks, maintainability]
+dependencies: []
+---
+
+# Consolidate the five hardcoded domain-routing tables into one source of truth
+
+## Problem
+
+The domain→rules/agents routing logic is duplicated in five places. Adding or
+renaming a domain requires five synchronized edits, and misses cause silent rot —
+this is exactly how the forum rules kept injecting machina-era guidance after the
+machina retirement (fixed in the 2026-06-10 harness audit, but the structural
+cause remains).
+
+## Findings
+
+- `.claude/hooks/inject-patterns.sh` (~18 independent path→domain if-blocks)
+- `.claude/hooks/kimi-review.sh` (case-statement mirror of the same mapping, lines ~47-80)
+- `.claude/skills/codify/SKILL.md` (Step 1 domain routing table)
+- `.claude/agents/code-review-orchestrator.md` (Phase 1 routing table)
+- `.claude/agents/full-review-orchestrator.md` (Phase 1 routing + hardcoded exclusions)
+- Discovery source: 2026-06-10 harness audit (Explore agent + manual verification).
+
+## Recommended Action
+
+1. Create `docs/rules/routing.json`: path-glob → `{domains: [...], agents: [...]}`
+   entries, plus a shared exclusion list (`existing_implementation/`, `docs/archive/`,
+   `**/migrations/` exclusions used by full-review-orchestrator).
+2. Add a small reader (`scripts/inject/route_domains.py` or pure-bash glob loop)
+   used by both hooks; keep the hooks' fail-open behavior (missing/unparseable
+   routing.json → exit 0 silently).
+3. Update the codify skill and both orchestrator agents to instruct reading
+   `docs/rules/routing.json` instead of carrying inline tables.
+4. Update hook tests (`test-inject-patterns.sh`, `test-kimi-review.sh`) to cover
+   the new lookup path, including the missing-file fail-open case.
+
+## Technical Details
+
+- Hooks are PreToolUse with 10s/180s timeouts — the lookup must stay cheap
+  (single jq/python3 invocation, no network).
+- `inject-patterns.sh` domains are additive (multiple matches allowed);
+  `kimi-review.sh` is first-match-wins per file. The JSON schema needs an
+  ordered list + a `mode` note, or both consumers normalize to additive.
+- Note: `.claude/hooks/*` edits are blocked by the auto-mode classifier — user
+  must disable Auto Mode for the implementation session.
+
+## Acceptance Criteria
+
+- [ ] One file defines all path→domain/agent mappings; both hooks and all three
+      markdown consumers reference it.
+- [ ] `bash .claude/hooks/test-inject-patterns.sh` and `test-kimi-review.sh` pass.
+- [ ] Adding a fake domain entry in routing.json is picked up by both hooks with
+      no other edits (manual smoke test documented in work log).
+
+## Work Log
+
+### 2026-06-10 - Created
+
+- Filed from harness audit session (finding #2 of the environment audit).

--- a/todos/227-pending-p2-posttooluse-lint-feedback-hook.md
+++ b/todos/227-pending-p2-posttooluse-lint-feedback-hook.md
@@ -1,0 +1,65 @@
+---
+status: pending
+priority: p2
+issue_id: "227"
+tags: [harness, hooks, code-quality]
+dependencies: []
+---
+
+# Add PostToolUse format/lint hook with exit-2 stderr feedback
+
+## Problem
+
+Formatting and lint errors are currently caught at commit time (kimi-review gate,
+pre-commit hooks) instead of edit time. The 2026 community-consensus pattern is a
+PostToolUse hook that formats the edited file and feeds lint errors back to Claude
+via exit code 2 + stderr, so it self-corrects on the next turn. This is the one
+consensus hook pattern missing from this harness, and it would reduce the
+"formatter reformats whole files at commit" friction (todo 117 territory).
+
+## Findings
+
+- No PostToolUse hooks exist in `.claude/settings.json` (only PreToolUse + Stop).
+- Boris Cherny's published workflow and the official hooks guide both use
+  PostToolUse auto-format with exit-2 stderr feedback
+  (<https://code.claude.com/docs/en/hooks-guide>).
+- Guidance: cheap formatters per-edit; typecheck at Stop or commit; full suite in
+  CI. Per-edit typecheck (10-30s) is explicitly discouraged.
+- Stack mapping: Python → `ruff format` + `ruff check --fix` (verify ruff is in
+  backend tooling; repo currently uses flake8 — pick whichever is configured),
+  TS/TSX → `prettier --write` + `eslint --fix`, Dart → `dart format`.
+- Discovery source: 2026-06-10 harness audit, community research phase.
+
+## Recommended Action
+
+1. Write `.claude/hooks/format-on-edit.sh`: read PreToolUse-style event JSON from
+   stdin, extract `tool_input.file_path`, dispatch by extension, run the
+   formatter; on remaining lint errors print them to stderr and exit 2 so Claude
+   sees and fixes them. Fail-open (exit 0) when the tool is missing.
+2. Register under `PostToolUse` with matcher `Edit|Write|MultiEdit`, timeout ~30s.
+3. Add `test-format-on-edit.sh` alongside the other hook tests.
+4. Confirm interaction with the kimi-review commit gate (formatted-at-edit files
+   should shrink commit-time diffs, not grow them).
+
+## Technical Details
+
+- `.claude/settings.json` hooks block; follow the existing
+  `cd "$(git rev-parse --show-toplevel ...)"` invocation pattern.
+- Only format the file from the event — never repo-wide (see
+  feedback_bulk_mechanical_edits memory; whole-file reformats caused friction,
+  todo 117).
+- `.claude/` edits require Auto Mode disabled (classifier self-mod block).
+
+## Acceptance Criteria
+
+- [ ] Editing a .py/.ts/.dart file with a formatting violation results in the file
+      being auto-formatted after the edit.
+- [ ] An unfixable lint error surfaces back to Claude (verify by observing exit-2
+      stderr in a test session).
+- [ ] Hook test script passes; missing formatter binaries cause silent skip.
+
+## Work Log
+
+### 2026-06-10 - Created
+
+- Filed from harness audit session (recommendation #4).

--- a/todos/228-pending-p2-pr-security-review-action.md
+++ b/todos/228-pending-p2-pr-security-review-action.md
@@ -1,0 +1,60 @@
+---
+status: pending
+priority: p2
+issue_id: "228"
+tags: [security, ci, github-actions, review]
+dependencies: []
+---
+
+# Add Anthropic security-review GitHub Action as unskippable PR layer
+
+## Problem
+
+The only automated code review gates are local and skippable (`SKIP_KIMI_REVIEW=1`
+bypasses the commit hook). There is no versioned, unskippable review layer at the
+PR level. Anthropic's free claude-code-security-review action fills exactly this
+gap (it caught real RCE/SSRF pre-merge at Anthropic).
+
+## Findings
+
+- Local kimi-review gate: `.claude/hooks/kimi-review.sh` — explicitly bypassable
+  by design, and project settings.local.json allowlists the bypass.
+- Repo has branch protection + required checks on main (see
+  feedback_no_direct_push_to_main memory), so a new check integrates cleanly.
+- Action: <https://github.com/anthropics/claude-code-security-review> (free OSS,
+  needs `ANTHROPIC_API_KEY` repo secret).
+- Caution from research: claude-code-action variants have pushed commits despite
+  read-intent workflows (anthropics/claude-code-action#1289) — set workflow
+  `permissions:` explicitly and minimally (`contents: read`,
+  `pull-requests: write` for comments only).
+- Discovery source: 2026-06-10 harness audit, community research phase.
+
+## Recommended Action
+
+1. Add `.github/workflows/security-review.yml` using
+   anthropics/claude-code-security-review on `pull_request`.
+2. Add `ANTHROPIC_API_KEY` as a repo secret (user action).
+3. Set minimal workflow permissions; pin the action to a SHA.
+4. Run it on one real PR; tune false-positive filtering if noisy before deciding
+   whether to make it a required check.
+
+## Technical Details
+
+- Keep it advisory (non-required) for the first 2-3 PRs, then promote to required
+  if signal/noise is acceptable — mirrors how the Cloudflare Workers check is
+  treated as non-required (project_cloudflare_workers_check memory).
+- Complements, not replaces, the kimi commit gate: kimi = fast/cheap/local,
+  action = unskippable/versioned/cross-vendor-independent.
+
+## Acceptance Criteria
+
+- [ ] Workflow runs on PRs and posts findings as comments.
+- [ ] Workflow permissions are minimal and the action is SHA-pinned.
+- [ ] Decision recorded (required vs advisory) after trial PRs, in this todo's
+      work log.
+
+## Work Log
+
+### 2026-06-10 - Created
+
+- Filed from harness audit session (recommendation #6).

--- a/todos/229-pending-p3-rationalize-reviewer-agent-fleet.md
+++ b/todos/229-pending-p3-rationalize-reviewer-agent-fleet.md
@@ -1,0 +1,66 @@
+---
+status: pending
+priority: p3
+issue_id: "229"
+tags: [harness, agents, review, maintainability]
+dependencies: ["226"]
+---
+
+# Rationalize the 17-agent reviewer fleet against bundled /code-review and /security-review
+
+## Problem
+
+The 17 project agents (2,839 lines) predate Claude Code's bundled `/code-review`
+and `/security-review`, which now provide fresh-subagent diff review with
+false-positive verification — the same architecture as the custom orchestrator.
+The generic reviewers are largely replicated by bundled tooling; maintaining them
+is cost without differentiation. There is also no documented boundary between
+`code-review-orchestrator` and `full-review-orchestrator`.
+
+## Findings
+
+- Generic reviewers with high overlap vs bundled commands: `test-quality-reviewer`,
+  `performance-reviewer`, `api-design-reviewer`, `security-reviewer` (bundled
+  `/security-review` overlaps the last).
+- Differentiated domain reviewers worth keeping: `wagtail-reviewer`,
+  `django-drf-reviewer` (project-gotcha-loaded), `flutter-dart-reviewer`,
+  `flutter-firebase-reviewer`, `firebase-cloudfunction-reviewer`,
+  `celery-async-reviewer`, `react-typescript-reviewer` (project-pattern-loaded).
+- `full-review-orchestrator.md` (562 lines) vs `code-review-orchestrator.md`
+  (186 lines): no "when to use which" doc; audit found unclear interaction with
+  the `/audit` skill as well.
+- Agent description frontmatter is always-loaded context; bodies are not.
+- Discovery source: 2026-06-10 harness audit (Explore agent report + community
+  research on fleet bloat, e.g. wshobson/agents#93).
+
+## Recommended Action
+
+1. Trial: run bundled `/code-review` on a real branch alongside
+   code-review-orchestrator; compare findings coverage for generic dimensions.
+2. Retire (git rm) generic reviewers whose findings are subsumed; fold any
+   project-specific checks they carried into the surviving domain reviewers or
+   docs/rules checklists.
+3. Add a short "when to use which" section to CLAUDE.md (Code Review Agents
+   table): orchestrator = domain review of a diff; full-review = whole-repo
+   sweep; bundled /code-review = quick generic pass.
+4. Trim agent frontmatter descriptions to one terse line each (always-loaded
+   context tax).
+
+## Technical Details
+
+- Depends loosely on todo 226 (routing consolidation) — retiring agents means
+  updating routing tables; do 226 first so it is one edit.
+- Keep kimi-review commit gate untouched; it is a different layer.
+
+## Acceptance Criteria
+
+- [ ] Side-by-side comparison documented (bundled vs custom on the same diff).
+- [ ] Each retired agent's unique checks are either codified elsewhere or
+      explicitly declared redundant in the work log.
+- [ ] CLAUDE.md documents the orchestrator/full-review/bundled boundaries.
+
+## Work Log
+
+### 2026-06-10 - Created
+
+- Filed from harness audit session (recommendation #7).

--- a/todos/230-pending-p3-harness-housekeeping-sweep.md
+++ b/todos/230-pending-p3-harness-housekeeping-sweep.md
@@ -1,0 +1,68 @@
+---
+status: pending
+priority: p3
+issue_id: "230"
+tags: [harness, docs, housekeeping, memory]
+dependencies: []
+---
+
+# Harness housekeeping: todos/ reference docs, stale pattern doc, memory pruning, CLAUDE.md trim
+
+## Problem
+
+Accumulated clutter across the harness: static reference docs mixed into the
+working todos/ directory, a stale forum pattern doc describing deleted code,
+May-era memory files whose lessons are already absorbed, and CLAUDE.md prose that
+duplicates enforcement that now lives in triggers/hooks.
+
+## Findings
+
+- `todos/` holds ~204KB of static reference docs alongside 7 working todos:
+  GITHUB_ISSUE_BEST_PRACTICES.md, GITHUB_ISSUE_CREATION_GUIDE.md,
+  GITHUB_RESEARCH_SUMMARY.md, IMPLEMENTATION_CHECKLIST.md,
+  QUICK_REFERENCE_ISSUE_CONVERSION.md, RESEARCH_SUMMARY.md.
+- `backend/docs/patterns/domain/forum.md` describes the deleted
+  forum_integration system (TrustLevelService, SpamDetectionService,
+  warm_moderation_cache — none exist in the codebase post-machina-retirement).
+  `docs/rules/forum.md` was rewritten 2026-06-10; the long-form doc was not.
+  New wagtail_forum rules should be derived from
+  `backend/packages/wagtail_forum/` (it has its own spam/ + moderation modules).
+- Memory dir (~/.claude/projects/...plant-id-community/memory/): May-era
+  feedback files + resolved project notes (~15-20K) are candidates for pruning;
+  `project_forum_app_path.md` is self-flagged stale.
+- CLAUDE.md: Critical Gotchas #1 and #3 are already enforced as triggers in
+  `docs/rules/triggers.json`; the prose can shrink to one-line pointers.
+  Kimi delegation rules appear in BOTH `~/.claude/CLAUDE.md` and project
+  CLAUDE.md — loaded twice in this repo.
+- Discovery source: 2026-06-10 harness audit.
+
+## Recommended Action
+
+1. `git mv` the six reference docs from `todos/` to `docs/archive/todos-reference/`.
+2. Rewrite `backend/docs/patterns/domain/forum.md` for the wagtail_forum package
+   (or archive it and start a new doc from the package README + code).
+3. Prune/merge stale memory files; update MEMORY.md index (delete
+   project_forum_app_path.md — superseded by repo docs fixed 2026-06-10).
+4. Trim CLAUDE.md: gotchas already trigger-enforced become pointers; dedupe the
+   delegation section against ~/.claude/CLAUDE.md (keep the project copy, slim
+   the global one to a pointer, or vice versa).
+
+## Technical Details
+
+- todos/README.md may reference the moved files — update links.
+- CLAUDE.md edits can hit the auto-mode self-mod classifier; have Auto Mode
+  disabled for that step.
+
+## Acceptance Criteria
+
+- [ ] todos/ contains only TEMPLATE.md, README.md, archive/, and live todo files.
+- [ ] Forum pattern doc matches code that actually exists.
+- [ ] MEMORY.md index has no entries flagged stale.
+- [ ] No instruction text is loaded twice (global + project CLAUDE.md overlap
+      resolved).
+
+## Work Log
+
+### 2026-06-10 - Created
+
+- Filed from harness audit session (recommendation #8).


### PR DESCRIPTION
## Summary

Fixes from the 2026-06-10 Claude Code environment audit (items 1, 3, 5 of the recommendation list; items 2/4/6/7/8 are filed as todos 226-230).

### Forum path rot (machina retirement follow-up)
- `docs/rules/forum.md` rewritten for the wagtail_forum world: drops rules referencing deleted code (TrustLevelService, SpamDetectionService, `warm_moderation_cache`, machina imports), keeps the four verified-still-valid rules, points long-form at the package README.
- `CLAUDE.md` project-structure table: `apps/forum_integration/` → `packages/wagtail_forum/` + `apps/forum_host/`.
- Both PreToolUse hooks now route `backend/apps/forum/`, `apps/forum_host/`, and `packages/wagtail_forum/` edits to the forum + wagtail checklists — forum edits previously got **no** forum rules.

### Trigger system: dedup + visibility
- Identical trigger-warning sets inject once per session (cksum marker, mirroring the existing domain-rule dedup).
- A trigger fire now emits a `systemMessage` so hits are visible without reading the fire log.

### Stop hook
- `/codify` reminder only fires when the working tree is dirty.

### Audit todos filed
- 226 (p2): consolidate the 5 duplicated domain-routing tables
- 227 (p2): PostToolUse format/lint feedback hook
- 228 (p2): PR-level security-review GitHub Action
- 229 (p3): rationalize the 17-agent reviewer fleet vs bundled /code-review
- 230 (p3): housekeeping sweep (todos/ ref docs, stale forum pattern doc, memory pruning, CLAUDE.md trim)

## Test plan
- [x] `test-inject-patterns.sh`: 20/20 (4 new tests: forum routing ×2, trigger fire visibility, same-session dedup)
- [x] `test-kimi-review.sh`: 20/20
- [x] `test-guard-worktree-isolation.sh`: 10/10
- [x] Manual smoke: wagtail_forum path → `[RULES — forum]` + `[RULES — wagtail]`; trigger fires once with systemMessage, dedups on repeat

🤖 Generated with [Claude Code](https://claude.com/claude-code)