### PR TITLE
Stop the three commit gates (markdownlint, detect-secrets, flake8 F401) aborting commits

### DIFF
--- a/.claude/hooks/format-on-edit.sh
+++ b/.claude/hooks/format-on-edit.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# PostToolUse hook — auto-remove unused Python imports (flake8 F401) right after
+# an Edit/Write/MultiEdit, so they never reach the commit gate and abort it.
+#
+# Implements the Python branch of todo 227. Uses `ruff check --select F401 --fix`
+# as an F401 FIXER ONLY — NOT a formatter (black + isort own formatting, todo 087).
+# Single-file only, never repo-wide. Fail-open: any missing tool → exit 0.
+#
+# Residual F401 that ruff cannot auto-fix are printed to stderr with exit 2 so
+# Claude sees the feedback and self-corrects (the edit itself already landed —
+# exit 2 in PostToolUse is advisory, it does not undo the edit).
+#
+# Skips the files whose F401 is intentional (re-exports / import-smoke-test),
+# mirroring setup.cfg [flake8] per-file-ignores — keep the two lists in sync.
+# Tests: .claude/hooks/test-format-on-edit.sh
+set -uo pipefail
+
+# (1) Kill switch: instant disable with no commit (mirrors INJECT_PATTERNS_DISABLE).
+[[ -n "${FORMAT_ON_EDIT_DISABLE:-}" ]] && exit 0
+
+command -v jq >/dev/null 2>&1 || exit 0
+
+INPUT=$(cat)
+TOOL_NAME=$(printf '%s' "$INPUT" | jq -re '.tool_name' 2>/dev/null) || exit 0
+FILE_PATH=$(printf '%s' "$INPUT" | jq -re '.tool_input.file_path' 2>/dev/null) || exit 0
+
+[[ "$TOOL_NAME" == "Edit" || "$TOOL_NAME" == "Write" || "$TOOL_NAME" == "MultiEdit" ]] || exit 0
+
+# Resolve paths relative to project root (two levels up from .claude/hooks/).
+# FORMAT_ON_EDIT_ROOT overrides it for tests (mirrors match_triggers' INJECT_PROJECT_ROOT).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="${FORMAT_ON_EDIT_ROOT:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
+
+# Repo-relative path (for backend/ scope + skip-list) and absolute path (for ruff).
+REL="${FILE_PATH#"$PROJECT_ROOT"/}"
+case "$FILE_PATH" in
+  /*) ABS="$FILE_PATH" ;;
+  *)  ABS="$PROJECT_ROOT/$FILE_PATH" ;;
+esac
+
+# Only backend Python files (the flake8 gate scopes to ^backend/.*\.py$).
+[[ "$REL" == backend/*.py ]] || exit 0
+[ -f "$ABS" ] || exit 0
+
+# Skip files with intentional unused imports — mirrors setup.cfg per-file-ignores
+# (F401). Removing these would break re-exports / the import-smoke-test.
+case "$REL" in
+  backend/plant_community_backend/settings.py| \
+  backend/apps/blog/api/viewsets.py| \
+  backend/apps/blog/tests/test_analytics.py| \
+  backend/apps/plant_identification/models.py| \
+  backend/apps/plant_identification/views.py| \
+  backend/apps/users/views.py| \
+  backend/test_django_imports.py)
+    exit 0 ;;
+esac
+
+# Resolve ruff: prefer the backend venv, fall back to PATH. Absent → fail-open.
+# FORMAT_ON_EDIT_RUFF is a test seam — when set it is authoritative (the test
+# points it at a nonexistent path to exercise the fail-open branch).
+if [ -n "${FORMAT_ON_EDIT_RUFF:-}" ]; then
+  RUFF="$FORMAT_ON_EDIT_RUFF"
+else
+  RUFF="$PROJECT_ROOT/backend/venv/bin/ruff"
+  [ -x "$RUFF" ] || RUFF="$(command -v ruff 2>/dev/null || true)"
+fi
+[ -x "$RUFF" ] || exit 0
+
+# Auto-fix unused imports in this one file (F401 only; no formatting, no reorder).
+# --isolated ignores ambient ruff config so behavior is exactly "remove unused
+# imports, nothing else" regardless of any future ruff.toml.
+"$RUFF" check --isolated --select F401 --fix --quiet "$ABS" >/dev/null 2>&1 || true
+
+# Report any F401 ruff could not auto-fix so Claude can resolve them before commit.
+RESIDUAL=$("$RUFF" check --isolated --select F401 --output-format concise "$ABS" 2>/dev/null) || RESIDUAL=""
+if [ -n "$RESIDUAL" ]; then
+  printf 'Unused imports remain in %s (flake8 F401 will block the commit):\n%s\n' "$REL" "$RESIDUAL" >&2
+  exit 2
+fi
+exit 0

--- a/.claude/hooks/format-on-edit.sh
+++ b/.claude/hooks/format-on-edit.sh
@@ -72,7 +72,11 @@ fi
 "$RUFF" check --isolated --select F401 --fix --quiet "$ABS" >/dev/null 2>&1 || true
 
 # Report any F401 ruff could not auto-fix so Claude can resolve them before commit.
-RESIDUAL=$("$RUFF" check --isolated --select F401 --output-format concise "$ABS" 2>/dev/null) || RESIDUAL=""
+# --quiet prints diagnostics only — without it ruff emits "All checks passed!" to
+# stdout on success, a false residual. No `|| RESIDUAL=""`: ruff exits non-zero
+# *because* it found diagnostics, so swallowing that would clear the very residual
+# we want. With no `set -e`, the failed substitution does not end the script.
+RESIDUAL=$("$RUFF" check --isolated --select F401 --quiet --output-format concise "$ABS" 2>/dev/null)
 if [ -n "$RESIDUAL" ]; then
   printf 'Unused imports remain in %s (flake8 F401 will block the commit):\n%s\n' "$REL" "$RESIDUAL" >&2
   exit 2

--- a/.claude/hooks/test-format-on-edit.sh
+++ b/.claude/hooks/test-format-on-edit.sh
@@ -6,11 +6,14 @@ set -uo pipefail
 
 HOOK="$(cd "$(dirname "$0")" && pwd)/format-on-edit.sh"
 REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+# Resolve ruff the way the hook does: backend venv first, then PATH (CI installs it
+# on PATH; local dev has it in the venv).
 REAL_RUFF="$REPO_ROOT/backend/venv/bin/ruff"
+[ -x "$REAL_RUFF" ] || REAL_RUFF="$(command -v ruff 2>/dev/null || true)"
 PASS=0; FAIL=0
 
 # The hook fail-opens without ruff, so there is nothing to assert if it is absent.
-[ -x "$REAL_RUFF" ] || { echo "SKIP: ruff not installed at $REAL_RUFF (run: backend/venv/bin/pip install -r backend/requirements.txt)"; exit 0; }
+[ -x "$REAL_RUFF" ] || { echo "SKIP: ruff not installed (pip install ruff, or backend/venv/bin/pip install -r backend/requirements.txt)"; exit 0; }
 
 # Throwaway fake repo root (FORMAT_ON_EDIT_ROOT) so no real file is touched, and
 # the ruff test seam (FORMAT_ON_EDIT_RUFF) so resolution is deterministic.

--- a/.claude/hooks/test-format-on-edit.sh
+++ b/.claude/hooks/test-format-on-edit.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Tests for format-on-edit.sh — run from anywhere.
+# Builds a throwaway fake repo root (FORMAT_ON_EDIT_ROOT) so no real file is
+# ever touched. Requires ruff (backend/venv/bin/ruff) and jq on the system.
+set -uo pipefail
+
+HOOK="$(cd "$(dirname "$0")" && pwd)/format-on-edit.sh"
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+REAL_RUFF="$REPO_ROOT/backend/venv/bin/ruff"
+PASS=0; FAIL=0
+
+# The hook fail-opens without ruff, so there is nothing to assert if it is absent.
+[ -x "$REAL_RUFF" ] || { echo "SKIP: ruff not installed at $REAL_RUFF (run: backend/venv/bin/pip install -r backend/requirements.txt)"; exit 0; }
+
+# Throwaway fake repo root (FORMAT_ON_EDIT_ROOT) so no real file is touched, and
+# the ruff test seam (FORMAT_ON_EDIT_RUFF) so resolution is deterministic.
+ROOT="$(mktemp -d)"
+export FORMAT_ON_EDIT_RUFF="$REAL_RUFF"
+trap 'chmod -R u+w "$ROOT" 2>/dev/null; rm -rf "$ROOT"' EXIT
+
+mkfixture() { # path-under-root, content
+  local p="$ROOT/$1"; mkdir -p "$(dirname "$p")"; printf '%b' "$2" > "$p"
+}
+run() { # file_path (repo-relative), tool_name → runs hook, sets RC/ERR
+  local fp="$1" tool="${2:-Edit}"
+  ERR=$(printf '{"tool_name":"%s","tool_input":{"file_path":"%s"}}' "$tool" "$fp" \
+        | FORMAT_ON_EDIT_ROOT="$ROOT" bash "$HOOK" 2>&1 >/dev/null); RC=$?
+}
+ok()   { echo "PASS: $1"; PASS=$((PASS+1)); }
+no()   { echo "FAIL: $1"; echo "  $2"; FAIL=$((FAIL+1)); }
+
+# 1. Core: unused import in a normal backend file is auto-removed.
+mkfixture backend/apps/scratch.py 'import os\nimport sys\n\nprint(sys.version)\n'
+run backend/apps/scratch.py
+if ! grep -q '^import os$' "$ROOT/backend/apps/scratch.py" && grep -q 'import sys' "$ROOT/backend/apps/scratch.py"; then
+  ok "removes unused import, keeps used one"
+else
+  no "removes unused import, keeps used one" "file still: $(tr '\n' ' ' < "$ROOT/backend/apps/scratch.py")"
+fi
+
+# 2. Skip-list: a per-file-ignore path is left untouched (intentional re-exports).
+mkfixture backend/apps/plant_identification/models.py 'import os\n'
+run backend/apps/plant_identification/models.py
+if grep -q '^import os$' "$ROOT/backend/apps/plant_identification/models.py" && [ "$RC" -eq 0 ]; then
+  ok "skip-list file untouched"
+else
+  no "skip-list file untouched" "rc=$RC content=$(cat "$ROOT/backend/apps/plant_identification/models.py")"
+fi
+
+# 3. Non-.py file is ignored.
+mkfixture backend/notes.txt 'import os\n'
+run backend/notes.txt
+[ "$RC" -eq 0 ] && grep -q 'import os' "$ROOT/backend/notes.txt" && ok "non-.py ignored" || no "non-.py ignored" "rc=$RC"
+
+# 4. Non-backend .py is ignored (gate scopes to backend/).
+mkfixture web/scripts/foo.py 'import os\n'
+run web/scripts/foo.py
+[ "$RC" -eq 0 ] && grep -q 'import os' "$ROOT/web/scripts/foo.py" && ok "non-backend .py ignored" || no "non-backend .py ignored" "rc=$RC"
+
+# 5. Missing file_path (e.g. Read-style event) → no-op, exit 0.
+ERR=$(printf '{"tool_name":"Edit","tool_input":{}}' | FORMAT_ON_EDIT_ROOT="$ROOT" bash "$HOOK" 2>&1 >/dev/null); RC=$?
+[ "$RC" -eq 0 ] && ok "missing file_path → exit 0" || no "missing file_path → exit 0" "rc=$RC"
+
+# 6. Fail-open: ruff absent (seam points at a nonexistent path) → exit 0, untouched.
+mkfixture backend/apps/failopen.py 'import os\n'
+ERR=$(printf '{"tool_name":"Edit","tool_input":{"file_path":"backend/apps/failopen.py"}}' \
+      | FORMAT_ON_EDIT_RUFF="$ROOT/no-such-ruff" FORMAT_ON_EDIT_ROOT="$ROOT" bash "$HOOK" 2>&1 >/dev/null); RC=$?
+[ "$RC" -eq 0 ] && grep -q 'import os' "$ROOT/backend/apps/failopen.py" && ok "ruff missing → fail-open exit 0" || no "ruff missing → fail-open exit 0" "rc=$RC"
+
+# 7. Residual F401 (read-only DIR blocks ruff's atomic-rename fix; report still
+#    works) → exit 2 + stderr. A read-only file alone fails: ruff rewrites via the
+#    parent dir, so the dir must be unwritable.
+mkdir -p "$ROOT/backend/apps/ro"
+mkfixture backend/apps/ro/locked.py 'import os\n'
+chmod 555 "$ROOT/backend/apps/ro"
+run backend/apps/ro/locked.py
+chmod u+w "$ROOT/backend/apps/ro"
+if [ "$RC" -eq 2 ] && printf '%s' "$ERR" | grep -qi 'F401\|unused'; then
+  ok "unfixable F401 → exit 2 with feedback"
+else
+  no "unfixable F401 → exit 2 with feedback" "rc=$RC err=$ERR"
+fi
+
+echo "----"
+echo "PASS=$PASS FAIL=$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/.claude/hooks/test-format-on-edit.sh
+++ b/.claude/hooks/test-format-on-edit.sh
@@ -29,13 +29,15 @@ run() { # file_path (repo-relative), tool_name → runs hook, sets RC/ERR
 ok()   { echo "PASS: $1"; PASS=$((PASS+1)); }
 no()   { echo "FAIL: $1"; echo "  $2"; FAIL=$((FAIL+1)); }
 
-# 1. Core: unused import in a normal backend file is auto-removed.
+# 1. Core: unused import is auto-removed, used one kept, and a CLEAN fix exits 0
+#    (RC=0 guards against ruff's "All checks passed!" being read as a residual).
 mkfixture backend/apps/scratch.py 'import os\nimport sys\n\nprint(sys.version)\n'
 run backend/apps/scratch.py
-if ! grep -q '^import os$' "$ROOT/backend/apps/scratch.py" && grep -q 'import sys' "$ROOT/backend/apps/scratch.py"; then
-  ok "removes unused import, keeps used one"
+if ! grep -q '^import os$' "$ROOT/backend/apps/scratch.py" \
+   && grep -q 'import sys' "$ROOT/backend/apps/scratch.py" && [ "$RC" -eq 0 ]; then
+  ok "removes unused import, keeps used one, exits 0"
 else
-  no "removes unused import, keeps used one" "file still: $(tr '\n' ' ' < "$ROOT/backend/apps/scratch.py")"
+  no "removes unused import, keeps used one, exits 0" "rc=$RC file: $(tr '\n' ' ' < "$ROOT/backend/apps/scratch.py")"
 fi
 
 # 2. Skip-list: a per-file-ignore path is left untouched (intentional re-exports).
@@ -67,14 +69,16 @@ ERR=$(printf '{"tool_name":"Edit","tool_input":{"file_path":"backend/apps/failop
       | FORMAT_ON_EDIT_RUFF="$ROOT/no-such-ruff" FORMAT_ON_EDIT_ROOT="$ROOT" bash "$HOOK" 2>&1 >/dev/null); RC=$?
 [ "$RC" -eq 0 ] && grep -q 'import os' "$ROOT/backend/apps/failopen.py" && ok "ruff missing → fail-open exit 0" || no "ruff missing → fail-open exit 0" "rc=$RC"
 
-# 7. Residual F401 (read-only DIR blocks ruff's atomic-rename fix; report still
-#    works) → exit 2 + stderr. A read-only file alone fails: ruff rewrites via the
-#    parent dir, so the dir must be unwritable.
-mkdir -p "$ROOT/backend/apps/ro"
-mkfixture backend/apps/ro/locked.py 'import os\n'
-chmod 555 "$ROOT/backend/apps/ro"
-run backend/apps/ro/locked.py
-chmod u+w "$ROOT/backend/apps/ro"
+# 7. Residual F401 that ruff cannot auto-fix → exit 2 + stderr feedback.
+#    The hook's contract is "if ruff still REPORTS F401 after the --fix pass, exit
+#    2" — test that control flow with a stub ruff (real ruff's fix heuristics are
+#    ruff's concern, not the hook's), which is deterministic.
+STUB="$ROOT/fake-ruff"
+{ echo '#!/usr/bin/env bash'; echo 'echo "residual.py:1:8: F401 os imported but unused"'; echo 'exit 1'; } > "$STUB"
+chmod +x "$STUB"
+mkfixture backend/apps/residual.py 'import os\n'
+ERR=$(printf '{"tool_name":"Edit","tool_input":{"file_path":"backend/apps/residual.py"}}' \
+      | FORMAT_ON_EDIT_RUFF="$STUB" FORMAT_ON_EDIT_ROOT="$ROOT" bash "$HOOK" 2>&1 >/dev/null); RC=$?
 if [ "$RC" -eq 2 ] && printf '%s' "$ERR" | grep -qi 'F401\|unused'; then
   ok "unfixable F401 → exit 2 with feedback"
 else

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -30,6 +30,19 @@
         ]
       }
     ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cd \"$(git rev-parse --show-toplevel 2>/dev/null || echo '.')\" && bash .claude/hooks/format-on-edit.sh",
+            "timeout": 30,
+            "statusMessage": "Auto-fixing unused imports..."
+          }
+        ]
+      }
+    ],
     "Stop": [
       {
         "hooks": [

--- a/.github/workflows/harness-ci.yml
+++ b/.github/workflows/harness-ci.yml
@@ -43,9 +43,11 @@ jobs:
 
       - name: Hook self-tests
         run: |
+          pip install ruff==0.15.17  # for test-format-on-edit.sh (matches backend/requirements.txt)
           bash .claude/hooks/test-inject-patterns.sh
           bash .claude/hooks/test-kimi-review.sh
           bash .claude/hooks/test-guard-worktree-isolation.sh
+          bash .claude/hooks/test-format-on-edit.sh
 
       - name: Python inject tests
         run: |

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,4 +1,6 @@
 {
   "MD013": false,
-  "MD036": false
+  "MD036": false,
+  "MD040": false,
+  "MD033": { "allowed_elements": ["details", "summary", "br", "img", "sub", "sup", "kbd", "div", "a", "table", "thead", "tbody", "tr", "th", "td"] }
 }

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -179,6 +179,7 @@ rpds-py==0.28.0
 rsa==4.9.1
 ruamel.yaml==0.18.16
 ruamel.yaml.clib==0.2.14
+ruff==0.15.17  # F401 auto-fix at edit time (.claude/hooks/format-on-edit.sh); NOT a formatter — black+isort own formatting
 safety==3.6.2
 safety-schemas==0.0.16
 sentry-sdk==2.59.0

--- a/docs/PRE_COMMIT_SETUP.md
+++ b/docs/PRE_COMMIT_SETUP.md
@@ -242,9 +242,18 @@ pip install detect-secrets
 # Verify installation
 detect-secrets --version
 
-# Regenerate baseline
-detect-secrets scan > .secrets.baseline
+# Refresh the baseline (preserves audit decisions; clears line-number churn)
+bash scripts/refresh-secrets-baseline.sh
+
+# Equivalent manual form — note `--baseline`, NOT `scan > .secrets.baseline`.
+# The redirect form WIPES every audit decision and re-introduces churn; only
+# use it for the very first baseline when none exists yet.
+#   detect-secrets scan --baseline .secrets.baseline
 ```
+
+> If a test **placeholder** secret keeps getting re-flagged after lines shift,
+> add a trailing `# pragma: allowlist secret` on that line — it is ignored
+> regardless of line number, so it never re-enters the baseline.
 
 ### Issue: Hooks too slow
 

--- a/docs/rules/triggers.json
+++ b/docs/rules/triggers.json
@@ -220,5 +220,19 @@
     "source": "codify: chore/forum-audit-2026-06-10",
     "added": "2026-06-10",
     "severity": "warn"
+  },
+  {
+    "id": "secrets-baseline-manual-edit",
+    "domains": [
+      "security"
+    ],
+    "path_glob": [
+      ".secrets.baseline"
+    ],
+    "message": "Editing .secrets.baseline by hand churns line numbers and drops audit decisions. If a test PLACEHOLDER is re-flagged, add `# pragma: allowlist secret` on that line instead — it survives line shifts. To refresh the baseline safely, run scripts/refresh-secrets-baseline.sh (uses `scan --baseline`, not `scan >`).",
+    "pattern_ref": "docs/PRE_COMMIT_SETUP.md",
+    "source": "pre-commit friction reduction 2026-06-13",
+    "added": "2026-06-13",
+    "severity": "warn"
   }
 ]

--- a/scripts/refresh-secrets-baseline.sh
+++ b/scripts/refresh-secrets-baseline.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Refresh .secrets.baseline line numbers WITHOUT discarding audit decisions.
+#
+# Run this when the detect-secrets pre-commit hook re-flags an already-known
+# placeholder secret after its line number shifted (baseline "churn").
+#
+# Uses `detect-secrets scan --baseline FILE`, which updates the existing
+# baseline in place and PRESERVES the `is_secret` / `is_verified` audit
+# decisions. Do NOT use `detect-secrets scan > .secrets.baseline` — the
+# redirect form wipes every audit decision and re-introduces the churn.
+#
+# The --exclude-files set below mirrors .pre-commit-config.yaml so the
+# refreshed baseline matches exactly what the commit gate scans.
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+
+DS="backend/venv/bin/detect-secrets"
+[ -x "$DS" ] || DS="$(command -v detect-secrets || true)"
+if [ -z "$DS" ]; then
+  echo "detect-secrets not found. Install it: backend/venv/bin/pip install detect-secrets" >&2
+  exit 1
+fi
+
+echo "Refreshing .secrets.baseline (in place, preserving audit decisions)..."
+"$DS" scan --baseline .secrets.baseline \
+  --exclude-files '\.env\.example$' \
+  --exclude-files 'package-lock\.json$' \
+  --exclude-files 'yarn\.lock$'
+
+echo "Done. Review the diff, then stage it:"
+echo "  git diff .secrets.baseline"
+echo "  git add .secrets.baseline"
+echo
+echo "Tip: to stop a test PLACEHOLDER from churning again, add a trailing"
+echo "     '# pragma: allowlist secret' on that line — it survives line shifts."


### PR DESCRIPTION
## Why

A plant_id_community-scoped review of the last ~3 weeks found commit-time tooling friction was the single biggest source of lost time in this repo — pre-commit gates silently aborting `git commit`. Three gates accounted for nearly all of it. This PR moves each from "block at commit" to "fixed/prevented automatically."

## What changed, per gate

**1. markdownlint MD040 / MD033** (style rules `--fix` can't repair) — relaxed in `.markdownlint.json`: MD040 (fence language) off; MD033 (inline HTML) scoped to the tags the docs already use (`details`, `summary`, `br`, `img`, `kbd`, …). One config edit, no machinery.

**2. detect-secrets baseline churn** (placeholders re-flagged when line numbers shift) —
- `scripts/refresh-secrets-baseline.sh`: safe in-place `scan --baseline` that **preserves audit decisions** (the destructive `scan >` form wiped them).
- A write-time trigger (`docs/rules/triggers.json`) warning when `.secrets.baseline` is hand-edited.
- Fixed `docs/PRE_COMMIT_SETUP.md`, which taught the destructive idiom; documented `# pragma: allowlist secret` recovery.

**3. flake8 F401 unused imports** (nothing auto-removed them) — an **edit-time** `PostToolUse` hook (`.claude/hooks/format-on-edit.sh`) runs `ruff check --select F401 --fix` on just the edited backend `.py`, so imports are gone before the commit gate sees them. Implements the Python branch of **todo 227**.
- Skips the 7 `setup.cfg` per-file-ignore paths (intentional re-exports).
- Fails open if ruff is absent; surfaces unfixable F401 via exit-2 stderr.
- `ruff==0.15.17` pinned in `backend/requirements.txt` (F401 fixer only — black+isort still own formatting).

## Verification

- markdownlint now **passes** a doc with a bare code fence + `<details>` that previously failed MD040+MD033.
- detect-secrets trigger fires; all 34 existing trigger tests still pass.
- `.claude/hooks/test-format-on-edit.sh` — **7/7** (fix works + exits 0, re-export files untouched, scope checks, fail-open, residual→exit-2).
- **Live dogfood**: a real `Write` to a backend `.py` stripped the unused import and exited clean.

Live dogfooding also caught a real bug pre-merge: the hook's residual check was inverted (`ruff check` prints `All checks passed!` on success but exits non-zero on findings, so `RESIDUAL=$(...) || RESIDUAL=""` cleared the residual exactly when there was one). Fixed with `--quiet` + dropping the `||`; added the exit-0-on-clean assertion that the original test was missing.

## Notes
- Hook registration required Auto Mode disabled (harness self-mod classifier) — done.
- todo 227 stays open: its broader TS/Dart formatter branches are left as stubs for a later pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)