### PR TITLE
Follow-up todos from PR #372 self-review (232, 233)

### DIFF
--- a/todos/232-pending-p3-format-hook-skiplist-sync-test.md
+++ b/todos/232-pending-p3-format-hook-skiplist-sync-test.md
@@ -1,0 +1,74 @@
+---
+status: pending
+priority: p3
+issue_id: "232"
+tags: [harness, hooks, ruff, testing]
+dependencies: []
+---
+
+# Enforce that the format-on-edit skip-list matches setup.cfg F401 ignores
+
+## Problem
+
+The PostToolUse hook `.claude/hooks/format-on-edit.sh` (PR #372) hardcodes a
+skip-list of 7 backend files whose unused imports are intentional (re-exports /
+import-smoke-test), mirroring `setup.cfg [flake8] per-file-ignores`. Nothing
+enforces that the two lists stay in sync. The dangerous direction: if someone
+adds a **new** intentional-re-export file to `setup.cfg` (F401) but not to the
+hook, the hook will strip imports the author meant to keep — silently breaking a
+re-export, with no test to catch it.
+
+## Findings
+
+- `.claude/hooks/format-on-edit.sh` — `case "$REL" in … exit 0 ;; esac` lists the
+  7 skip paths; a comment says "keep the two lists in sync" but there is no check.
+- `setup.cfg` — `[flake8] per-file-ignores` is the source of truth for which files
+  carry intentional F401. As of PR #372 these are: `apps/blog/api/viewsets.py`,
+  `apps/blog/tests/test_analytics.py`, `apps/plant_identification/models.py`,
+  `apps/plant_identification/views.py`, `apps/users/views.py`,
+  `test_django_imports.py` (+ `plant_community_backend/settings.py`, which the hook
+  also skips for its non-standard import order).
+- `.claude/hooks/test-format-on-edit.sh` asserts a skip-list path is left
+  untouched, but only for one hardcoded path — it does not detect a setup.cfg
+  entry that is missing from the hook.
+- Discovery source: self-review of PR #372 (2026-06-14), issue #1.
+
+## Recommended Action
+
+1. Add a check (in `test-format-on-edit.sh` or a small `scripts/` helper) that
+   parses the `F401` entries from `setup.cfg [flake8] per-file-ignores` and asserts
+   the set equals the hook's skip-list (the hook may legitimately include extras
+   like `settings.py` — assert setup.cfg's F401 set is a **subset** of the hook
+   skip-list, so a new ignore that isn't mirrored fails CI).
+2. Wire it into the `Hook self-tests` step of `.github/workflows/harness-ci.yml`
+   (already runs `test-format-on-edit.sh`).
+3. Consider extracting the skip-list to a single shared source (e.g. a generated
+   list) so the hook reads it rather than duplicating — only if step 1 proves too
+   brittle; a subset-assertion test is the lighter fix.
+
+## Technical Details
+
+- Parsing `setup.cfg`: the `per-file-ignores` block is multi-line `path: CODES`;
+  select lines whose CODES contain `F401`.
+- The hook's skip-list is a bash `case` — simplest to compare is to have the test
+  source the same path list from a single place, or to grep both and diff the sets.
+
+## Acceptance Criteria
+
+- [ ] A test fails when a file with an `F401` per-file-ignore in `setup.cfg` is not
+      present in the hook's skip-list.
+- [ ] The test runs in `harness-ci.yml` and passes on the current (in-sync) state.
+
+## Work Log
+
+### 2026-06-14 - Filed
+
+- Created from self-review of PR #372 (issue #1). Skip-list ↔ setup.cfg sync is
+  currently maintained only by a comment.
+
+## Notes
+
+- p3: latent footgun, not an active defect — the lists are in sync today. Becomes
+  relevant the next time someone adds an intentional re-export module.
+- Related: PR #372; `.claude/hooks/format-on-edit.sh`; todo 227 (broader edit-time
+  lint hook).

--- a/todos/233-pending-p2-verify-detect-secrets-refresh-helper.md
+++ b/todos/233-pending-p2-verify-detect-secrets-refresh-helper.md
@@ -1,0 +1,80 @@
+---
+status: pending
+priority: p2
+issue_id: "233"
+tags: [detect-secrets, pre-commit, harness, verification]
+dependencies: []
+---
+
+# Verify the detect-secrets refresh helper end-to-end and resolve the gate version skew
+
+## Problem
+
+PR #372 added `scripts/refresh-secrets-baseline.sh` to clear detect-secrets
+baseline churn, but the helper was only syntax-checked (`bash -n`) — it was never
+run against a real churn case. Compounding this, the commit gate pins
+detect-secrets **v1.4.0** (`.pre-commit-config.yaml`) while `backend/venv` has
+**v1.5.0**, so the helper regenerates the baseline with a different version than
+the gate validates it with. If the baseline formats diverge, a "refreshed"
+baseline could fail the very gate it was meant to satisfy.
+
+## Findings
+
+- `scripts/refresh-secrets-baseline.sh` (added in PR #372, commit `e989192`) uses
+  `detect-secrets scan --baseline .secrets.baseline` (correct in-place idiom per
+  docs) but has no end-to-end test; the `## Verification` step "V3" in the source
+  plan was never executed (no churn case was reproduced).
+- `.pre-commit-config.yaml:17` pins `rev: v1.4.0`; `backend/venv/bin/detect-secrets
+  --version` reports `1.5.0`. The `scripts/inject` / harness CI does not exercise
+  this path.
+- The write-time trigger `secrets-baseline-manual-edit` (in `docs/rules/triggers.json`)
+  and the doc fix in `docs/PRE_COMMIT_SETUP.md` *were* verified; only the helper +
+  version skew remain unverified.
+- Discovery source: self-review of PR #372 (2026-06-14), issue #2.
+
+## Recommended Action
+
+1. Reproduce a churn case: shift a placeholder-secret line in a tracked test file
+   so its line number changes, and confirm `pre-commit run detect-secrets
+   --all-files` re-flags it.
+2. Run `bash scripts/refresh-secrets-baseline.sh`; confirm `git diff
+   .secrets.baseline` shows only line-number deltas and that `is_secret` /
+   `is_verified` audit fields are preserved (not reset to `null`).
+3. Re-run `pre-commit run detect-secrets --all-files` and confirm it passes —
+   this is the cross-version (1.5.0-written → 1.4.0-validated) compatibility check.
+4. If step 3 fails on a format mismatch, **bump the gate** `rev:` in
+   `.pre-commit-config.yaml` from `v1.4.0` → `v1.5.0` (single line) so the helper
+   and gate agree, then re-run. (Recommended even if step 3 passes, to remove the
+   skew as a latent risk.)
+5. Confirm `# pragma: allowlist secret` on a shifted placeholder keeps the gate
+   green with no baseline diff.
+
+## Technical Details
+
+- `scripts/refresh-secrets-baseline.sh` — the `--exclude-files` set mirrors
+  `.pre-commit-config.yaml` lines 24–29; keep them in sync if the gate's excludes
+  change.
+- `.pre-commit-config.yaml:16–36` — detect-secrets hook block.
+- `docs/PRE_COMMIT_SETUP.md` — recovery docs updated in PR #372.
+
+## Acceptance Criteria
+
+- [ ] The helper has been run once against a reproduced churn case, with the
+      resulting baseline passing `pre-commit run detect-secrets --all-files`.
+- [ ] Audit decisions (`is_secret`/`is_verified`) are confirmed preserved across a
+      refresh (not wiped).
+- [ ] The v1.4.0 (gate) vs v1.5.0 (venv) skew is resolved — either proven
+      compatible in step 3 or removed by bumping the gate `rev:`.
+
+## Work Log
+
+### 2026-06-14 - Filed
+
+- Created from self-review of PR #372 (issue #2). Helper shipped but unverified;
+  version skew deferred from the source plan.
+
+## Notes
+
+- p2 because a broken refresh path silently re-introduces the churn this PR set
+  out to fix, and the version skew is a real (if low-probability) correctness risk.
+- Related: PR #372; `secrets-baseline-manual-edit` trigger in `docs/rules/triggers.json`.

--- a/todos/234-pending-p2-flaky-web-vitest-unhandled-rejection.md
+++ b/todos/234-pending-p2-flaky-web-vitest-unhandled-rejection.md
@@ -1,0 +1,80 @@
+---
+status: pending
+priority: p2
+issue_id: "234"
+tags: [web, testing, vitest, ci, flaky]
+dependencies: []
+---
+
+# Flaky Web CI: an unhandled async rejection fails Vitest despite all tests passing
+
+## Problem
+
+The "Web CI → Type-check, lint, and unit/component tests (Vitest)" job fails
+intermittently with **all test files passing** but **1 unhandled error**, which
+makes the runner exit 1. Because it is non-deterministic and unrelated to the
+diff under test, it blocks unrelated PRs until the job is re-run by hand —
+a recurring tax on every merge.
+
+## Findings
+
+- Observed on run `27482300767` (PR #372, a docs/config-only change with **zero**
+  `web/` files): Vitest summary `Test Files 34 passed (34)` and `Errors 1 error`
+  → `Process completed with exit code 1`.
+- Same branch (`chore/commit-gate-friction`) ran "Web CI" twice with no web code
+  change — once **pass**, once **fail** — confirming a flake, not a real failure.
+- The leaked error stacks in that run were forum-service error paths:
+  `Error: Thread not found`, `Error: Search failed`, `Error: Category not found`.
+  These are the error-path branches of forum service/component tests — the likely
+  source is a promise rejection that isn't awaited/caught inside a test (or a
+  fire-and-forget call in the component under test) that surfaces *after* the test
+  resolves, so Vitest counts it as an unhandled error rather than a failed assertion.
+- Exact originating test file was not pinned: re-running the failed job (to unblock
+  #372's auto-merge) cleared the failed-attempt logs.
+- Discovery source: self-review of PR #372 (2026-06-14), issue #3.
+
+## Recommended Action
+
+1. Reproduce: re-run the Web CI job (or run the suite locally with
+   `cd web && npm run test -- --run`) repeatedly until it fails; capture the
+   `⎯⎯ Unhandled Errors ⎯⎯` / "This error originated in …" section to identify the
+   exact test file and call site. Candidates: forum thread / category / search
+   service or component tests exercising the error path.
+2. Fix the leak at the source — `await` (or `.catch`) the rejecting call in the
+   test, or in the component make the fire-and-forget call awaited / its rejection
+   handled. Prefer fixing the leak over suppressing it.
+3. Only if the leak is genuinely benign and unfixable, scope a narrow
+   `test.fails`/`expect(...).rejects` or a targeted vitest config — do NOT globally
+   set `dangerouslyIgnoreUnhandledErrors` (that would mask real future leaks).
+4. Add an assertion so the error-path test actually awaits and asserts the
+   rejection, converting the leaked rejection into a checked expectation.
+
+## Technical Details
+
+- Job: `.github/workflows/` Web CI → step "Unit and component tests (Vitest)".
+- Likely areas: `web/src/**/forum/**` service/component tests and their
+  `*.test.tsx?` error-path cases (`Thread not found`, `Search failed`,
+  `Category not found`).
+- Vitest treats a post-test unhandled rejection as a run-level error (exit 1) even
+  when every test file passes — see the `Errors: 1 error` line in the summary.
+
+## Acceptance Criteria
+
+- [ ] The originating test file + call site are identified and documented.
+- [ ] The unhandled rejection is fixed at the source (awaited/caught), not globally
+      suppressed.
+- [ ] The Web CI Vitest job passes across multiple consecutive runs of an unrelated
+      change (no intermittent exit-1 with all-tests-passing).
+
+## Work Log
+
+### 2026-06-14 - Filed
+
+- Created from self-review of PR #372 (issue #3). Flake pre-exists on `main` and is
+  independent of the commit-gate work; re-running the job cleared #372 to merge.
+
+## Notes
+
+- p2: not a product bug, but it intermittently blocks every PR's path to a green
+  merge (including #373), so it has real ongoing cost.
+- Related: PR #372 / #373; the flake is on `main`, not introduced by either.


### PR DESCRIPTION
Files two tracked follow-ups surfaced while reviewing #372 (the commit-gate friction PR):

- **todo 233 (p2)** — `scripts/refresh-secrets-baseline.sh` (added in #372) was syntax-checked but never run against a real churn case, and the detect-secrets gate pins **v1.4.0** while the venv has **v1.5.0**. Verify the helper end-to-end and resolve/clear the version skew.
- **todo 232 (p3)** — the `format-on-edit.sh` skip-list mirrors `setup.cfg` F401 per-file-ignores but is kept in sync only by a comment. Add a test asserting the setup.cfg F401 set is a subset of the hook's skip-list (a new intentional re-export not mirrored would otherwise have its imports silently stripped).

Two markdown files only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)