### PR TITLE
Forum Spec 2 — Phase 1 (read path): backend read endpoints + web client migration

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -28,7 +28,6 @@ python manage.py test apps.users --keepdb
 python manage.py warm_moderation_cache
 python manage.py warm_moderation_cache --force
 
-# Forum seeding (run after deploy to ensure the forum has a default board)
 python manage.py seed_default_forum    # ensure the forum has a default board (idempotent)
 
 # Redis

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -28,6 +28,9 @@ python manage.py test apps.users --keepdb
 python manage.py warm_moderation_cache
 python manage.py warm_moderation_cache --force
 
+# Forum seeding (run after deploy to ensure the forum has a default board)
+python manage.py seed_default_forum    # ensure the forum has a default board (idempotent)
+
 # Redis
 brew services start redis
 redis-cli ping   # should return PONG

--- a/backend/apps/forum_host/api_urls.py
+++ b/backend/apps/forum_host/api_urls.py
@@ -7,7 +7,7 @@ package endpoint cannot silently ship unmounted or unthrottled.
 """
 
 from django.urls import path
-from wagtail_forum.api.views import BoardListView, TopicListView
+from wagtail_forum.api.views import BoardListView, TopicDetailView, TopicListView
 
 from .api import (
     MeProfileView,
@@ -28,6 +28,7 @@ urlpatterns = [
         TopicCreateView.as_view(),
         name="topic-create",
     ),
+    path("topics/<int:topic_id>/", TopicDetailView.as_view(), name="topic-detail"),
     path(
         "topics/<int:topic_id>/posts/create/",
         ReplyCreateView.as_view(),

--- a/backend/apps/forum_host/api_urls.py
+++ b/backend/apps/forum_host/api_urls.py
@@ -7,7 +7,12 @@ package endpoint cannot silently ship unmounted or unthrottled.
 """
 
 from django.urls import path
-from wagtail_forum.api.views import BoardListView, TopicDetailView, TopicListView
+from wagtail_forum.api.views import (
+    BoardListView,
+    PostListView,
+    TopicDetailView,
+    TopicListView,
+)
 
 from .api import (
     MeProfileView,
@@ -29,6 +34,11 @@ urlpatterns = [
         name="topic-create",
     ),
     path("topics/<int:topic_id>/", TopicDetailView.as_view(), name="topic-detail"),
+    path(
+        "topics/<int:topic_id>/posts/",
+        PostListView.as_view(),
+        name="post-list",
+    ),
     path(
         "topics/<int:topic_id>/posts/create/",
         ReplyCreateView.as_view(),

--- a/backend/apps/forum_host/management/commands/seed_default_forum.py
+++ b/backend/apps/forum_host/management/commands/seed_default_forum.py
@@ -1,4 +1,4 @@
-from django.core.management.base import BaseCommand
+from django.core.management.base import BaseCommand, CommandError
 from wagtail.models import Page
 from wagtail_forum.models import ForumBoard, ForumIndex
 
@@ -10,8 +10,14 @@ class Command(BaseCommand):
         index = ForumIndex.objects.first()
         if index is None:
             root = Page.objects.filter(depth=1).first()
+            if root is None:
+                raise CommandError(
+                    "No Wagtail root page found. Run migrations before seeding."
+                )
             index = root.add_child(instance=ForumIndex(title="Forum", slug="forum"))
             self.stdout.write(self.style.SUCCESS("Created ForumIndex 'forum'."))
+        else:
+            self.stdout.write("ForumIndex 'forum' already exists.")
 
         if not index.get_children().type(ForumBoard).exists():
             index.add_child(

--- a/backend/apps/forum_host/management/commands/seed_default_forum.py
+++ b/backend/apps/forum_host/management/commands/seed_default_forum.py
@@ -1,0 +1,26 @@
+from django.core.management.base import BaseCommand
+from wagtail.models import Page
+from wagtail_forum.models import ForumBoard, ForumIndex
+
+
+class Command(BaseCommand):
+    help = "Idempotently ensure a ForumIndex + a starter ForumBoard exist."
+
+    def handle(self, *args, **options):
+        index = ForumIndex.objects.first()
+        if index is None:
+            root = Page.objects.filter(depth=1).first()
+            index = root.add_child(instance=ForumIndex(title="Forum", slug="forum"))
+            self.stdout.write(self.style.SUCCESS("Created ForumIndex 'forum'."))
+
+        if not index.get_children().type(ForumBoard).exists():
+            index.add_child(
+                instance=ForumBoard(
+                    title="General Discussion",
+                    slug="general-discussion",
+                    description="Talk about anything plant-related.",
+                )
+            )
+            self.stdout.write(self.style.SUCCESS("Created board 'general-discussion'."))
+        else:
+            self.stdout.write("Forum already seeded; nothing to do.")

--- a/backend/apps/forum_host/tests/test_seed_command.py
+++ b/backend/apps/forum_host/tests/test_seed_command.py
@@ -1,0 +1,14 @@
+import pytest
+from django.core.management import call_command
+from wagtail_forum.models import ForumBoard, ForumIndex
+
+
+@pytest.mark.django_db
+def test_seed_default_forum_is_idempotent():
+    call_command("seed_default_forum")
+    call_command("seed_default_forum")  # second run must not duplicate
+    assert ForumIndex.objects.count() == 1
+    assert ForumBoard.objects.count() == 1
+    board = ForumBoard.objects.get()
+    assert board.live is True
+    assert board.slug == "general-discussion"

--- a/backend/packages/wagtail_forum/wagtail_forum/api/pagination.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/api/pagination.py
@@ -13,3 +13,9 @@ class TopicCursorPagination(ForumCursorPagination):
     # deterministic when last_post_at ties. The list filters live=True, and live
     # topics always have a non-null last_post_at, so the cursor never orders on NULL.
     ordering = ("-last_post_at", "-id")
+
+
+class PostCursorPagination(ForumCursorPagination):
+    # Posts read oldest-first (Post.Meta.ordering = ["created_at"]); id is the
+    # unique tiebreak that keeps the cursor deterministic when created_at ties.
+    ordering = ("created_at", "id")

--- a/backend/packages/wagtail_forum/wagtail_forum/api/serializers.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/api/serializers.py
@@ -1,6 +1,8 @@
 from rest_framework import serializers
+from wagtail.blocks import RichTextBlock
+from wagtail.rich_text import expand_db_html
 
-from ..models import ForumBoard, ForumProfile, Reaction, Topic
+from ..models import ForumBoard, ForumProfile, Post, Reaction, Topic
 from .sanitize import validate_forum_body
 
 # Bio is stored in an unbounded TextField; bound it at the API boundary like
@@ -70,6 +72,94 @@ class TopicDetailSerializer(serializers.ModelSerializer):
     def get_opening_post_id(self, obj):
         post = obj.posts.filter(is_opening_post=True, live=True).only("id").first()
         return post.id if post else None
+
+
+def serialize_forum_body(stream_value):
+    """StreamField -> [{type, value, id}] for the React StreamFieldRenderer.
+
+    RichText (paragraph) blocks are run through expand_db_html() so Wagtail's
+    link rewriter runs (SECURITY: blocks.py:18-21) — never raw value.source.
+    Phase 1 bodies contain only text blocks (heading/paragraph/quote/code);
+    image-block rendition serialization arrives in Phase 3.
+    """
+    blocks = []
+    for bound in stream_value:
+        if isinstance(bound.block, RichTextBlock):
+            value = expand_db_html(bound.value.source)
+        else:
+            value = bound.block.get_api_representation(bound.value)
+        blocks.append({"type": bound.block_type, "value": value, "id": bound.id})
+    return blocks
+
+
+class PostAuthorSerializer(serializers.Serializer):
+    username = serializers.CharField(source="get_username")
+    display_name = serializers.SerializerMethodField()
+    trust_level = serializers.SerializerMethodField()
+
+    def get_display_name(self, obj):
+        full = obj.get_full_name()
+        return full or obj.get_username()
+
+    def get_trust_level(self, obj):
+        return None  # populated in a later plan when ForumProfile is joined
+
+
+class PostSerializer(serializers.ModelSerializer):
+    author = serializers.SerializerMethodField()
+    body = serializers.SerializerMethodField()
+    topic_id = serializers.IntegerField()
+    edited_at = serializers.SerializerMethodField()
+    status = serializers.SerializerMethodField()
+    can_edit = serializers.SerializerMethodField()
+    can_delete = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Post
+        fields = [
+            "id",
+            "topic_id",
+            "author",
+            "body",
+            "created_at",
+            "updated_at",
+            "edited_at",
+            "is_opening_post",
+            "status",
+            "reaction_counts",
+            "can_edit",
+            "can_delete",
+        ]
+
+    def get_author(self, obj):
+        if obj.author is None:
+            return {
+                "username": "[deleted]",
+                "display_name": "[deleted]",
+                "trust_level": None,
+            }
+        return PostAuthorSerializer(obj.author).data
+
+    def get_body(self, obj):
+        return serialize_forum_body(obj.body)
+
+    def get_edited_at(self, obj):
+        return obj.updated_at if obj.edited else None
+
+    def get_status(self, obj):
+        return "live" if obj.live else "pending"
+
+    def _is_owner_or_mod(self, obj):
+        user = self.context.get("request").user if self.context.get("request") else None
+        if not user or not user.is_authenticated:
+            return False
+        return user == obj.author or user.has_perm("wagtail_forum.change_post")
+
+    def get_can_edit(self, obj):
+        return self._is_owner_or_mod(obj)
+
+    def get_can_delete(self, obj):
+        return self._is_owner_or_mod(obj)
 
 
 class TopicCreateSerializer(serializers.Serializer):

--- a/backend/packages/wagtail_forum/wagtail_forum/api/serializers.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/api/serializers.py
@@ -36,6 +36,42 @@ class TopicListSerializer(serializers.ModelSerializer):
         ]
 
 
+class TopicDetailSerializer(serializers.ModelSerializer):
+    author = serializers.CharField(source="author.get_username", default=None)
+    last_post_author = serializers.CharField(
+        source="last_post_author.get_username", default=None
+    )
+    board = serializers.SerializerMethodField()
+    opening_post_id = serializers.SerializerMethodField()
+    locked = serializers.BooleanField()
+
+    class Meta:
+        model = Topic
+        fields = [
+            "id",
+            "title",
+            "slug",
+            "board",
+            "author",
+            "is_pinned",
+            "is_closed",
+            "locked",
+            "reply_count",
+            "view_count",
+            "created_at",
+            "last_post_at",
+            "last_post_author",
+            "opening_post_id",
+        ]
+
+    def get_board(self, obj):
+        return {"id": obj.board.id, "slug": obj.board.slug, "title": obj.board.title}
+
+    def get_opening_post_id(self, obj):
+        post = obj.posts.filter(is_opening_post=True, live=True).only("id").first()
+        return post.id if post else None
+
+
 class TopicCreateSerializer(serializers.Serializer):
     title = serializers.CharField(max_length=255)
     slug = serializers.SlugField(max_length=255)

--- a/backend/packages/wagtail_forum/wagtail_forum/api/urls.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/api/urls.py
@@ -8,6 +8,7 @@ from .views import (
     SearchView,
     SyncView,
     TopicCreateView,
+    TopicDetailView,
     TopicListView,
 )
 
@@ -21,6 +22,7 @@ urlpatterns = [
         TopicCreateView.as_view(),
         name="topic-create",
     ),
+    path("topics/<int:topic_id>/", TopicDetailView.as_view(), name="topic-detail"),
     path(
         "topics/<int:topic_id>/posts/create/",
         ReplyCreateView.as_view(),

--- a/backend/packages/wagtail_forum/wagtail_forum/api/urls.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/api/urls.py
@@ -3,6 +3,7 @@ from django.urls import path
 from .views import (
     BoardListView,
     MeProfileView,
+    PostListView,
     ReactionToggleView,
     ReplyCreateView,
     SearchView,
@@ -23,6 +24,11 @@ urlpatterns = [
         name="topic-create",
     ),
     path("topics/<int:topic_id>/", TopicDetailView.as_view(), name="topic-detail"),
+    path(
+        "topics/<int:topic_id>/posts/",
+        PostListView.as_view(),
+        name="post-list",
+    ),
     path(
         "topics/<int:topic_id>/posts/create/",
         ReplyCreateView.as_view(),

--- a/backend/packages/wagtail_forum/wagtail_forum/api/views.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/api/views.py
@@ -28,10 +28,11 @@ from ..models import ForumBoard, Post, Reaction, Topic
 from ..workflow import submit_for_moderation
 from .exceptions import Conflict, UnprocessableEntity
 from .idempotency import fingerprint, idempotency_cache_key, remember, replay, reserve
-from .pagination import TopicCursorPagination
+from .pagination import PostCursorPagination, TopicCursorPagination
 from .serializers import (
     BoardSerializer,
     MeProfileSerializer,
+    PostSerializer,
     ReactionSerializer,
     ReplyCreateSerializer,
     TopicCreateSerializer,
@@ -133,6 +134,19 @@ class TopicDetailView(generics.RetrieveAPIView):
         return Topic.objects.filter(
             live=True, board__in=_visible_boards()
         ).select_related("board", "author", "last_post_author")
+
+
+class PostListView(generics.ListAPIView):
+    serializer_class = PostSerializer
+    pagination_class = PostCursorPagination
+    versioning_class = None
+
+    def get_queryset(self):
+        topic = get_object_or_404(
+            Topic.objects.filter(live=True, board__in=_visible_boards()),
+            id=self.kwargs["topic_id"],
+        )
+        return topic.posts.filter(live=True).select_related("author")
 
 
 class TopicCreateView(APIView):

--- a/backend/packages/wagtail_forum/wagtail_forum/api/views.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/api/views.py
@@ -35,6 +35,7 @@ from .serializers import (
     ReactionSerializer,
     ReplyCreateSerializer,
     TopicCreateSerializer,
+    TopicDetailSerializer,
     TopicListSerializer,
 )
 
@@ -121,6 +122,17 @@ class TopicListView(generics.ListAPIView):
             .select_related("author", "last_post_author")
             .order_by("-last_post_at", "-id")
         )
+
+
+class TopicDetailView(generics.RetrieveAPIView):
+    serializer_class = TopicDetailSerializer
+    versioning_class = None
+    lookup_url_kwarg = "topic_id"
+
+    def get_queryset(self):
+        return Topic.objects.filter(
+            live=True, board__in=_visible_boards()
+        ).select_related("board", "author", "last_post_author")
 
 
 class TopicCreateView(APIView):

--- a/backend/packages/wagtail_forum/wagtail_forum/api/views.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/api/views.py
@@ -382,22 +382,35 @@ class SearchView(APIView):
 
     @extend_schema(
         responses={200: dict},
-        description="Search live topic titles. Query param: q.",
+        description="Search live topic titles and post bodies. Query param: q.",
     )
     def get(self, request):
         query = request.query_params.get("q", "").strip()
-        results = []
+        topics, posts = [], []
         if query:
             backend = get_search_backend()
-            hits = backend.search(
-                query,
-                Topic.objects.filter(live=True, board__in=_visible_boards()),
+            boards = _visible_boards()
+            topic_hits = backend.search(
+                query, Topic.objects.filter(live=True, board__in=boards)
             )
-            for topic in hits[: self.MAX_RESULTS]:
-                results.append(
-                    {"id": topic.id, "slug": topic.slug, "title": topic.title}
+            for t in topic_hits[: self.MAX_RESULTS]:
+                topics.append({"id": t.id, "slug": t.slug, "title": t.title})
+            post_hits = backend.search(
+                query,
+                Post.objects.filter(
+                    live=True, topic__live=True, topic__board__in=boards
+                ).select_related("topic"),
+            )
+            for p in post_hits[: self.MAX_RESULTS]:
+                posts.append(
+                    {
+                        "id": p.id,
+                        "topic_id": p.topic_id,
+                        "topic_title": p.topic.title,
+                        "excerpt": p.body.render_as_block()[:200] if p.body else "",
+                    }
                 )
-        return Response({"results": results})
+        return Response({"topics": topics, "posts": posts})
 
 
 class SyncView(APIView):

--- a/backend/packages/wagtail_forum/wagtail_forum/models/posts.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/models/posts.py
@@ -61,6 +61,17 @@ class Post(
         # Any real-backend search over live posts filters on this; without it
         # Elasticsearch raises FilterFieldError (Topic declares it; Post must too).
         index.FilterField("live"),
+        # Required so the DB search backend can filter on topic__live and
+        # topic__board_id (visibility constraints in SearchView). Without this
+        # declaration the backend raises FilterFieldError. No migration or
+        # reindex needed for the DB backend.
+        index.RelatedFields(
+            "topic",
+            [
+                index.FilterField("live"),
+                index.FilterField("board_id"),
+            ],
+        ),
     ]
 
     panels = [

--- a/backend/packages/wagtail_forum/wagtail_forum/tests/api/test_post_list.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/tests/api/test_post_list.py
@@ -1,0 +1,70 @@
+import pytest
+from django.contrib.auth import get_user_model
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
+from rest_framework.test import APIClient
+from wagtail.models import Page
+from wagtail_forum.models import ForumBoard, ForumIndex, Post, Topic
+
+User = get_user_model()
+pytestmark = pytest.mark.urls("wagtail_forum.tests.api.urls")
+
+
+def _topic_with_posts(n):
+    root = Page.objects.get(id=1)
+    index = root.add_child(instance=ForumIndex(title="Forum", slug="forum"))
+    board = index.add_child(instance=ForumBoard(title="General", slug="general"))
+    author = User.objects.create_user(username="ada", password="x")
+    topic = Topic.objects.create(
+        board=board, title="T", slug="t", author=author, live=True
+    )
+    for i in range(n):
+        Post.objects.create(
+            topic=topic,
+            author=author,
+            is_opening_post=(i == 0),
+            live=True,
+            body=[{"type": "paragraph", "value": "<p>hi</p>"}],
+        )
+    return topic
+
+
+@pytest.mark.django_db
+def test_post_list_serializes_streamfield_body():
+    topic = _topic_with_posts(1)
+    resp = APIClient().get(f"/forum/topics/{topic.id}/posts/")
+    assert resp.status_code == 200
+    post = resp.data["results"][0]
+    assert post["topic_id"] == topic.id
+    assert post["author"]["username"] == "ada"
+    assert post["is_opening_post"] is True
+    assert post["body"] == [
+        {"type": "paragraph", "value": "<p>hi</p>", "id": post["body"][0]["id"]}
+    ]
+    assert post["reaction_counts"] == {}
+    assert post["can_edit"] is False  # anonymous
+
+
+@pytest.mark.django_db
+def test_post_list_is_cursor_paginated_with_bounded_queries():
+    topic = _topic_with_posts(25)
+    client = APIClient()
+    with CaptureQueriesContext(connection) as ctx:
+        resp = client.get(f"/forum/topics/{topic.id}/posts/")
+    assert resp.status_code == 200
+    assert len(resp.data["results"]) == 20  # page_size
+    assert resp.data["next"] is not None
+    # Q1: PageViewRestriction prefetch (from _visible_boards().public())
+    # Q2: topic lookup (wagtail_forum_topic with board__in=_visible_boards() subquery)
+    # Q3: posts page with select_related author (cursor fetches page_size+1 rows; the
+    #     extra row is the has-next probe — no separate COUNT query)
+    # Pinned EXACTLY (docs/rules/testing.md). If this changes, explain the new number.
+    assert len(ctx.captured_queries) == 3
+
+
+@pytest.mark.django_db
+def test_post_list_hides_posts_on_hidden_topic():
+    topic = _topic_with_posts(1)
+    topic.live = False
+    topic.save()
+    assert APIClient().get(f"/forum/topics/{topic.id}/posts/").status_code == 404

--- a/backend/packages/wagtail_forum/wagtail_forum/tests/api/test_search_sync.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/tests/api/test_search_sync.py
@@ -1,9 +1,12 @@
 import datetime
 
 import pytest
+from django.contrib.auth import get_user_model
 from rest_framework.test import APIClient
 from wagtail.models import Page
-from wagtail_forum.models import ForumBoard, ForumIndex, Topic
+from wagtail_forum.models import ForumBoard, ForumIndex, Post, Topic
+
+User = get_user_model()
 
 pytestmark = pytest.mark.urls("wagtail_forum.tests.api.urls")
 
@@ -21,7 +24,7 @@ def test_search_returns_matching_topics():
 
     resp = APIClient().get("/forum/search/?q=Monstera")
     assert resp.status_code == 200
-    assert any(r["slug"] == "m" for r in resp.data["results"])
+    assert any(t["slug"] == "m" for t in resp.data["topics"])
 
 
 @pytest.mark.django_db
@@ -78,3 +81,26 @@ def test_sync_truncation_sets_has_more_and_boundary_next_since(monkeypatch):
     # next_since is the LAST RETURNED row's timestamp; with the >= boundary the
     # client re-receives that row and upserts by id — never loses one.
     assert resp.data["next_since"] == Topic.objects.get(slug="t1").updated_at
+
+
+@pytest.mark.django_db
+def test_search_returns_topics_and_posts():
+    board = _board()
+    author = User.objects.create_user(username="ada", password="x")
+    topic = Topic.objects.create(
+        board=board, title="Monstera care", slug="monstera", author=author, live=True
+    )
+    post = Post.objects.create(
+        topic=topic,
+        author=author,
+        is_opening_post=True,
+        live=True,
+        body=[{"type": "paragraph", "value": "<p>watering a monstera</p>"}],
+    )
+
+    resp = APIClient().get("/forum/search/?q=monstera")
+
+    assert resp.status_code == 200
+    assert "topics" in resp.data and "posts" in resp.data
+    assert any(t["id"] == topic.id for t in resp.data["topics"])
+    assert any(p["id"] == post.id for p in resp.data["posts"])

--- a/backend/packages/wagtail_forum/wagtail_forum/tests/api/test_topic_detail.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/tests/api/test_topic_detail.py
@@ -1,0 +1,51 @@
+import pytest
+from django.contrib.auth import get_user_model
+from rest_framework.test import APIClient
+from wagtail.models import Page
+from wagtail_forum.models import ForumBoard, ForumIndex, Post, Topic
+
+User = get_user_model()
+pytestmark = pytest.mark.urls("wagtail_forum.tests.api.urls")
+
+
+def _board(slug="general"):
+    root = Page.objects.get(id=1)
+    index = root.add_child(instance=ForumIndex(title="Forum", slug="forum"))
+    return index.add_child(instance=ForumBoard(title="General", slug=slug))
+
+
+@pytest.mark.django_db
+def test_topic_detail_returns_live_topic():
+    board = _board()
+    author = User.objects.create_user(username="ada", password="x")
+    topic = Topic.objects.create(
+        board=board, title="Hello", slug="hello", author=author, live=True
+    )
+    opening = Post.objects.create(
+        topic=topic, author=author, is_opening_post=True, live=True
+    )
+
+    resp = APIClient().get(f"/forum/topics/{topic.id}/")
+
+    assert resp.status_code == 200
+    assert resp.data["id"] == topic.id
+    assert resp.data["title"] == "Hello"
+    assert resp.data["board"]["slug"] == "general"
+    assert resp.data["author"] == "ada"
+    assert resp.data["opening_post_id"] == opening.id
+
+
+@pytest.mark.django_db
+def test_topic_detail_hides_draft_topic():
+    board = _board()
+    topic = Topic.objects.create(board=board, title="Draft", slug="draft", live=False)
+    assert APIClient().get(f"/forum/topics/{topic.id}/").status_code == 404
+
+
+@pytest.mark.django_db
+def test_topic_detail_hides_topic_on_unpublished_board():
+    board = _board()
+    board.live = False
+    board.save()
+    topic = Topic.objects.create(board=board, title="X", slug="x", live=True)
+    assert APIClient().get(f"/forum/topics/{topic.id}/").status_code == 404

--- a/backend/packages/wagtail_forum/wagtail_forum/tests/api/test_topic_detail.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/tests/api/test_topic_detail.py
@@ -1,5 +1,7 @@
 import pytest
 from django.contrib.auth import get_user_model
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
 from rest_framework.test import APIClient
 from wagtail.models import Page
 from wagtail_forum.models import ForumBoard, ForumIndex, Post, Topic
@@ -25,7 +27,8 @@ def test_topic_detail_returns_live_topic():
         topic=topic, author=author, is_opening_post=True, live=True
     )
 
-    resp = APIClient().get(f"/forum/topics/{topic.id}/")
+    with CaptureQueriesContext(connection) as ctx:
+        resp = APIClient().get(f"/forum/topics/{topic.id}/")
 
     assert resp.status_code == 200
     assert resp.data["id"] == topic.id
@@ -33,6 +36,10 @@ def test_topic_detail_returns_live_topic():
     assert resp.data["board"]["slug"] == "general"
     assert resp.data["author"] == "ada"
     assert resp.data["opening_post_id"] == opening.id
+    # Exactly 4: page-view-restriction check, topic fetch (select_related board/author),
+    # opening-post id lookup, post refetch by id.
+    # Pinned EXACTLY (docs/rules/testing.md) — if this changes, explain the new count here.
+    assert len(ctx.captured_queries) == 4
 
 
 @pytest.mark.django_db

--- a/backend/packages/wagtail_forum/wagtail_forum/tests/api/test_visibility.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/tests/api/test_visibility.py
@@ -51,7 +51,10 @@ def test_pending_topics_are_excluded_from_list_search_and_sync():
     assert [t["slug"] for t in synced.data["topics"]] == ["visible"]
 
     searched = client.get("/forum/search/?q=hidden")
-    assert searched.data["results"] == []
+    # Search shape is {topics, posts} (Spec 2). A live=False topic and any of
+    # its posts must be absent from BOTH lists.
+    assert searched.data["topics"] == []
+    assert searched.data["posts"] == []
 
 
 @pytest.mark.django_db
@@ -119,4 +122,6 @@ def test_search_excludes_taken_down_board():
     board.unpublish()
 
     resp = APIClient().get("/forum/search/?q=findme")
-    assert resp.data["results"] == []
+    # A taken-down (unpublished) board must be excluded from BOTH search lists.
+    assert resp.data["topics"] == []
+    assert resp.data["posts"] == []

--- a/backend/packages/wagtail_forum/wagtail_forum/tests/api/test_visibility.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/tests/api/test_visibility.py
@@ -25,10 +25,13 @@ def _board(slug="general"):
     return index.add_child(instance=ForumBoard(title=slug.title(), slug=slug))
 
 
-def _live_topic(board, slug="t"):
+def _live_topic(board, slug="t", body=None):
     author = User.objects.create_user(username=f"op-{slug}", password="x")
     topic = Topic.objects.create(board=board, title=slug, slug=slug, author=author)
-    post = Post.objects.create(topic=topic, author=author, is_opening_post=True)
+    kwargs = {"topic": topic, "author": author, "is_opening_post": True}
+    if body is not None:
+        kwargs["body"] = body
+    post = Post.objects.create(**kwargs)
     post.save_revision().publish()
     return topic, post
 
@@ -38,8 +41,18 @@ def test_pending_topics_are_excluded_from_list_search_and_sync():
     board = _board()
     _live_topic(board, slug="visible")
     author = User.objects.create_user(username="spammer", password="x")
-    Topic.objects.create(
+    hidden_topic = Topic.objects.create(
         board=board, title="hidden spam", slug="hidden-spam", author=author, live=False
+    )
+    # Add a live post whose body contains the search term "hidden" so the
+    # post-search visibility filter (topic__live=True) is genuinely exercised.
+    # Without this post, searched.data["posts"] == [] is vacuously true.
+    Post.objects.create(
+        topic=hidden_topic,
+        author=author,
+        is_opening_post=True,
+        live=True,
+        body=[{"type": "paragraph", "value": "<p>hidden spam body</p>"}],
     )
     client = APIClient()
 
@@ -118,7 +131,13 @@ def test_search_excludes_taken_down_board():
     # SearchView must gate on board visibility too — deleting its
     # _visible_boards() filter has to fail a test (review finding 10).
     board = _board(slug="searchable")
-    _live_topic(board, slug="findme")
+    # Give the opening post a body containing the search term so the
+    # post-search path (topic__board__in=_visible_boards()) is genuinely exercised.
+    _live_topic(
+        board,
+        slug="findme",
+        body=[{"type": "paragraph", "value": "<p>findme body text</p>"}],
+    )
     board.unpublish()
 
     resp = APIClient().get("/forum/search/?q=findme")

--- a/backend/railway.json
+++ b/backend/railway.json
@@ -4,7 +4,7 @@
     "builder": "NIXPACKS"
   },
   "deploy": {
-    "startCommand": "python manage.py migrate --noinput && python manage.py collectstatic --noinput --verbosity 0 && gunicorn plant_community_backend.wsgi:application --bind 0.0.0.0:$PORT --workers 2 --timeout 120",
+    "startCommand": "python manage.py migrate --noinput && python manage.py seed_default_forum && python manage.py collectstatic --noinput --verbosity 0 && gunicorn plant_community_backend.wsgi:application --bind 0.0.0.0:$PORT --workers 2 --timeout 120",
     "restartPolicyType": "ON_FAILURE",
     "restartPolicyMaxRetries": 5
   }

--- a/docs/superpowers/plans/2026-06-20-forum-spec2-phase1-read-path.md
+++ b/docs/superpowers/plans/2026-06-20-forum-spec2-phase1-read-path.md
@@ -1,0 +1,910 @@
+# Forum Spec 2 — Phase 1 (Read Path) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the deployed web forum browsable again by building the two missing read endpoints (topic detail + post list), extending search to posts, seeding a default board, and migrating the React read path off the retired machina API — killing the live "Error loading categories: Request failed."
+
+**Architecture:** Add `TopicDetailView` + `PostListView` (cursor-paginated) to the `wagtail_forum` package, mount them unwrapped in `forum_host` (matching the existing read-view precedent), extend the package `SearchView` to also search post bodies, and add an idempotent `seed_default_forum` management command. Then rewrite the read half of the React forum client to the new contract and render post bodies as StreamField JSON via the existing `StreamFieldRenderer`.
+
+**Tech Stack:** Django 5 / DRF, Wagtail 7 (snippets, StreamField, `expand_db_html`), pytest + `CaptureQueriesContext`; React 19 + TypeScript, Vitest.
+
+**Spec:** `docs/superpowers/specs/2026-06-20-forum-spec2-read-write-client-design.md` (Phase 1 only).
+
+## Global Constraints
+
+- **Every new DRF view MUST set `versioning_class = None`** — the host mounts the package under a `NamespaceVersioning` `v1` namespace that 404s package routes otherwise.
+- **No plant imports in `backend/packages/wagtail_forum/`** — the package core stays domain-agnostic (a reusability test enforces this).
+- **Route-parity test must stay green** — every package route in `wagtail_forum/api/urls.py` must have an identical `(pattern, name)` entry in `apps/forum_host/api_urls.py` (`apps/forum_host/tests/test_ratelimits.py::test_host_api_routes_match_package`).
+- **No DB mocks; real Postgres test DB.** Query counts are pinned **exactly** (`len(ctx.captured_queries) == N`), never `<=` (per `docs/rules/testing.md`).
+- **Post body is StreamField JSON.** On read, `paragraph` (RichText) blocks are serialized through Wagtail `expand_db_html()` — never raw `value.source`.
+- **Visibility rule:** a hidden/draft topic, or one on a non-live/restricted board, is **404** (never 403) — mirror `_visible_boards()` = `ForumBoard.objects.live().public()`.
+- **Backend tests** run with `pytest.mark.urls("wagtail_forum.tests.api.urls")` and hit paths under `/forum/...`. **Web CI gates:** `npm run type-check`, `npm run lint`, `npm run test` must pass.
+
+---
+
+## File Structure
+
+**Backend (package — `backend/packages/wagtail_forum/wagtail_forum/`):**
+
+- `api/serializers.py` — add `serialize_forum_body()`, `TopicDetailSerializer`, `PostSerializer`.
+- `api/pagination.py` — add `PostCursorPagination`.
+- `api/views.py` — add `TopicDetailView`, `PostListView`; extend `SearchView` to topics + posts.
+- `api/urls.py` — add `topic-detail` + `post-list` routes.
+- `tests/api/test_topic_detail.py`, `tests/api/test_post_list.py` — new.
+- `tests/api/test_search_sync.py` — extend for post hits.
+
+**Backend (host — `backend/apps/forum_host/`):**
+
+- `api_urls.py` — mount the two new read views (unwrapped).
+- `management/commands/seed_default_forum.py` — new, idempotent board seeding.
+- `tests/test_seed_command.py` — new.
+
+**Web (`web/src/`):**
+
+- `services/forumMappers.ts` — replace machina backend shapes with the new API shapes + mappers.
+- `services/forumService.ts` — rewrite read functions to the new contract.
+- `types/forum.ts` — adjust types (cursor pagination, StreamField body).
+- `pages/forum/CategoryListPage.tsx`, `ThreadListPage.tsx`, `ThreadDetailPage.tsx` (read only), `SearchPage.tsx` — update to the new service.
+- `components/forum/PostCard.tsx` — render `post.body` via `StreamFieldRenderer`.
+- Corresponding `*.test.ts(x)` files.
+
+---
+
+## Task 1: Topic detail endpoint
+
+**Files:**
+
+- Modify: `backend/packages/wagtail_forum/wagtail_forum/api/serializers.py`
+- Modify: `backend/packages/wagtail_forum/wagtail_forum/api/views.py`
+- Modify: `backend/packages/wagtail_forum/wagtail_forum/api/urls.py`
+- Modify: `backend/apps/forum_host/api_urls.py`
+- Test: `backend/packages/wagtail_forum/wagtail_forum/tests/api/test_topic_detail.py`
+
+**Interfaces:**
+
+- Produces: `TopicDetailSerializer` (fields below); `TopicDetailView` (GET `topics/<int:topic_id>/`, name `topic-detail`).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/packages/wagtail_forum/wagtail_forum/tests/api/test_topic_detail.py`:
+
+```python
+import pytest
+from django.contrib.auth import get_user_model
+from rest_framework.test import APIClient
+from wagtail.models import Page
+from wagtail_forum.models import ForumBoard, ForumIndex, Post, Topic
+
+User = get_user_model()
+pytestmark = pytest.mark.urls("wagtail_forum.tests.api.urls")
+
+
+def _board(slug="general"):
+    root = Page.objects.get(id=1)
+    index = root.add_child(instance=ForumIndex(title="Forum", slug="forum"))
+    return index.add_child(instance=ForumBoard(title="General", slug=slug))
+
+
+@pytest.mark.django_db
+def test_topic_detail_returns_live_topic():
+    board = _board()
+    author = User.objects.create_user(username="ada", password="x")
+    topic = Topic.objects.create(
+        board=board, title="Hello", slug="hello", author=author, live=True
+    )
+    opening = Post.objects.create(
+        topic=topic, author=author, is_opening_post=True, live=True
+    )
+
+    resp = APIClient().get(f"/forum/topics/{topic.id}/")
+
+    assert resp.status_code == 200
+    assert resp.data["id"] == topic.id
+    assert resp.data["title"] == "Hello"
+    assert resp.data["board"]["slug"] == "general"
+    assert resp.data["author"] == "ada"
+    assert resp.data["opening_post_id"] == opening.id
+
+
+@pytest.mark.django_db
+def test_topic_detail_hides_draft_topic():
+    board = _board()
+    topic = Topic.objects.create(board=board, title="Draft", slug="draft", live=False)
+    assert APIClient().get(f"/forum/topics/{topic.id}/").status_code == 404
+
+
+@pytest.mark.django_db
+def test_topic_detail_hides_topic_on_unpublished_board():
+    board = _board()
+    board.live = False
+    board.save()
+    topic = Topic.objects.create(board=board, title="X", slug="x", live=True)
+    assert APIClient().get(f"/forum/topics/{topic.id}/").status_code == 404
+```
+
+- [ ] **Step 2: Run the test, verify it fails**
+
+Run: `cd backend && python -m pytest packages/wagtail_forum/wagtail_forum/tests/api/test_topic_detail.py -v`
+Expected: FAIL — 404 (route does not exist yet).
+
+- [ ] **Step 3: Add `TopicDetailSerializer`**
+
+In `api/serializers.py`, after `TopicListSerializer`, add:
+
+```python
+class TopicDetailSerializer(serializers.ModelSerializer):
+    author = serializers.CharField(source="author.get_username", default=None)
+    last_post_author = serializers.CharField(
+        source="last_post_author.get_username", default=None
+    )
+    board = serializers.SerializerMethodField()
+    opening_post_id = serializers.SerializerMethodField()
+    locked = serializers.BooleanField()
+
+    class Meta:
+        model = Topic
+        fields = [
+            "id",
+            "title",
+            "slug",
+            "board",
+            "author",
+            "is_pinned",
+            "is_closed",
+            "locked",
+            "reply_count",
+            "view_count",
+            "created_at",
+            "last_post_at",
+            "last_post_author",
+            "opening_post_id",
+        ]
+
+    def get_board(self, obj):
+        return {"id": obj.board.id, "slug": obj.board.slug, "title": obj.board.title}
+
+    def get_opening_post_id(self, obj):
+        post = obj.posts.filter(is_opening_post=True, live=True).only("id").first()
+        return post.id if post else None
+```
+
+- [ ] **Step 4: Add `TopicDetailView`**
+
+In `api/views.py`, after `TopicListView`, add (note `_visible_boards()` already exists in this module):
+
+```python
+class TopicDetailView(generics.RetrieveAPIView):
+    serializer_class = TopicDetailSerializer
+    versioning_class = None
+    lookup_url_kwarg = "topic_id"
+
+    def get_queryset(self):
+        return (
+            Topic.objects.filter(live=True, board__in=_visible_boards())
+            .select_related("board", "author", "last_post_author")
+        )
+```
+
+Add `TopicDetailSerializer` to the `from .serializers import (...)` block.
+
+- [ ] **Step 5: Register the route (package + host)**
+
+In `api/urls.py`, add to `urlpatterns` (import `TopicDetailView`):
+
+```python
+    path("topics/<int:topic_id>/", TopicDetailView.as_view(), name="topic-detail"),
+```
+
+In `apps/forum_host/api_urls.py`, add `TopicDetailView` to the
+`from wagtail_forum.api.views import ...` line and add the **identical** route:
+
+```python
+    path("topics/<int:topic_id>/", TopicDetailView.as_view(), name="topic-detail"),
+```
+
+- [ ] **Step 6: Run the tests, verify they pass**
+
+Run: `cd backend && python -m pytest packages/wagtail_forum/wagtail_forum/tests/api/test_topic_detail.py apps/forum_host/tests/test_ratelimits.py::test_host_api_routes_match_package -v`
+Expected: PASS (detail tests + parity guard).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/packages/wagtail_forum/wagtail_forum/api/serializers.py \
+        backend/packages/wagtail_forum/wagtail_forum/api/views.py \
+        backend/packages/wagtail_forum/wagtail_forum/api/urls.py \
+        backend/apps/forum_host/api_urls.py \
+        backend/packages/wagtail_forum/wagtail_forum/tests/api/test_topic_detail.py
+git commit -m "feat(forum): add GET /topics/{id}/ topic-detail endpoint"
+```
+
+---
+
+## Task 2: Post list endpoint (cursor-paginated, StreamField body)
+
+**Files:**
+
+- Modify: `backend/packages/wagtail_forum/wagtail_forum/api/serializers.py`
+- Modify: `backend/packages/wagtail_forum/wagtail_forum/api/pagination.py`
+- Modify: `backend/packages/wagtail_forum/wagtail_forum/api/views.py`
+- Modify: `backend/packages/wagtail_forum/wagtail_forum/api/urls.py`
+- Modify: `backend/apps/forum_host/api_urls.py`
+- Test: `backend/packages/wagtail_forum/wagtail_forum/tests/api/test_post_list.py`
+
+**Interfaces:**
+
+- Consumes: `_board()` test helper, `_visible_boards()`.
+- Produces: `serialize_forum_body(stream_value) -> list[dict]`; `PostSerializer`; `PostCursorPagination`; `PostListView` (GET `topics/<int:topic_id>/posts/`, name `post-list`).
+
+- [ ] **Step 1: Write the failing test (body shape + query-count pin)**
+
+Create `backend/packages/wagtail_forum/wagtail_forum/tests/api/test_post_list.py`:
+
+```python
+import pytest
+from django.contrib.auth import get_user_model
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
+from rest_framework.test import APIClient
+from wagtail.models import Page
+from wagtail_forum.models import ForumBoard, ForumIndex, Post, Topic
+
+User = get_user_model()
+pytestmark = pytest.mark.urls("wagtail_forum.tests.api.urls")
+
+
+def _topic_with_posts(n):
+    root = Page.objects.get(id=1)
+    index = root.add_child(instance=ForumIndex(title="Forum", slug="forum"))
+    board = index.add_child(instance=ForumBoard(title="General", slug="general"))
+    author = User.objects.create_user(username="ada", password="x")
+    topic = Topic.objects.create(
+        board=board, title="T", slug="t", author=author, live=True
+    )
+    for i in range(n):
+        Post.objects.create(
+            topic=topic,
+            author=author,
+            is_opening_post=(i == 0),
+            live=True,
+            body=[{"type": "paragraph", "value": "<p>hi</p>"}],
+        )
+    return topic
+
+
+@pytest.mark.django_db
+def test_post_list_serializes_streamfield_body():
+    topic = _topic_with_posts(1)
+    resp = APIClient().get(f"/forum/topics/{topic.id}/posts/")
+    assert resp.status_code == 200
+    post = resp.data["results"][0]
+    assert post["topic_id"] == topic.id
+    assert post["author"]["username"] == "ada"
+    assert post["is_opening_post"] is True
+    assert post["body"] == [{"type": "paragraph", "value": "<p>hi</p>", "id": post["body"][0]["id"]}]
+    assert post["reaction_counts"] == {}
+    assert post["can_edit"] is False  # anonymous
+
+
+@pytest.mark.django_db
+def test_post_list_is_cursor_paginated_with_bounded_queries():
+    topic = _topic_with_posts(25)
+    client = APIClient()
+    with CaptureQueriesContext(connection) as ctx:
+        resp = client.get(f"/forum/topics/{topic.id}/posts/")
+    assert resp.status_code == 200
+    assert len(resp.data["results"]) == 20  # page_size
+    assert resp.data["next"] is not None
+    # topic visibility lookup, posts page (select_related author), cursor has-next probe.
+    # Pinned EXACTLY (docs/rules/testing.md). If this changes, explain the new number.
+    assert len(ctx.captured_queries) == 3
+
+
+@pytest.mark.django_db
+def test_post_list_hides_posts_on_hidden_topic():
+    topic = _topic_with_posts(1)
+    topic.live = False
+    topic.save()
+    assert APIClient().get(f"/forum/topics/{topic.id}/posts/").status_code == 404
+```
+
+- [ ] **Step 2: Run the test, verify it fails**
+
+Run: `cd backend && python -m pytest packages/wagtail_forum/wagtail_forum/tests/api/test_post_list.py -v`
+Expected: FAIL — 404 (route missing).
+
+- [ ] **Step 3: Add the body serializer + `PostSerializer`**
+
+In `api/serializers.py`, add near the top (imports) and after `TopicDetailSerializer`:
+
+```python
+from wagtail.blocks import RichTextBlock
+from wagtail.rich_text import expand_db_html
+
+from ..models import Post  # add Post to the existing model import
+
+
+def serialize_forum_body(stream_value):
+    """StreamField -> [{type, value, id}] for the React StreamFieldRenderer.
+
+    RichText (paragraph) blocks are run through expand_db_html() so Wagtail's
+    link rewriter runs (SECURITY: blocks.py:18-21) — never raw value.source.
+    Phase 1 bodies contain only text blocks (heading/paragraph/quote/code);
+    image-block rendition serialization arrives in Phase 3.
+    """
+    blocks = []
+    for bound in stream_value:
+        if isinstance(bound.block, RichTextBlock):
+            value = expand_db_html(bound.value.source)
+        else:
+            value = bound.block.get_api_representation(bound.value)
+        blocks.append({"type": bound.block_type, "value": value, "id": bound.id})
+    return blocks
+
+
+class PostAuthorSerializer(serializers.Serializer):
+    username = serializers.CharField(source="get_username")
+    display_name = serializers.SerializerMethodField()
+    trust_level = serializers.SerializerMethodField()
+
+    def get_display_name(self, obj):
+        full = obj.get_full_name()
+        return full or obj.get_username()
+
+    def get_trust_level(self, obj):
+        return None  # populated in a later plan when ForumProfile is joined
+
+
+class PostSerializer(serializers.ModelSerializer):
+    author = serializers.SerializerMethodField()
+    body = serializers.SerializerMethodField()
+    topic_id = serializers.IntegerField()
+    edited_at = serializers.SerializerMethodField()
+    status = serializers.SerializerMethodField()
+    can_edit = serializers.SerializerMethodField()
+    can_delete = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Post
+        fields = [
+            "id",
+            "topic_id",
+            "author",
+            "body",
+            "created_at",
+            "updated_at",
+            "edited_at",
+            "is_opening_post",
+            "status",
+            "reaction_counts",
+            "can_edit",
+            "can_delete",
+        ]
+
+    def get_author(self, obj):
+        if obj.author is None:
+            return {"username": "[deleted]", "display_name": "[deleted]", "trust_level": None}
+        return PostAuthorSerializer(obj.author).data
+
+    def get_body(self, obj):
+        return serialize_forum_body(obj.body)
+
+    def get_edited_at(self, obj):
+        return obj.updated_at if obj.edited else None
+
+    def get_status(self, obj):
+        return "live" if obj.live else "pending"
+
+    def _is_owner_or_mod(self, obj):
+        user = self.context.get("request").user if self.context.get("request") else None
+        if not user or not user.is_authenticated:
+            return False
+        return user == obj.author or user.has_perm("wagtail_forum.change_post")
+
+    def get_can_edit(self, obj):
+        return self._is_owner_or_mod(obj)
+
+    def get_can_delete(self, obj):
+        return self._is_owner_or_mod(obj)
+```
+
+Note: `edited_by` is intentionally omitted — the `Post` model has no such field (a future `edited_by` is out of scope; `PostCard` already renders the "by …" clause conditionally).
+
+- [ ] **Step 4: Add `PostCursorPagination`**
+
+In `api/pagination.py`, add:
+
+```python
+class PostCursorPagination(ForumCursorPagination):
+    # Posts read oldest-first (Post.Meta.ordering = ["created_at"]); id is the
+    # unique tiebreak that keeps the cursor deterministic when created_at ties.
+    ordering = ("created_at", "id")
+```
+
+- [ ] **Step 5: Add `PostListView`**
+
+In `api/views.py`, after `TopicDetailView`, add (import `PostSerializer`, `PostCursorPagination`):
+
+```python
+class PostListView(generics.ListAPIView):
+    serializer_class = PostSerializer
+    pagination_class = PostCursorPagination
+    versioning_class = None
+
+    def get_queryset(self):
+        topic = get_object_or_404(
+            Topic.objects.filter(live=True, board__in=_visible_boards()),
+            id=self.kwargs["topic_id"],
+        )
+        return topic.posts.filter(live=True).select_related("author")
+```
+
+- [ ] **Step 6: Register the route (package + host)**
+
+In `api/urls.py` add (import `PostListView`):
+
+```python
+    path(
+        "topics/<int:topic_id>/posts/",
+        PostListView.as_view(),
+        name="post-list",
+    ),
+```
+
+In `apps/forum_host/api_urls.py` add `PostListView` to the package-views import and the **identical** route.
+
+- [ ] **Step 7: Run the tests, verify they pass**
+
+Run: `cd backend && python -m pytest packages/wagtail_forum/wagtail_forum/tests/api/test_post_list.py apps/forum_host/tests/test_ratelimits.py -v`
+Expected: PASS. If the query-count assertion is off, read the captured queries and adjust the pin **with an explanation comment** — do not loosen to `<=`.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add backend/packages/wagtail_forum/wagtail_forum/api/ backend/apps/forum_host/api_urls.py \
+        backend/packages/wagtail_forum/wagtail_forum/tests/api/test_post_list.py
+git commit -m "feat(forum): add GET /topics/{id}/posts/ cursor-paginated post list"
+```
+
+---
+
+## Task 3: Extend search to post bodies (full parity)
+
+**Files:**
+
+- Modify: `backend/packages/wagtail_forum/wagtail_forum/api/views.py` (`SearchView`)
+- Test: `backend/packages/wagtail_forum/wagtail_forum/tests/api/test_search_sync.py`
+
+**Interfaces:**
+
+- Consumes: `Post.search_fields` (already declares `index.SearchField("body")`).
+- Produces: `GET /search/?q=` response shape `{"topics": [...], "posts": [...]}`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `backend/packages/wagtail_forum/wagtail_forum/tests/api/test_search_sync.py` (reuse that file's existing `_board`/user fixtures; if it lacks one, mirror the `_board()` helper from Task 1):
+
+```python
+@pytest.mark.django_db
+def test_search_returns_topics_and_posts():
+    board = _board()
+    author = User.objects.create_user(username="ada", password="x")
+    topic = Topic.objects.create(
+        board=board, title="Monstera care", slug="monstera", author=author, live=True
+    )
+    Post.objects.create(
+        topic=topic, author=author, is_opening_post=True, live=True,
+        body=[{"type": "paragraph", "value": "<p>watering a monstera</p>"}],
+    )
+
+    resp = APIClient().get("/forum/search/?q=monstera")
+
+    assert resp.status_code == 200
+    assert "topics" in resp.data and "posts" in resp.data
+    assert any(t["id"] == topic.id for t in resp.data["topics"])
+```
+
+(Ensure `Post` is imported in this test module.)
+
+- [ ] **Step 2: Run the test, verify it fails**
+
+Run: `cd backend && python -m pytest packages/wagtail_forum/wagtail_forum/tests/api/test_search_sync.py::test_search_returns_topics_and_posts -v`
+Expected: FAIL — `KeyError`/missing `posts` (current shape is `{"results": [...]}`).
+
+- [ ] **Step 3: Extend `SearchView`**
+
+Replace the `get` body of `SearchView` in `api/views.py` with topics + posts (keep `MAX_RESULTS`, `versioning_class = None`):
+
+```python
+    def get(self, request):
+        query = request.query_params.get("q", "").strip()
+        topics, posts = [], []
+        if query:
+            backend = get_search_backend()
+            boards = _visible_boards()
+            topic_hits = backend.search(
+                query, Topic.objects.filter(live=True, board__in=boards)
+            )
+            for t in topic_hits[: self.MAX_RESULTS]:
+                topics.append({"id": t.id, "slug": t.slug, "title": t.title})
+            post_hits = backend.search(
+                query,
+                Post.objects.filter(live=True, topic__live=True, topic__board__in=boards)
+                .select_related("topic"),
+            )
+            for p in post_hits[: self.MAX_RESULTS]:
+                posts.append(
+                    {
+                        "id": p.id,
+                        "topic_id": p.topic_id,
+                        "topic_title": p.topic.title,
+                        "excerpt": p.body.render_as_block()[:200] if p.body else "",
+                    }
+                )
+        return Response({"topics": topics, "posts": posts})
+```
+
+(`Post` is already imported in `views.py`.)
+
+- [ ] **Step 4: Run the tests, verify they pass**
+
+Run: `cd backend && python -m pytest packages/wagtail_forum/wagtail_forum/tests/api/test_search_sync.py -v`
+Expected: PASS (the new test + existing search/sync tests; the existing throttle test in `test_ratelimits.py` still gets a 200).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/packages/wagtail_forum/wagtail_forum/api/views.py \
+        backend/packages/wagtail_forum/wagtail_forum/tests/api/test_search_sync.py
+git commit -m "feat(forum): search returns topic + post hits (full parity)"
+```
+
+---
+
+## Task 4: `seed_default_forum` management command
+
+> **Mechanism note (deviation from the spec's "post_migrate" wording):** auto-seeding inside `post_migrate` creates a `ForumIndex(slug="forum")`/`ForumBoard(slug="general")` in **every test database**, which collides with the test suite's own `_board()` helpers (two `slug="general"` siblings → `_get_board` raises `Conflict` 409, breaking list/detail tests). A management command — idempotent, run on deploy like the existing `warm_moderation_cache` — gives the same "board out of the box" result without polluting tests. Run it in the release/deploy step and after local setup.
+
+**Files:**
+
+- Create: `backend/apps/forum_host/management/commands/seed_default_forum.py`
+- Create: `backend/apps/forum_host/management/__init__.py` and `.../commands/__init__.py` if absent
+- Test: `backend/apps/forum_host/tests/test_seed_command.py`
+
+**Interfaces:**
+
+- Produces: `python manage.py seed_default_forum` — ensures one `ForumIndex` + one `ForumBoard`, idempotently.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/apps/forum_host/tests/test_seed_command.py`:
+
+```python
+import pytest
+from django.core.management import call_command
+from wagtail_forum.models import ForumBoard, ForumIndex
+
+
+@pytest.mark.django_db
+def test_seed_default_forum_is_idempotent():
+    call_command("seed_default_forum")
+    call_command("seed_default_forum")  # second run must not duplicate
+    assert ForumIndex.objects.count() == 1
+    assert ForumBoard.objects.count() == 1
+    board = ForumBoard.objects.get()
+    assert board.live is True
+    assert board.slug == "general-discussion"
+```
+
+- [ ] **Step 2: Run the test, verify it fails**
+
+Run: `cd backend && python -m pytest apps/forum_host/tests/test_seed_command.py -v`
+Expected: FAIL — `CommandError: Unknown command 'seed_default_forum'`.
+
+- [ ] **Step 3: Implement the command**
+
+Create the package dirs if missing (`management/__init__.py`, `management/commands/__init__.py`), then `seed_default_forum.py`:
+
+```python
+from django.core.management.base import BaseCommand
+from wagtail.models import Page
+from wagtail_forum.models import ForumBoard, ForumIndex
+
+
+class Command(BaseCommand):
+    help = "Idempotently ensure a ForumIndex + a starter ForumBoard exist."
+
+    def handle(self, *args, **options):
+        index = ForumIndex.objects.first()
+        if index is None:
+            root = Page.objects.filter(depth=1).first()
+            index = root.add_child(
+                instance=ForumIndex(title="Forum", slug="forum")
+            )
+            self.stdout.write(self.style.SUCCESS("Created ForumIndex 'forum'."))
+
+        if not index.get_children().type(ForumBoard).exists():
+            index.add_child(
+                instance=ForumBoard(
+                    title="General Discussion",
+                    slug="general-discussion",
+                    description="Talk about anything plant-related.",
+                )
+            )
+            self.stdout.write(self.style.SUCCESS("Created board 'general-discussion'."))
+        else:
+            self.stdout.write("Forum already seeded; nothing to do.")
+```
+
+- [ ] **Step 4: Run the test, verify it passes**
+
+Run: `cd backend && python -m pytest apps/forum_host/tests/test_seed_command.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Document the deploy step**
+
+In `backend/CLAUDE.md`, under the "Cache warming (run after deploy…)" block, add a line:
+
+```bash
+python manage.py seed_default_forum    # ensure the forum has a default board (idempotent)
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/apps/forum_host/management backend/apps/forum_host/tests/test_seed_command.py backend/CLAUDE.md
+git commit -m "feat(forum): seed_default_forum idempotent board-seeding command"
+```
+
+---
+
+## Task 5: Rewrite the web client read contract (service + mappers + types)
+
+**Files:**
+
+- Modify: `web/src/services/forumMappers.ts`
+- Modify: `web/src/services/forumService.ts`
+- Modify: `web/src/types/forum.ts`
+- Test: `web/src/services/forumMappers.test.ts`, `web/src/services/forumService.test.ts`
+
+**Interfaces:**
+
+- Consumes (backend, this plan): `GET /boards/` → `{results: BackendBoard[]}`; `GET /boards/{slug}/topics/` → `{results, next, previous}`; `GET /topics/{id}/` → `BackendTopicDetail`; `GET /topics/{id}/posts/` → `{results, next, previous}`; `GET /search/?q=` → `{topics, posts}`.
+- Produces: `fetchCategories`, `fetchCategory(slug)`, `fetchThreads({board, cursor})`, `fetchThread(topicId)`, `fetchPosts({thread, cursor})`, `searchForum` — all returning the existing React domain types.
+
+- [ ] **Step 1: Replace the backend shapes + mappers**
+
+In `forumMappers.ts`, replace the machina `BackendForum`/`BackendTopic`/`BackendPost` interfaces and their mappers with the new API shapes. Key mappers:
+
+```typescript
+export interface BackendBoard {
+  id: number;
+  title: string;
+  slug: string;
+  description?: string;
+  topic_count?: number;
+  post_count?: number;
+}
+
+export interface BackendTopicListItem {
+  id: number;
+  title: string;
+  slug: string;
+  author: string | null;
+  is_pinned: boolean;
+  is_closed: boolean;
+  reply_count: number;
+  view_count: number;
+  last_post_at: string | null;
+  last_post_author: string | null;
+}
+
+export interface BackendBodyBlock { type: string; value: unknown; id: string }
+
+export interface BackendPost {
+  id: number;
+  topic_id: number;
+  author: { username: string; display_name?: string; trust_level?: string | null };
+  body: BackendBodyBlock[];
+  created_at: string;
+  updated_at?: string;
+  edited_at?: string | null;
+  is_opening_post: boolean;
+  status: 'live' | 'pending';
+  reaction_counts: Record<string, number>;
+  can_edit: boolean;
+  can_delete: boolean;
+}
+
+export function mapBoardToCategory(b: BackendBoard): Category {
+  return {
+    id: String(b.id),
+    name: b.title,
+    slug: b.slug,
+    description: b.description,
+    thread_count: b.topic_count ?? 0,
+    post_count: b.post_count ?? 0,
+    created_at: '',
+  };
+}
+```
+
+Write `mapTopicListItemToThread`, `mapTopicDetailToThread`, and `mapPostToPost` (carrying `body` blocks, `is_first_post = is_opening_post`, `reaction_counts`, `edited_at`). The full mapper bodies follow the field names above; keep the `[deleted]` author fallback when `author` is null.
+
+- [ ] **Step 2: Adjust `types/forum.ts`**
+
+Add `body?: BackendBodyBlock[]`-shaped field to `Post` for StreamField rendering (reuse the `StreamFieldBlock` type from `@/types/blog`); change `PaginatedResponse.meta` to carry cursor links (`next?: string | null; previous?: string | null` — already present; drop reliance on `count`). Remove machina-only types that no longer have a producer (`content_html` stays optional for back-compat in tests but is no longer populated).
+
+- [ ] **Step 3: Rewrite the read functions in `forumService.ts`**
+
+Point `FORUM_BASE` calls at the new paths:
+
+```typescript
+export async function fetchCategories(): Promise<Category[]> {
+  const data = await authenticatedFetch<{ results: BackendBoard[] }>(`${FORUM_BASE}/boards/`);
+  return (data.results || []).map(mapBoardToCategory);
+}
+export const fetchCategoryTree = fetchCategories;
+
+export async function fetchThreads(
+  options: { board?: string; cursor?: string } = {}
+): Promise<PaginatedResponse<Thread>> {
+  const { board, cursor } = options;
+  if (!board) throw new Error('A board slug is required');
+  const url = cursor || `${FORUM_BASE}/boards/${board}/topics/`;
+  const data = await authenticatedFetch<DrfPage<BackendTopicListItem>>(url);
+  return {
+    items: (data.results || []).map(mapTopicListItemToThread),
+    meta: { count: 0, next: data.next, previous: data.previous },
+  };
+}
+
+export async function fetchThread(topicId: number): Promise<Thread> {
+  const data = await authenticatedFetch<BackendTopicDetail>(`${FORUM_BASE}/topics/${topicId}/`);
+  return mapTopicDetailToThread(data);
+}
+
+export async function fetchPosts(
+  options: { thread: number; cursor?: string }
+): Promise<PaginatedResponse<Post>> {
+  const { thread, cursor } = options;
+  if (thread == null) throw new Error('Thread id is required');
+  const url = cursor || `${FORUM_BASE}/topics/${thread}/posts/`;
+  const data = await authenticatedFetch<DrfPage<BackendPost>>(url);
+  return {
+    items: (data.results || []).map((p) => mapPostToPost(p, String(thread))),
+    meta: { count: 0, next: data.next, previous: data.previous },
+  };
+}
+
+export async function searchForum(options: SearchForumOptions): Promise<SearchForumResponse> {
+  const { q } = options;
+  if (!q || q.trim() === '') throw new Error('Search query is required');
+  const params = new URLSearchParams({ q: q.trim() });
+  const data = await authenticatedFetch<{ topics: BackendSearchTopic[]; posts: BackendSearchPost[] }>(
+    `${FORUM_BASE}/search/?${params}`
+  );
+  const threads = (data.topics || []).map(mapSearchTopicToThread);
+  const posts = (data.posts || []).map(mapSearchPostToPost);
+  return { query: q.trim(), threads, posts, total_threads: threads.length,
+    total_posts: posts.length, has_next_threads: false, has_next_posts: false,
+    page: 1, page_size: threads.length + posts.length } as SearchForumResponse;
+}
+```
+
+Delete `fetchCategory(forumId: number)`'s id-scan and replace with a slug lookup over `fetchCategories()`. Leave the **write** functions (`createThread`, `createPost`, `updatePost`, `deletePost`, `toggleReaction`, image fns) untouched in this phase — Phase 2/3 rewrite them; they are not exercised by the read pages after Task 6.
+
+- [ ] **Step 4: Rewrite the service + mapper unit tests**
+
+Update `forumService.test.ts` and `forumMappers.test.ts` to assert the new request paths (`/boards/`, `/topics/{id}/`, `/topics/{id}/posts/`, `/search/`) and the new mapped shapes. Delete machina-shape assertions.
+
+- [ ] **Step 5: Run the tests + type-check**
+
+Run: `cd web && npm run test -- forumService forumMappers && npm run type-check`
+Expected: PASS, zero type errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add web/src/services/forumMappers.ts web/src/services/forumService.ts web/src/types/forum.ts \
+        web/src/services/forumMappers.test.ts web/src/services/forumService.test.ts
+git commit -m "feat(web/forum): migrate read service to wagtail_forum API contract"
+```
+
+---
+
+## Task 6: Update the forum read pages + PostCard rendering
+
+**Files:**
+
+- Modify: `web/src/pages/forum/CategoryListPage.tsx`
+- Modify: `web/src/pages/forum/ThreadListPage.tsx`
+- Modify: `web/src/pages/forum/ThreadDetailPage.tsx` (read paths only)
+- Modify: `web/src/pages/forum/SearchPage.tsx`
+- Modify: `web/src/components/forum/PostCard.tsx`
+- Test: the corresponding `*.test.tsx` files
+
+**Interfaces:**
+
+- Consumes: the Task 5 service functions and the `body` blocks on `Post`.
+
+- [ ] **Step 1: PostCard renders the StreamField body**
+
+In `PostCard.tsx`, replace the `sanitizedContent` `useMemo` + the `dangerouslySetInnerHTML` content `<div>` with the shared renderer:
+
+```tsx
+import StreamFieldRenderer from '../StreamFieldRenderer';
+// ...
+<div className="prose prose-sm sm:prose-base max-w-none mb-4 break-words ...">
+  <StreamFieldRenderer blocks={post.body} />
+</div>
+```
+
+Remove the now-unused `sanitizeHtml` import. (The `image` block case is Phase 3; Phase 1 bodies are heading/paragraph/quote/code, which `StreamFieldRenderer` already handles. An unknown `image` type would render the renderer's "Unsupported block type" placeholder — acceptable until Phase 3.)
+
+- [ ] **Step 2: Update the pages to the new service signatures**
+
+- `CategoryListPage.tsx`: unchanged call (`fetchCategoryTree()`), but it now resolves boards. Verify the empty-state renders when `results: []`.
+- `ThreadListPage.tsx`: change `fetchThreads({ category })` to `fetchThreads({ board: <categorySlug> })`; replace page-number "Load More" with cursor (`meta.next`) — keep a `nextCursor` state and pass it as `{ board, cursor: nextCursor }`.
+- `ThreadDetailPage.tsx`: `fetchThread(topicId)` + `fetchPosts({ thread: topicId })` unchanged in spirit; replace page-number pagination with cursor (`postsData.meta.next`); compute "remaining" from `thread.post_count` minus loaded. Leave reply/delete/react handlers in place but expect them to no-op against the unbuilt write endpoints until Phase 2 (or hide the compose UI behind a `// Phase 2` comment — do not delete).
+- `SearchPage.tsx`: consume `{ threads, posts }` from `searchForum` (shape unchanged from the existing `SearchForumResponse`).
+
+- [ ] **Step 3: Update the page tests**
+
+Adjust `CategoryListPage.test.tsx`, `ThreadListPage.test.tsx`, `ThreadDetailPage.test.tsx`, `SearchPage.test.tsx` mocks to the new service signatures and assert: boards render, a thread's StreamField body renders (mock `post.body = [{type:'paragraph', value:'<p>hi</p>', id:'1'}]` and assert the text appears), cursor "Load More" calls the service with `{ cursor }`.
+
+- [ ] **Step 4: Run the full web test suite + gates**
+
+Run: `cd web && npm run type-check && npm run lint && npm run test`
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/src/pages/forum web/src/components/forum/PostCard.tsx
+git commit -m "feat(web/forum): render boards/threads/posts against the new read API"
+```
+
+---
+
+## Task 7: End-to-end verification against a local backend
+
+**Files:** none (manual verification).
+
+- [ ] **Step 1: Seed + run the backend**
+
+```bash
+cd backend && source venv/bin/activate
+python manage.py migrate
+python manage.py seed_default_forum
+python manage.py runserver
+```
+
+- [ ] **Step 2: Create content**
+
+In `/cms/`, create one `Topic` with an opening `Post` under "General Discussion" (or via the topic-create API). Publish it.
+
+- [ ] **Step 3: Run the web app and confirm the error is gone**
+
+```bash
+cd web && npm run dev   # http://localhost:5174
+```
+
+Visit `/forum`: the board list renders (no "Error loading categories"). Click the board → thread list → a thread → posts render with the StreamField body. Run a search and confirm topic + post hits appear.
+
+- [ ] **Step 4: Confirm the backend suite is green**
+
+Run: `cd backend && python -m pytest packages/wagtail_forum apps/forum_host -q`
+Expected: PASS (new endpoints, parity guard, seeding, search, plus the pre-existing forum suite).
+
+---
+
+## Self-Review
+
+**Spec coverage (Phase 1 rows):** topic-detail (Task 1) ✓; post-list + StreamField body + `assertNumQueries` (Task 2) ✓; `versioning_class = None` (every view, Global Constraints + each view) ✓; host wrappers + parity test (Tasks 1–2) ✓; full-parity search topics+posts (Task 3) ✓; board auto-seed (Task 4, as a command — deviation flagged) ✓; client read rewrite, boards-by-slug/topics-by-id, cursor pagination, `grep categories/` empties (Tasks 5–6) ✓; `PostCard` → `StreamFieldRenderer` (Task 6) ✓; `expand_db_html` + `nh3` N+1 guard via pinned query count (Task 2) ✓; error-status surfacing — the new JSON-returning endpoints remove the HTML-404 "Request failed" path (intrinsic to Tasks 1–2). Deferred to Phase 2/3 (correctly absent): writes, edit/delete, images, route rationalization.
+
+**Placeholder scan:** no TBD/TODO; every code step carries real code; query-count pins are exact with explanation comments.
+
+**Type consistency:** `serialize_forum_body` → `[{type,value,id}]` consumed by `StreamFieldRenderer` (`block.type`/`block.value`); `PostSerializer.body` (method) → same shape; client `BackendPost.body` → `mapPostToPost` → `Post.body` → `StreamFieldRenderer`. `post-list`/`topic-detail` route names match between `api/urls.py` and `forum_host/api_urls.py` (parity test enforces). `fetchThreads({board, cursor})` / `fetchPosts({thread, cursor})` signatures match their callers in Task 6.
+
+**Open items intentionally deferred to the plan's execution, not blockers:** `trust_level` in `PostAuthorSerializer` returns `None` until a `ForumProfile` join is added (a later plan); `edited_by` omitted (no model field).

--- a/docs/superpowers/specs/2026-06-20-forum-spec2-read-write-client-design.md
+++ b/docs/superpowers/specs/2026-06-20-forum-spec2-read-write-client-design.md
@@ -1,0 +1,314 @@
+# Forum Spec 2 — Read/Write API + Web Client Migration — Design
+
+- **Date:** 2026-06-20
+- **Status:** Approved (brainstorming) — ready for implementation planning
+- **Scope:** Web only. Build the missing `wagtail_forum` read/write endpoints and
+  migrate the React web forum client off the retired machina dialect to the new
+  API, at **full feature parity** with today's (broken) UI.
+- **Tracks:** todo `231-pending-p1-forum-spec2-read-api-web-client.md`
+  (forum audit finding **H4**); design Spec 1 =
+  `2026-06-06-wagtail-native-forum-package-design.md` (which named this as "Spec 2").
+- **Author:** Brainstorming session (William + Claude)
+
+## Background
+
+The forum was rebuilt as a Wagtail-native package (`wagtail_forum`, host
+`apps/forum_host`) in Spec 1; machina was retired. Spec 1 was **backend only** and
+explicitly deferred updating the React/Flutter clients to "Spec 2." That deferral
+was never done, so the **deployed web forum is 100% broken**.
+
+Verified against production (`plantidcommunity-production.up.railway.app`) on
+2026-06-20:
+
+- `GET /api/v1/forum/boards/` → **200** `{"results":[]}` — new API is live and healthy.
+- `GET /api/v1/forum/categories/` → **404 (HTML body)** — the path the web client
+  still calls.
+
+The visible symptom on `houseplant-md.com/forum` is **"Error loading categories:
+Request failed."** Mechanism: `CategoryListPage` → `fetchCategoryTree()` →
+`GET …/forum/categories/` returns a 404 with an HTML body; `authenticatedFetch`
+(`web/src/services/forumService.ts:55-58`) sees `!response.ok`, `response.json()`
+throws on the HTML, and the `.catch(() => ({ message: 'Request failed' }))`
+fallback surfaces the generic error. Every other forum page fails the same way.
+
+### Root cause
+
+The deployed web client (`forumService.ts`) speaks the **retired machina dialect**
+(`categories/`, `topics/<id>/`, `posts/?topic=`, `posts/<id>/delete/`, …). The new
+`wagtail_forum` API serves a different surface (`boards/`, `boards/<slug>/topics/`,
+…) and is **missing** the read endpoints the client needs (topic detail, post
+list) and several write endpoints (post edit, delete, image upload).
+
+## Goal
+
+A working web forum at parity with the current UI's feature set:
+
+- Browse: boards → threads (per board) → thread detail with posts.
+- Compose: create topic, reply, edit own post, delete own post.
+- React: toggle reactions, see counts + the current user's active reactions.
+- Images: upload and display inline post images.
+- Search: topics + posts (post bodies indexed for full parity).
+- No machina paths remain: `grep -r "categories/" web/src/services/` is empty.
+
+## Non-Goals / Out of Scope (named, not silently dropped)
+
+- **Flutter forum client** — `plant_community_mobile/lib/features/forum/forum_screen.dart`
+  is an explicit stub ("live posting is not yet implemented", hardcoded sample
+  posts). There is no real Flutter forum client to migrate; building one is a
+  **separate future spec**.
+- **Public profiles** (`GET /users/{id}/profile/`) — only `/me/profile/` exists;
+  not required for parity. Deferred.
+- **Delta-sync hardening** — compound `(updated_at, id)` cursor and soft-delete
+  tombstones (todo 231 sub-items) are backend-internal to `/sync/`, not used by
+  the web client. Deferred; remain tracked under todo 231.
+- **Post preview** — deferred in Spec 1; unchanged here.
+- **WebSockets / real-time** — unchanged from Spec 1.
+
+## Architecture & invariants
+
+The forum is a **reusable, zero-plant-coupling package** mounted by a thin host:
+
+- Package endpoints live in `backend/packages/wagtail_forum/wagtail_forum/api/`
+  (`views.py`, `urls.py`, `serializers.py`, `pagination.py`, `sanitize.py`,
+  `idempotency.py`, `exceptions.py`).
+- The host (`backend/apps/forum_host/`) re-mounts each package route via a
+  **rate-limited wrapper** (`api.py` + `api_urls.py`) so throttling lives in the
+  app, not the reusable core.
+- A **route-parity test** (`apps/forum_host/tests/test_ratelimits.py`) asserts the
+  host and package route sets stay identical — a new package endpoint that is not
+  host-wrapped fails CI. **Every new endpoint below must be added in both places
+  and keep this test green.**
+- Auth: DRF `DEFAULT_AUTHENTICATION_CLASSES` lead with
+  `apps.users.authentication.CookieJWTAuthentication`, so the web cookie-JWT
+  session authenticates write endpoints (`IsAuthenticated`) with no Bearer header.
+  Mutating requests already send `X-CSRFToken` + `credentials: 'include'`.
+- **Versioning:** every existing forum view sets `versioning_class = None` because
+  the host mounts the package under a `NamespaceVersioning` `v1` namespace that
+  would otherwise 404 the package's own routes. **Every new view below MUST set
+  `versioning_class = None`** — omitting it is a silent 404.
+
+No plant imports may be added to the package core (a package test runs against a
+minimal settings module to prove zero coupling).
+
+## Implementation phases
+
+Sequenced so the production error dies first, at lowest risk (the read path is
+public — that is why `/boards/` already 200s without auth).
+
+### Phase 1 — Read path (removes the live error)
+
+**New package endpoints (+ host wrappers + parity test):**
+
+| Endpoint | View | Notes |
+|---|---|---|
+| `GET /topics/{id}/` | `TopicDetailView` | Live topic on a visible board, else 404. Returns detail serializer (below). |
+| `GET /topics/{id}/posts/` | `PostListView` | Cursor pagination (mirrors `TopicListView`); ordered `created_at, id`. |
+
+**Visibility** mirrors the existing guards (`_visible_boards()` = `.live().public()`;
+topic `live=True`): a hidden/draft topic or one on a restricted/non-live board is
+**404**, never 403 (no existence leak) — consistent with `ReplyCreateView`.
+
+**`TopicDetailSerializer`** (read): `id, title, slug, board {id, slug, title},
+author, is_pinned, is_closed, locked, reply_count, view_count, created_at,
+last_post_at, opening_post_id`. Denormalized counters only — no joins to
+`_revisions`/`workflow_states` (preserve the mobile-cheap-read invariant).
+
+**`PostSerializer`** (read): `id, topic_id, author {username, display_name,
+trust_level}, body (StreamField JSON, see §Body), created_at, updated_at,
+edited_at (nullable), edited_by (username/display_name, nullable), is_opening_post,
+status (live|pending), reaction_counts, can_edit, can_delete (capability flags
+computed for request.user)`. No `reacted_by_me` — `PostCard.tsx` renders reaction
+*counts* only and does not highlight the user's own reactions, so per-user reaction
+state is unused at parity (a `my_reactions: string[]` field for active-reaction
+highlighting is a deferred enhancement).
+
+**Pinned `assertNumQueries`** on the post-list endpoint proves the denormalized-read
+claim and guards N+1 (reactions/author must not fan out per post).
+
+**Client (Phase 1):** rewrite the read side of `forumService.ts` +
+`forumMappers.ts` + `types/forum.ts`; update `CategoryListPage`, `ThreadListPage`,
+`ThreadDetailPage` (read render), `SearchPage`. Cursor pagination replaces
+page-number ("Load More" follows the `next` cursor; "remaining" derives from the
+topic's `reply_count`). Boards route by **slug**, topics by **id**. `PostCard.tsx`
+moves from `sanitizeHtml(content_raw)` + `dangerouslySetInnerHTML` to rendering the
+StreamField `body` via the extended `StreamFieldRenderer` (§Body); it already reads
+`edited_at`/`edited_by`, which the new `PostSerializer` provides.
+
+**Board seeding (decided — auto-seed):** `forum_host` bootstrap (`bootstrap.py`,
+`post_migrate`) today seeds only the moderation workflow + "Forum Moderators"
+group — **no `ForumBoard`** — so a freshly-migrated forum is empty and `/forum`
+renders "No categories available yet." Extend the host bootstrap to idempotently
+ensure a `ForumIndex` page + one starter `ForumBoard` ("General Discussion") so
+Phase 1 renders real content and tests have a board. Seeding lives in `forum_host`
+(the app), **not** the reusable package core. Plan must settle page-tree placement
+(parent page / site root, locale, treebeard `add_child`) and idempotency. This is
+part of Phase 1's definition-of-done — without it, the empty state is
+indistinguishable from a bug.
+
+**Search (decided — full parity, topics + posts):** the existing `SearchView`
+indexes/searches topic titles only and returns `{results:[{id,slug,title}]}`; the
+current `SearchPage` expects topic **and** post hits. Extend the backend: add
+`index.Indexed` + `search_fields` on `Post` (body), search across live topics +
+posts (on visible boards), and return `{topics:[...], posts:[...]}` with serialized
+hits (post hit: `id, topic_id, excerpt, author`). Bound + query-count-pin the
+search path. Client `searchForum` maps the new shape to the existing
+`SearchForumResponse`.
+
+### Phase 2 — Write path
+
+**Route rationalization** (do now — no consumer depends on these yet; parity test
+guards it):
+
+- `POST /boards/{slug}/topics/create/` → **`POST /boards/{slug}/topics/`**
+- `POST /topics/{id}/posts/create/` → **`POST /topics/{id}/posts/`**
+
+(`TopicListView`/`PostListView` keep `GET` on the same collection paths; the create
+views take `POST`. Rename view route names + host wrappers + parity test + the
+existing forum_host rate-limit tests in lockstep.)
+
+**New package endpoints (+ host wrappers + parity test):**
+
+| Endpoint | View | Notes |
+|---|---|---|
+| `PATCH /posts/{id}/` | `PostUpdateView` | Author (or moderator) edits own post → new `RevisionMixin` revision; re-runs `validate_forum_body`; rejects if topic `is_closed`/`locked` (409); 404 on hidden; 403 on not-author/non-mod. Sets `edited=True`. |
+| `DELETE /posts/{id}/` | `PostDeleteView` | Author (or moderator) soft-deletes; recounts topic `reply_count`. Opening-post rule: see Open Questions. |
+
+Wire the client write side: create topic, reply, edit, delete — onto the
+**existing** `TopicCreateView`/`ReplyCreateView`/`ReactionToggleView` plus the two
+new write views. Reactions: the toggle endpoint already exists; adapt the client to
+its `{reaction_counts, reacted}` response and drive UI from the post's
+`reaction_counts`.
+
+**De-risk first (before building the composer):** prototype the
+TipTap-HTML → `paragraph` `RichTextBlock` value → `expand_db_html()` round-trip on
+a throwaway spike. Wagtail's stored rich-text DB format is not identical to editor
+output HTML; `bold`/`italic`/`ol`/`ul`/`code`/external-`link` should round-trip,
+but confirm nothing corrupts silently through `to_python`/`expand_db_html` before
+committing the composer design. This is the Phase 2 long pole and where scope can
+grow.
+
+### Phase 3 — Images
+
+**New package endpoint (+ host wrapper + parity test):**
+
+| Endpoint | View | Notes |
+|---|---|---|
+| `POST /topics/{id}/images/` | `PostImageUploadView` | 4-layer-validated upload (extension, MIME, size, PIL — `backend/docs/patterns/security/file-upload.md`) into a **forum-scoped Wagtail collection**; returns `{id, renditions}`. `IsAuthenticated`. |
+
+**Relax `validate_forum_body`** (`api/sanitize.py:96-106` currently rejects all
+chooser/image blocks): accept an `image` block **only if** its id references an
+image in the forum collection (collection-membership check) — closes the IDOR /
+nonexistent-id holes the current hard rejection guards against. All other chooser
+types stay rejected.
+
+**Read render:** the `image` block serializes to renditions (srcset-style); add an
+`image` case to the web `StreamFieldRenderer` (it was removed; line 94). On read,
+inline images come back inside the body StreamField — no separate attachments call.
+
+> Image model note: Spec 1 models inline images as `ImageChooserBlock` inside the
+> body StreamField (Wagtail Image → renditions), **not** a separate per-post
+> attachment model (the machina `ForumPostImage` shape the old client used). The
+> client's compose flow therefore changes from "attach files to a post" to "insert
+> an image block into the body."
+
+## Body serialization & rendering (cross-cutting)
+
+The post body is **StreamField JSON** on read and write — the package already
+mandates this (`TopicCreateSerializer.body`/`ReplyCreateSerializer.body` are
+`JSONField` validated by `validate_forum_body`; the machina client sent an HTML
+string, which the new API rejects).
+
+- **Block set** (`ForumBodyBlock`): `heading` (text), `paragraph` (RichText:
+  bold/italic/link/ol/ul/code), `quote`, `code` (language + code), `image`.
+- **Read:** serialize the body as a list of `{type, value}` blocks. The
+  `paragraph` block's value is rendered through Wagtail `expand_db_html()` so the
+  link rewriter runs (SECURITY note in `blocks.py:18-21`) — **never** raw
+  `value.source`. Text blocks (`heading`/`quote`/`code`) stay text-by-contract.
+  - **`expand_db_html` query cost:** internal *page*/document links would make
+    `expand_db_html` do a per-link DB lookup → a hidden N+1 across a page of posts,
+    exactly where the post-list `assertNumQueries` is pinned. This is neutralized
+    by the existing write-path sanitizer: `nh3`'s `ALLOWED_ATTRIBUTES` for `<a>` is
+    `{href, title}` only (`api/sanitize.py:26`), so Wagtail's `linktype="page"`/`id`
+    attributes are stripped on write — no internal-link markup survives for
+    `expand_db_html` to resolve. The pinned `assertNumQueries` must **verify** this
+    holds (it is the guardrail, not just an assumption); if a future change admits
+    internal links, restrict the `paragraph` `link` feature to external-only.
+- **Render (web):** reuse the shared `StreamFieldRenderer` — it already handles
+  `heading`/`paragraph`/`quote`/`code` (forum `code` = `{language, code}` matches;
+  forum `quote` = string is handled by its string-or-struct branch). **Add an
+  `image` case.** `paragraph` HTML is DOMPurify-sanitized at render
+  (`SANITIZE_PRESETS.STREAMFIELD`) on top of server-side `nh3` on write
+  (defense-in-depth).
+- **Write/compose:** the composer emits forum-safe block JSON. Minimum viable:
+  wrap rich text as `[{type:'paragraph', value:'<p>…</p>'}]`; images add
+  `{type:'image', value:<image_id>}` blocks after upload. Replaces the TipTap→HTML
+  output. `nh3` server-side sanitization (`sanitize_rich_text`) is the trust
+  boundary — direct API POSTs bypass any editor filtering.
+
+## Error handling
+
+The client must surface real backend statuses instead of the generic "Request
+failed": **404** (hidden/missing), **409** (closed/locked topic; idempotency twin
+in-flight), **422** (idempotency key reused with a different payload), **429**
+(throttled — host wrappers; CLAUDE.md gotcha #4 requires 429 not 403), **400**
+(validation). `authenticatedFetch` already prefers `error.message`/`error.detail`;
+the new views return JSON error bodies so the parse path no longer falls through to
+the "Request failed" string.
+
+## Testing strategy
+
+Per CLAUDE.md testing rules — **no DB mocks**, real Postgres + real Wagtail
+revision/workflow machinery.
+
+**Backend:**
+
+- `assertNumQueries` pinned on `GET /topics/{id}/posts/` and `GET /topics/{id}/`
+  (denormalized-read + N+1 guard; reactions/author must not fan out per post).
+- Visibility: hidden/draft topic, restricted/non-live board → 404 on detail, post
+  list, edit, delete, upload.
+- Edit: author edits → new revision + `edited=True`; non-author → 403; locked/closed
+  topic → 409; malformed body → 400 (not 500).
+- Delete: author/moderator soft-deletes; `reply_count` recounted; opening-post rule
+  enforced (per resolved Open Question).
+- Images: 4-layer validation rejects bad uploads; **collection-validation test** —
+  an `image` block referencing an out-of-collection / nonexistent id is rejected
+  (IDOR guard); a valid forum-collection image round-trips through body validation.
+- Search: topic-title **and** post-body hits returned; results scoped to visible
+  boards + live content; query-count pinned.
+- Board seeding: `forum_host` bootstrap idempotently creates `ForumIndex` + the
+  starter `ForumBoard` (running `migrate` twice does not duplicate).
+- **Route-parity test green** after every route add/rename; forum_host rate-limit
+  tests updated for renamed routes.
+- Package zero-coupling test still passes (no plant imports added to core).
+
+**Web:**
+
+- `forumService` + `forumMappers` unit tests rewritten to the new contract;
+  machina-shape tests deleted.
+- Page tests: `CategoryListPage` renders boards (and the empty state when
+  `{"results":[]}`), `ThreadDetailPage` renders a StreamField body **including an
+  image block**, compose/edit/delete/react flows, cursor "Load More".
+- Type-check + ESLint + Vitest green (web CI gates).
+
+## Open questions for implementation planning
+
+1. **Opening-post delete:** does `DELETE` on an `is_opening_post` post delete the
+   whole topic (cascade) or get rejected (409, "delete the topic instead")?
+   Leaning **reject** for v1 (simpler; topic-delete is not in scope).
+2. **Edit re-moderation:** does a low-trust author editing a live post re-enter the
+   moderation workflow (new revision → re-`submit_for_moderation`) or publish in
+   place? Leaning **publish in place for trusted authors; flag for moderation only
+   if the spam backend trips** — settle against `workflow.py` semantics in the plan.
+3. **Soft-delete field — is one even needed?** `Post` has `DraftStateMixin` and
+   `PostListView` filters `live=True`, so *unpublishing* a post (`live=False`)
+   already hides it with no new field/migration. A dedicated field
+   (`deleted_at`/`is_removed`) is justified **only** to distinguish a *deleted* post
+   from a *pending-moderation* post — both are `live=False`. This couples to a
+   sub-decision: does `PostListView` show an author their own `pending` post
+   ("awaiting approval", per Spec 1's mobile principle)? If yes, "deleted" and
+   "pending" must be distinguishable → add the field; if the list only ever shows
+   `live=True` posts, unpublish-to-delete suffices and **no field is added**.
+   Resolve both together in the plan; do not add the field by default.
+4. **View-count increment:** does `GET /topics/{id}/` bump `view_count`? If so,
+   do it without breaking the detail endpoint's `assertNumQueries` (single UPDATE)
+   and guard against double-count on the client's parallel detail+posts fetch.

--- a/todos/231-pending-p1-forum-spec2-read-api-web-client.md
+++ b/todos/231-pending-p1-forum-spec2-read-api-web-client.md
@@ -83,3 +83,41 @@ tracked it; this todo is that tracker.
 
 - Filed from forum audit H4 (+ L10, sync-cursor note) during Phase 4 deferral;
   everything else from the audit was fixed in the audit branch.
+
+### 2026-06-21 - Phase 1 (read path) landed — todo still OPEN (Phase 2/3 remain)
+
+Spec + plan: `docs/superpowers/specs/2026-06-20-forum-spec2-read-write-client-design.md`,
+`docs/superpowers/plans/2026-06-20-forum-spec2-phase1-read-path.md`. Branch
+`feat/forum-spec2-web-client` (subagent-driven execution, 8 tasks, each reviewed).
+
+**Done in Phase 1:**
+
+- Backend read endpoints: `GET /topics/{id}/` (topic-detail) + `GET /topics/{id}/posts/`
+  (cursor-paginated) with `expand_db_html()` body serialization and EXACT query-count
+  pins. Search extended to topics + posts (full parity) — required adding
+  `index.RelatedFields("topic", [live, board_id])` to `Post.search_fields` so the DB
+  backend can visibility-filter post hits. `seed_default_forum` idempotent command.
+  Route-parity guard green; forum backend suite 114 passed.
+- Web read client rewritten to the new contract (boards/topics/posts/search); machina
+  read paths gone; post bodies render via `StreamFieldRenderer`. Thread view is
+  **read-only for Phase 1** (reply/react/delete controls hidden behind a "coming soon"
+  notice — user-approved) since the write endpoints are Phase 2. Web suite green.
+
+**Still open (do NOT close this todo):**
+
+- Phase 2: write path (create/edit/delete post, reactions) + re-enable the write UI;
+  `grep categories/ web/src/services/` still hits the un-rewritten `createThread`.
+- Phase 3: image upload + rendition serialization (chooser blocks still rejected on the
+  API path); add the `image` case back to `StreamFieldRenderer`.
+- Compound `(updated_at, id)` sync cursor + same-timestamp livelock test (kimi note).
+- Route rationalization (audit L10): verb-style create routes + mixed slug/id identifiers.
+
+**Phase 1 tech-debt follow-ups (small):**
+
+- topic-detail query pin is N=4 and includes a redundant Q4
+  (`SELECT id, topic_id FROM post WHERE id=… LIMIT 21`) — a refetch of the opening post
+  already found by `get_opening_post_id`. Constant-cost; eliminate when convenient.
+- New DRF views are auto-schema'd (spectacular warnings, non-gating). "schema-annotated"
+  acceptance wants `@extend_schema`/`@extend_schema_field` + `swagger_fake_view` guards.
+- Deploy: confirm `seed_default_forum` runs in the Railway release step (not just
+  documented in `backend/CLAUDE.md`) so prod isn't error-free-but-empty.

--- a/web/src/components/forum/PostCard.test.tsx
+++ b/web/src/components/forum/PostCard.test.tsx
@@ -75,24 +75,32 @@ describe('PostCard', () => {
     expect(screen.queryByText('Original Post')).not.toBeInTheDocument();
   });
 
-  it('sanitizes HTML content to prevent XSS', () => {
+  it('renders StreamField body blocks and sanitizes HTML to prevent XSS', () => {
     const post = createMockPost({
-      content_raw: '<p>Safe content</p><script>alert("xss")</script>',
+      body: [
+        { id: '1', type: 'paragraph', value: '<p>Safe content</p><script>alert("xss")</script>' },
+      ],
     });
 
     const { container } = renderPostCard(post);
 
-    // Should render safe content
+    // Should render the text content from the paragraph block
     expect(screen.getByText('Safe content')).toBeInTheDocument();
 
-    // Should NOT render script tag
+    // StreamFieldRenderer sanitizes via DOMPurify — script tags must not appear
     const scripts = container.querySelectorAll('script');
     expect(scripts.length).toBe(0);
   });
 
-  it('allows safe HTML tags (paragraphs, bold, links)', () => {
+  it('renders StreamField paragraph body with safe HTML elements', () => {
     const post = createMockPost({
-      content_raw: '<p>Test <strong>bold</strong> and <a href="#">link</a></p>',
+      body: [
+        {
+          id: '1',
+          type: 'paragraph',
+          value: '<p>Test <strong>bold</strong> and <a href="#">link</a></p>',
+        },
+      ],
     });
 
     const { container } = renderPostCard(post);

--- a/web/src/components/forum/PostCard.test.tsx
+++ b/web/src/components/forum/PostCard.test.tsx
@@ -15,12 +15,14 @@ vi.mock('../../contexts/AuthContext', () => ({
 }));
 
 /**
- * Helper to render PostCard with Router context
+ * Helper to render PostCard with Router context.
+ * Passes onEdit/onDelete/onReact by default so display tests stay unaffected
+ * by the handler-presence guards.
  */
-function renderPostCard(post, onEdit = vi.fn(), onDelete = vi.fn()) {
+function renderPostCard(post, onEdit = vi.fn(), onDelete = vi.fn(), onReact = vi.fn()) {
   return render(
     <BrowserRouter>
-      <PostCard post={post} onEdit={onEdit} onDelete={onDelete} />
+      <PostCard post={post} onEdit={onEdit} onDelete={onDelete} onReact={onReact} />
     </BrowserRouter>
   );
 }
@@ -146,7 +148,7 @@ describe('PostCard', () => {
     expect(screen.queryByText(/edited/i)).not.toBeInTheDocument();
   });
 
-  it('renders reaction counts with emojis', () => {
+  it('renders reaction counts with emojis when onReact is provided', () => {
     const post = createMockPost({
       reaction_counts: {
         like: 5,
@@ -168,14 +170,14 @@ describe('PostCard', () => {
     expect(screen.getByText('1')).toBeInTheDocument();
   });
 
-  it('always renders the four reaction buttons, defaulting counts to 0', () => {
+  it('renders the four reaction buttons when onReact is provided, defaulting counts to 0', () => {
     const post = createMockPost({
       reaction_counts: {},
     });
 
     renderPostCard(post);
 
-    // All four reaction buttons render so a user can add a first reaction.
+    // All four reaction buttons render when handler is present.
     expect(screen.getByLabelText('React like')).toBeInTheDocument();
     expect(screen.getByLabelText('React love')).toBeInTheDocument();
     expect(screen.getByLabelText('React helpful')).toBeInTheDocument();
@@ -183,7 +185,7 @@ describe('PostCard', () => {
     expect(screen.getAllByText('0')).toHaveLength(4);
   });
 
-  it('shows each reaction type with its count (0 when absent)', () => {
+  it('shows each reaction type with its count (0 when absent) when onReact is provided', () => {
     const post = createMockPost({
       reaction_counts: {
         like: 0,
@@ -195,6 +197,21 @@ describe('PostCard', () => {
 
     expect(screen.getByLabelText('React love')).toHaveTextContent('2');
     expect(screen.getByLabelText('React like')).toHaveTextContent('0');
+  });
+
+  it('hides reaction buttons when onReact is not provided', () => {
+    const post = createMockPost({ reaction_counts: { like: 5 } });
+
+    render(
+      <BrowserRouter>
+        <PostCard post={post} />
+      </BrowserRouter>
+    );
+
+    expect(screen.queryByLabelText('React like')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('React love')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('React helpful')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('React thanks')).not.toBeInTheDocument();
   });
 
   it('calls onReact with the post id and reaction type when clicked', async () => {
@@ -255,7 +272,7 @@ describe('PostCard', () => {
     expect(screen.getByText('p')).toBeInTheDocument();
   });
 
-  it('edit and delete buttons are in the DOM for the post owner without hover', () => {
+  it('edit and delete buttons are in the DOM for the post owner when handlers are provided', () => {
     vi.mocked(useAuth).mockReturnValueOnce({
       user: { id: 1, email: 'owner@example.com', is_staff: false, is_moderator: false },
       isAuthenticated: true,
@@ -276,5 +293,31 @@ describe('PostCard', () => {
     // Buttons must be in the DOM regardless of hover state (CSS hides them on md+).
     expect(screen.getByTitle('Edit post')).toBeInTheDocument();
     expect(screen.getByTitle('Delete post')).toBeInTheDocument();
+  });
+
+  it('hides edit and delete buttons for the post owner when no handlers are provided', () => {
+    vi.mocked(useAuth).mockReturnValueOnce({
+      user: { id: 1, email: 'owner@example.com', is_staff: false, is_moderator: false },
+      isAuthenticated: true,
+      isLoading: false,
+      error: null,
+      login: vi.fn(),
+      logout: vi.fn(),
+      signup: vi.fn(),
+      clearError: vi.fn(),
+    });
+
+    const post = createMockPost({
+      author: { id: 1, username: 'owner', email: '', display_name: 'Owner', trust_level: 'member' },
+    });
+
+    render(
+      <BrowserRouter>
+        <PostCard post={post} />
+      </BrowserRouter>
+    );
+
+    expect(screen.queryByTitle('Edit post')).not.toBeInTheDocument();
+    expect(screen.queryByTitle('Delete post')).not.toBeInTheDocument();
   });
 });

--- a/web/src/components/forum/PostCard.tsx
+++ b/web/src/components/forum/PostCard.tsx
@@ -1,7 +1,7 @@
 import { memo, useMemo } from 'react';
 import { formatDistanceToNow } from 'date-fns';
-import { sanitizeHtml, SANITIZE_PRESETS } from '../../utils/sanitize';
 import { useAuth } from '../../contexts/AuthContext';
+import StreamFieldRenderer from '../StreamFieldRenderer';
 import type { Post } from '@/types';
 
 interface PostCardProps {
@@ -46,11 +46,6 @@ function PostCard({ post, onEdit, onDelete, onReact }: PostCardProps) {
       return 'recently';
     }
   }, [post.created_at]);
-
-  // Sanitize content for display
-  const sanitizedContent = useMemo(() => {
-    return sanitizeHtml(post.content_raw, SANITIZE_PRESETS.FORUM);
-  }, [post.content_raw]);
 
   return (
     <div
@@ -127,10 +122,9 @@ function PostCard({ post, onEdit, onDelete, onReact }: PostCardProps) {
       </div>
 
       {/* Post Content */}
-      <div
-        className="prose prose-sm sm:prose-base max-w-none mb-4 break-words prose-pre:overflow-x-auto prose-img:max-w-full prose-img:h-auto prose-table:block prose-table:overflow-x-auto dark:prose-invert"
-        dangerouslySetInnerHTML={{ __html: sanitizedContent }}
-      />
+      <div className="mb-4 break-words">
+        <StreamFieldRenderer blocks={post.body} />
+      </div>
 
       {/* Reactions — always show the four reaction buttons so a user can add a
           first reaction; counts default to 0 when none exist yet. */}

--- a/web/src/components/forum/PostCard.tsx
+++ b/web/src/components/forum/PostCard.tsx
@@ -100,23 +100,28 @@ function PostCard({ post, onEdit, onDelete, onReact }: PostCardProps) {
           </div>
         </div>
 
-        {/* Actions (edit/delete) — always visible on mobile, fade in on desktop hover */}
-        {canEdit && (
+        {/* Actions (edit/delete) — shown only when handlers are provided (Phase 2 write UI).
+            Always visible on mobile, fade in on desktop hover. */}
+        {canEdit && (onEdit || onDelete) && (
           <div className="flex gap-2 md:opacity-0 md:group-hover:opacity-100 transition-opacity">
-            <button
-              onClick={() => onEdit?.(post)}
-              className="min-h-11 px-3 py-1 text-sm text-sky hover:bg-sky/10 rounded inline-flex items-center"
-              title="Edit post"
-            >
-              ✏️ Edit
-            </button>
-            <button
-              onClick={() => onDelete?.(post)}
-              className="min-h-11 px-3 py-1 text-sm text-error hover:bg-error/10 rounded inline-flex items-center"
-              title="Delete post"
-            >
-              🗑️ Delete
-            </button>
+            {onEdit && (
+              <button
+                onClick={() => onEdit(post)}
+                className="min-h-11 px-3 py-1 text-sm text-sky hover:bg-sky/10 rounded inline-flex items-center"
+                title="Edit post"
+              >
+                ✏️ Edit
+              </button>
+            )}
+            {onDelete && (
+              <button
+                onClick={() => onDelete(post)}
+                className="min-h-11 px-3 py-1 text-sm text-error hover:bg-error/10 rounded inline-flex items-center"
+                title="Delete post"
+              >
+                🗑️ Delete
+              </button>
+            )}
           </div>
         )}
       </div>
@@ -126,23 +131,24 @@ function PostCard({ post, onEdit, onDelete, onReact }: PostCardProps) {
         <StreamFieldRenderer blocks={post.body} />
       </div>
 
-      {/* Reactions — always show the four reaction buttons so a user can add a
-          first reaction; counts default to 0 when none exist yet. */}
-      <div className="flex gap-3 pt-4 border-t border-line">
-        {REACTION_TYPES.map((type) => (
-          <button
-            key={type}
-            type="button"
-            onClick={() => onReact?.(post.id, type)}
-            className="inline-flex items-center gap-1 min-h-11 px-3 py-1 bg-surface-2 hover:bg-surface-3 rounded-full text-sm transition-colors"
-            aria-label={`React ${type}`}
-            title={`React ${type}`}
-          >
-            <span>{getReactionEmoji(type)}</span>
-            <span className="font-medium">{post.reaction_counts?.[type] ?? 0}</span>
-          </button>
-        ))}
-      </div>
+      {/* Reactions — shown only when an onReact handler is provided (Phase 2 write UI). */}
+      {onReact && (
+        <div className="flex gap-3 pt-4 border-t border-line">
+          {REACTION_TYPES.map((type) => (
+            <button
+              key={type}
+              type="button"
+              onClick={() => onReact(post.id, type)}
+              className="inline-flex items-center gap-1 min-h-11 px-3 py-1 bg-surface-2 hover:bg-surface-3 rounded-full text-sm transition-colors"
+              aria-label={`React ${type}`}
+              title={`React ${type}`}
+            >
+              <span>{getReactionEmoji(type)}</span>
+              <span className="font-medium">{post.reaction_counts?.[type] ?? 0}</span>
+            </button>
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/web/src/components/forum/ThreadCard.tsx
+++ b/web/src/components/forum/ThreadCard.tsx
@@ -8,6 +8,8 @@ import type { Thread } from '@/types';
 interface ThreadCardProps {
   thread: Thread;
   compact?: boolean;
+  /** Pass true for search results where author data is unavailable (sentinel). */
+  hideAuthor?: boolean;
 }
 
 /**
@@ -16,7 +18,7 @@ interface ThreadCardProps {
  * Displays a thread preview in the thread list.
  * Shows title, excerpt, author, stats, and activity time.
  */
-function ThreadCard({ thread, compact = false }: ThreadCardProps) {
+function ThreadCard({ thread, compact = false, hideAuthor = false }: ThreadCardProps) {
   // Memoize formatted date to prevent recalculation
   const formattedDate = useMemo(() => {
     try {
@@ -76,12 +78,15 @@ function ThreadCard({ thread, compact = false }: ThreadCardProps) {
 
         {/* Metadata */}
         <div className="flex items-center gap-2 text-sm text-ink-3 flex-wrap">
-          {/* Author */}
-          <span className="font-medium text-ink-2">
-            {thread.author.display_name || thread.author.username}
-          </span>
-
-          <span aria-hidden="true">•</span>
+          {/* Author — omitted for search results where no real author data exists */}
+          {!hideAuthor && (
+            <>
+              <span className="font-medium text-ink-2">
+                {thread.author.display_name || thread.author.username}
+              </span>
+              <span aria-hidden="true">•</span>
+            </>
+          )}
 
           {/* Category (if compact) */}
           {compact && (

--- a/web/src/pages/forum/SearchPage.test.tsx
+++ b/web/src/pages/forum/SearchPage.test.tsx
@@ -3,7 +3,8 @@ import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import SearchPage from './SearchPage';
-import { createMockCategory, createMockThread, createMockPost } from '../../tests/forumUtils';
+import { createMockCategory, createMockThread } from '../../tests/forumUtils';
+import { mapSearchPostToPost } from '../../services/forumMappers';
 import * as forumService from '../../services/forumService';
 
 // Mock the forumService
@@ -205,22 +206,24 @@ describe('SearchPage', () => {
       expect(screen.queryByText('[deleted]')).not.toBeInTheDocument();
     });
 
-    it('renders post results in separate section', async () => {
+    it('renders post results as compact rows (excerpt + topic title link, no PostCard)', async () => {
+      // Use real mapSearchPostToPost output — shape is {id, thread, author=[deleted], body=[], content_raw=excerpt, topic_title}
+      // This matches what forumService.searchForum actually returns and would have shown "[deleted]" via PostCard.
+      const post1 = mapSearchPostToPost({
+        id: 1,
+        topic_id: 42,
+        topic_title: 'Watering Guide',
+        excerpt: 'Water your plants regularly',
+      });
+      const post2 = mapSearchPostToPost({
+        id: 2,
+        topic_id: 43,
+        topic_title: 'Beginner Tips',
+        excerpt: 'Watering tips for beginners',
+      });
       const mockResults = createMockSearchResults({
         query: 'watering',
-        posts: [
-          createMockPost({
-            id: '1',
-            // body renders in PostCard; content_raw is used for plain-text highlight
-            body: [{ id: 'b1', type: 'paragraph', value: '<p>Water your plants regularly</p>' }],
-            content_raw: 'Water your plants regularly',
-          }),
-          createMockPost({
-            id: '2',
-            body: [{ id: 'b2', type: 'paragraph', value: '<p>Watering tips for beginners</p>' }],
-            content_raw: 'Watering tips for beginners',
-          }),
-        ],
+        posts: [post1, post2],
         total_posts: 2,
       });
 
@@ -229,9 +232,16 @@ describe('SearchPage', () => {
       renderSearchPage('/forum/search?q=watering');
 
       await waitFor(() => {
-        // PostCard renders body blocks; text comes from paragraph block value
+        // Topic title rendered as a link
+        expect(screen.getByRole('link', { name: /Watering Guide/i })).toBeInTheDocument();
+        // Excerpt rendered as plain text
         expect(screen.getByText(/Water your plants regularly/i)).toBeInTheDocument();
       });
+
+      // [deleted] sentinel must NOT appear — compact row does not render author
+      expect(screen.queryByText('[deleted]')).not.toBeInTheDocument();
+      // No empty PostCard author block (PostCard renders author.display_name in a specific element)
+      expect(screen.queryByText('Test User')).not.toBeInTheDocument();
     });
 
     it('displays no results message when no matches found', async () => {

--- a/web/src/pages/forum/SearchPage.test.tsx
+++ b/web/src/pages/forum/SearchPage.test.tsx
@@ -184,8 +184,17 @@ describe('SearchPage', () => {
       const mockResults = createMockSearchResults({
         query: 'watering',
         posts: [
-          createMockPost({ id: '1', content_raw: 'Water your plants regularly' }),
-          createMockPost({ id: '2', content_raw: 'Watering tips for beginners' }),
+          createMockPost({
+            id: '1',
+            // body renders in PostCard; content_raw is used for plain-text highlight
+            body: [{ id: 'b1', type: 'paragraph', value: '<p>Water your plants regularly</p>' }],
+            content_raw: 'Water your plants regularly',
+          }),
+          createMockPost({
+            id: '2',
+            body: [{ id: 'b2', type: 'paragraph', value: '<p>Watering tips for beginners</p>' }],
+            content_raw: 'Watering tips for beginners',
+          }),
         ],
         total_posts: 2,
       });
@@ -195,7 +204,7 @@ describe('SearchPage', () => {
       renderSearchPage('/forum/search?q=watering');
 
       await waitFor(() => {
-        // Check for post content in results
+        // PostCard renders body blocks; text comes from paragraph block value
         expect(screen.getByText(/Water your plants regularly/i)).toBeInTheDocument();
       });
     });

--- a/web/src/pages/forum/SearchPage.test.tsx
+++ b/web/src/pages/forum/SearchPage.test.tsx
@@ -180,6 +180,26 @@ describe('SearchPage', () => {
       });
     });
 
+    it('does not render [deleted] author sentinel on search thread cards', async () => {
+      // Search topics have no real author data; mapSearchTopicToThread produces a [deleted] sentinel.
+      // ThreadCard must not surface this sentinel as an author label.
+      const mockResults = createMockSearchResults({
+        query: 'watering',
+        threads: [createMockThread({ id: '1', title: 'Watering Guide' })],
+        total_threads: 1,
+      });
+
+      vi.spyOn(forumService, 'searchForum').mockResolvedValue(mockResults);
+
+      renderSearchPage('/forum/search?q=watering');
+
+      await waitFor(() => {
+        expect(screen.getByText('Watering Guide')).toBeInTheDocument();
+      });
+
+      expect(screen.queryByText('[deleted]')).not.toBeInTheDocument();
+    });
+
     it('renders post results in separate section', async () => {
       const mockResults = createMockSearchResults({
         query: 'watering',

--- a/web/src/pages/forum/SearchPage.test.tsx
+++ b/web/src/pages/forum/SearchPage.test.tsx
@@ -182,10 +182,15 @@ describe('SearchPage', () => {
 
     it('does not render [deleted] author sentinel on search thread cards', async () => {
       // Search topics have no real author data; mapSearchTopicToThread produces a [deleted] sentinel.
-      // ThreadCard must not surface this sentinel as an author label.
+      // ThreadCard with hideAuthor must not surface this sentinel as an author label.
+      const deletedThread = createMockThread({
+        id: '1',
+        title: 'Watering Guide',
+        author: { id: 0, email: '', username: '[deleted]', display_name: '[deleted]' },
+      });
       const mockResults = createMockSearchResults({
         query: 'watering',
-        threads: [createMockThread({ id: '1', title: 'Watering Guide' })],
+        threads: [deletedThread],
         total_threads: 1,
       });
 

--- a/web/src/pages/forum/SearchPage.tsx
+++ b/web/src/pages/forum/SearchPage.tsx
@@ -425,7 +425,7 @@ export default function SearchPage() {
               <div className="space-y-4">
                 {searchResults.threads.map((thread) => (
                   <div key={thread.id}>
-                    <ThreadCard thread={thread} />
+                    <ThreadCard thread={thread} hideAuthor />
                     {(hasSearchMatch(thread.title, query) ||
                       hasSearchMatch(thread.excerpt, query)) && (
                       <p

--- a/web/src/pages/forum/SearchPage.tsx
+++ b/web/src/pages/forum/SearchPage.tsx
@@ -1,8 +1,7 @@
 import { useState, useEffect, useCallback, useMemo, useRef, ChangeEvent } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams, Link } from 'react-router-dom';
 import { searchForum, fetchCategories } from '../../services/forumService';
 import ThreadCard from '../../components/forum/ThreadCard';
-import PostCard from '../../components/forum/PostCard';
 import LoadingSpinner from '../../components/ui/LoadingSpinner';
 import { Pagination } from '../../components/ui/Pagination';
 import { useHandlePageChange } from '../../hooks/useHandlePageChange';
@@ -453,14 +452,20 @@ export default function SearchPage() {
                   // content_raw holds the backend excerpt (may contain truncated HTML tags).
                   // Strip tags so we render plain text only — never dangerouslySetInnerHTML.
                   const plainExcerpt = stripTags(post.content_raw);
+                  // Build a link to the topic by id (topic_title is carried by mapSearchPostToPost).
+                  // topic_id is stored in post.thread; topic_title is carried through.
+                  const topicLink = `/forum/-topic/${post.thread}`;
                   return (
-                    <div key={post.id}>
-                      <PostCard post={post} />
-                      {hasSearchMatch(plainExcerpt, query) && (
-                        <p
-                          className="mt-2 text-sm text-ink-2 bg-tertiary/10 border border-tertiary/20 rounded-lg p-3"
-                          aria-label="Highlighted post match"
-                        >
+                    <div key={post.id} className="bg-surface-2 rounded-lg border border-line-2 p-4">
+                      <Link
+                        to={topicLink}
+                        className="text-base font-semibold text-primary hover:underline"
+                        aria-label={`Go to topic: ${post.topic_title || 'View topic'}`}
+                      >
+                        {highlightText(post.topic_title || 'View topic', query)}
+                      </Link>
+                      {plainExcerpt && (
+                        <p className="mt-2 text-sm text-ink-2" aria-label="Highlighted post match">
                           {highlightText(plainExcerpt, query)}
                         </p>
                       )}

--- a/web/src/pages/forum/SearchPage.tsx
+++ b/web/src/pages/forum/SearchPage.tsx
@@ -9,6 +9,11 @@ import { useHandlePageChange } from '../../hooks/useHandlePageChange';
 import { logger } from '../../utils/logger';
 import type { Category, SearchForumResponse } from '@/types';
 
+/** Strip HTML tags from a string, returning plain text. */
+function stripTags(html: string): string {
+  return html.replace(/<[^>]*>/g, '');
+}
+
 function highlightText(text: string | undefined, query: string) {
   if (!text || !query.trim()) return text || '';
 
@@ -444,19 +449,24 @@ export default function SearchPage() {
                 Posts ({searchResults.total_posts})
               </h2>
               <div className="space-y-4">
-                {searchResults.posts.map((post) => (
-                  <div key={post.id}>
-                    <PostCard post={post} />
-                    {hasSearchMatch(post.content_raw, query) && (
-                      <p
-                        className="mt-2 text-sm text-ink-2 bg-tertiary/10 border border-tertiary/20 rounded-lg p-3"
-                        aria-label="Highlighted post match"
-                      >
-                        {highlightText(post.content_raw, query)}
-                      </p>
-                    )}
-                  </div>
-                ))}
+                {searchResults.posts.map((post) => {
+                  // content_raw holds the backend excerpt (may contain truncated HTML tags).
+                  // Strip tags so we render plain text only — never dangerouslySetInnerHTML.
+                  const plainExcerpt = stripTags(post.content_raw);
+                  return (
+                    <div key={post.id}>
+                      <PostCard post={post} />
+                      {hasSearchMatch(plainExcerpt, query) && (
+                        <p
+                          className="mt-2 text-sm text-ink-2 bg-tertiary/10 border border-tertiary/20 rounded-lg p-3"
+                          aria-label="Highlighted post match"
+                        >
+                          {highlightText(plainExcerpt, query)}
+                        </p>
+                      )}
+                    </div>
+                  );
+                })}
               </div>
             </div>
           )}

--- a/web/src/pages/forum/ThreadDetailPage.test.tsx
+++ b/web/src/pages/forum/ThreadDetailPage.test.tsx
@@ -250,10 +250,9 @@ describe('ThreadDetailPage', () => {
 
     renderThreadDetailPage();
 
-    await waitFor(() => {
-      // Wait for page to finish loading
-      expect(screen.queryByRole('status')).not.toBeInTheDocument();
-    });
+    // Block until the loaded state is rendered (the read-only notice appears),
+    // then assert the write UI is absent.
+    await screen.findByText(/read-only/i);
 
     expect(screen.queryByText(/Post Your Reply/i)).not.toBeInTheDocument();
     expect(screen.queryByRole('textbox')).not.toBeInTheDocument();

--- a/web/src/pages/forum/ThreadDetailPage.test.tsx
+++ b/web/src/pages/forum/ThreadDetailPage.test.tsx
@@ -90,11 +90,11 @@ describe('ThreadDetailPage', () => {
     expect(screen.getByRole('status')).toBeInTheDocument();
   });
 
-  it('fetches thread and posts in parallel on mount', async () => {
+  it('fetches thread and posts on mount', async () => {
     const mockThread = createMockThread({ slug: 'watering-tips' });
     const mockPosts = {
       items: [createMockPost({ id: '1' })],
-      meta: { count: 1 },
+      meta: { count: 0, next: null, previous: null },
     };
 
     const fetchThreadSpy = vi.spyOn(forumService, 'fetchThread').mockResolvedValue(mockThread);
@@ -104,10 +104,7 @@ describe('ThreadDetailPage', () => {
 
     await waitFor(() => {
       expect(fetchThreadSpy).toHaveBeenCalledWith(12);
-      expect(fetchPostsSpy).toHaveBeenCalledWith({
-        thread: 12,
-        page: 1,
-      });
+      expect(fetchPostsSpy).toHaveBeenCalledWith({ thread: 12 });
     });
   });
 
@@ -209,16 +206,16 @@ describe('ThreadDetailPage', () => {
       items: [
         createMockPost({
           id: '1',
-          content_raw: '<p>First post content</p>',
+          body: [{ id: 'b1', type: 'paragraph', value: '<p>First post content</p>' }],
           is_first_post: true,
         }),
         createMockPost({
           id: '2',
-          content_raw: '<p>Second post content</p>',
+          body: [{ id: 'b2', type: 'paragraph', value: '<p>Second post content</p>' }],
           is_first_post: false,
         }),
       ],
-      meta: { count: 2 },
+      meta: { count: 0, next: null, previous: null },
     };
 
     vi.spyOn(forumService, 'fetchThread').mockResolvedValue(mockThread);
@@ -371,13 +368,13 @@ describe('ThreadDetailPage', () => {
     expect(submitButton).toBeDisabled();
   });
 
-  it('shows Load More button when more posts exist', async () => {
-    const mockThread = createMockThread();
+  it('shows Load More button when meta.next is present', async () => {
+    const mockThread = createMockThread({ post_count: 45 });
     const mockPosts = {
       items: Array(20)
         .fill(null)
         .map((_, i) => createMockPost({ id: `post-${i}` })),
-      meta: { count: 45 }, // Total 45 posts, showing 20
+      meta: { count: 0, next: 'http://api/next-cursor', previous: null },
     };
 
     vi.spyOn(forumService, 'fetchThread').mockResolvedValue(mockThread);
@@ -409,19 +406,20 @@ describe('ThreadDetailPage', () => {
     });
   });
 
-  it('loads more posts when Load More button is clicked', async () => {
-    const mockThread = createMockThread();
+  it('loads more posts using cursor when Load More button is clicked', async () => {
+    const nextCursorUrl = 'http://api/next-cursor';
+    const mockThread = createMockThread({ post_count: 45 });
     const initialPosts = {
       items: Array(20)
         .fill(null)
         .map((_, i) => createMockPost({ id: `post-${i}` })),
-      meta: { count: 45 },
+      meta: { count: 0, next: nextCursorUrl, previous: null },
     };
     const morePosts = {
       items: Array(20)
         .fill(null)
         .map((_, i) => createMockPost({ id: `post-${i + 20}` })),
-      meta: { count: 45 },
+      meta: { count: 0, next: null, previous: null },
     };
 
     vi.spyOn(forumService, 'fetchThread').mockResolvedValue(mockThread);
@@ -442,16 +440,17 @@ describe('ThreadDetailPage', () => {
     await waitFor(() => {
       expect(fetchPostsSpy).toHaveBeenCalledWith({
         thread: 12,
-        page: 2,
+        cursor: nextCursorUrl,
       });
     });
   });
 
-  it('displays total post count in header', async () => {
-    const mockThread = createMockThread();
+  it('displays total post count in header from thread.post_count', async () => {
+    const mockThread = createMockThread({ post_count: 150 });
     const mockPosts = {
       items: Array(20).fill(createMockPost()),
-      meta: { count: 150 }, // 150 total posts
+      // meta.count is hardcoded 0 by the service; page uses thread.post_count instead
+      meta: { count: 0, next: null, previous: null },
     };
 
     vi.spyOn(forumService, 'fetchThread').mockResolvedValue(mockThread);

--- a/web/src/pages/forum/ThreadDetailPage.test.tsx
+++ b/web/src/pages/forum/ThreadDetailPage.test.tsx
@@ -6,8 +6,6 @@ import * as ReactRouter from 'react-router-dom';
 import ThreadDetailPage from './ThreadDetailPage';
 import { createMockThread, createMockPost } from '../../tests/forumUtils';
 import * as forumService from '../../services/forumService';
-import { useAuth } from '../../contexts/AuthContext';
-import type { AuthContextValue } from '../../contexts/AuthContext';
 
 vi.mock('react-router-dom', async () => {
   const actual = await vi.importActual('react-router-dom');
@@ -17,38 +15,16 @@ vi.mock('react-router-dom', async () => {
   };
 });
 
-// Mock the forumService and AuthContext
+// Mock the forumService and AuthContext (PostCard calls useAuth internally)
 vi.mock('../../services/forumService');
 vi.mock('../../contexts/AuthContext', () => ({
   useAuth: vi.fn(() => ({ user: null, isAuthenticated: false })),
 }));
 
-// Mock TipTapEditor to prevent ProseMirror initialization hanging
-vi.mock('../../components/forum/TipTapEditor', () => ({
-  default: vi.fn(({ content, onChange, placeholder }) => (
-    <div data-testid="mock-tiptap-editor">
-      <textarea
-        className="ProseMirror"
-        value={content}
-        onChange={(e) => onChange(e.target.value)}
-        placeholder={placeholder}
-      />
-    </div>
-  )),
-}));
-
 /**
  * Helper to render ThreadDetailPage with Router
  */
-function renderThreadDetailPage(
-  categorySlug = 'plant-care',
-  threadSlug = 'watering-tips',
-  authState: Partial<AuthContextValue> = { user: null, isAuthenticated: false }
-) {
-  // The component only reads user/isAuthenticated; useAuth is fully mocked, so a
-  // partial value is sufficient for these render tests.
-  vi.mocked(useAuth).mockReturnValue(authState as AuthContextValue);
-
+function renderThreadDetailPage(categorySlug = 'plant-care', threadSlug = 'watering-tips') {
   return render(
     <MemoryRouter initialEntries={[`/forum/${categorySlug}/${threadSlug}`]}>
       <ThreadDetailPage />
@@ -245,7 +221,7 @@ describe('ThreadDetailPage', () => {
     expect(screen.getByText(errorMessage)).toBeInTheDocument();
   });
 
-  it('shows login prompt for unauthenticated users', async () => {
+  it('shows read-only notice instead of reply form', async () => {
     const mockThread = createMockThread();
 
     vi.spyOn(forumService, 'fetchThread').mockResolvedValue(mockThread);
@@ -254,20 +230,16 @@ describe('ThreadDetailPage', () => {
       meta: { count: 0 },
     });
 
-    renderThreadDetailPage('plant-care', 'watering-tips', {
-      user: null,
-      isAuthenticated: false,
-    });
+    renderThreadDetailPage();
 
     await waitFor(() => {
-      expect(screen.getByText(/You must be logged in to reply/i)).toBeInTheDocument();
+      expect(screen.getByText(/read-only/i)).toBeInTheDocument();
     });
 
-    const loginButton = screen.getByText('Log In');
-    expect(loginButton).toBeInTheDocument();
+    expect(screen.getByText(/coming soon/i)).toBeInTheDocument();
   });
 
-  it('shows reply form for authenticated users', async () => {
+  it('does not show reply form or Post Your Reply heading', async () => {
     const mockThread = createMockThread();
 
     vi.spyOn(forumService, 'fetchThread').mockResolvedValue(mockThread);
@@ -276,96 +248,16 @@ describe('ThreadDetailPage', () => {
       meta: { count: 0 },
     });
 
-    renderThreadDetailPage('plant-care', 'watering-tips', {
-      user: { id: 1, email: 'testuser@example.com', username: 'testuser' },
-      isAuthenticated: true,
-    });
+    renderThreadDetailPage();
 
     await waitFor(() => {
-      expect(screen.getByText('Post Your Reply')).toBeInTheDocument();
+      // Wait for page to finish loading
+      expect(screen.queryByRole('status')).not.toBeInTheDocument();
     });
 
-    expect(screen.getByText('Post Reply')).toBeInTheDocument();
-  });
-
-  it('hides reply form when thread is locked', async () => {
-    const mockThread = createMockThread({ is_locked: true });
-
-    vi.spyOn(forumService, 'fetchThread').mockResolvedValue(mockThread);
-    vi.spyOn(forumService, 'fetchPosts').mockResolvedValue({
-      items: [],
-      meta: { count: 0 },
-    });
-
-    renderThreadDetailPage('plant-care', 'watering-tips', {
-      user: { id: 1, email: 'testuser@example.com', username: 'testuser' },
-      isAuthenticated: true,
-    });
-
-    await waitFor(() => {
-      expect(screen.getByText(/This thread is locked/i)).toBeInTheDocument();
-    });
-
-    expect(screen.queryByText('Post Your Reply')).not.toBeInTheDocument();
-  });
-
-  it('submits reply when authenticated user posts', async () => {
-    const mockThread = createMockThread({ id: 'thread-1' });
-    const mockPosts = { items: [], meta: { count: 0 } };
-    const newPost = createMockPost({ id: 'new-post', content_raw: '<p>My reply</p>' });
-
-    vi.spyOn(forumService, 'fetchThread').mockResolvedValue(mockThread);
-    vi.spyOn(forumService, 'fetchPosts').mockResolvedValue(mockPosts);
-    const createPostSpy = vi.spyOn(forumService, 'createPost').mockResolvedValue(newPost);
-
-    const { container } = renderThreadDetailPage('plant-care', 'watering-tips', {
-      user: { id: 1, email: 'testuser@example.com', username: 'testuser' },
-      isAuthenticated: true,
-    });
-
-    await waitFor(() => {
-      expect(screen.getByText('Post Reply')).toBeInTheDocument();
-    });
-
-    // Find TipTap editor and type content
-    const editor = container.querySelector('.ProseMirror');
-    await userEvent.click(editor);
-    await userEvent.keyboard('My reply');
-
-    const submitButton = screen.getByText('Post Reply');
-    await userEvent.click(submitButton);
-
-    await waitFor(() => {
-      expect(createPostSpy).toHaveBeenCalledWith({
-        thread: 12,
-        content_raw: expect.stringContaining('My reply'),
-        content_format: 'html',
-      });
-    });
-  });
-
-  it('shows validation error when submitting empty reply', async () => {
-    const mockThread = createMockThread();
-
-    vi.spyOn(forumService, 'fetchThread').mockResolvedValue(mockThread);
-    vi.spyOn(forumService, 'fetchPosts').mockResolvedValue({
-      items: [],
-      meta: { count: 0 },
-    });
-
-    renderThreadDetailPage('plant-care', 'watering-tips', {
-      user: { id: 1, email: 'testuser@example.com', username: 'testuser' },
-      isAuthenticated: true,
-    });
-
-    await waitFor(() => {
-      expect(screen.getByText('Post Reply')).toBeInTheDocument();
-    });
-
-    const submitButton = screen.getByText('Post Reply');
-
-    // Button should be disabled when content is empty
-    expect(submitButton).toBeDisabled();
+    expect(screen.queryByText(/Post Your Reply/i)).not.toBeInTheDocument();
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Post Reply/i })).not.toBeInTheDocument();
   });
 
   it('shows Load More button when meta.next is present', async () => {
@@ -461,124 +353,5 @@ describe('ThreadDetailPage', () => {
     await waitFor(() => {
       expect(screen.getByText(/150 replies/i)).toBeInTheDocument();
     });
-  });
-
-  it('updates post count when new post is submitted', async () => {
-    const mockThread = createMockThread({ id: 'thread-1' });
-    const mockPosts = { items: [], meta: { count: 5 } };
-    const newPost = createMockPost({ id: 'new-post' });
-
-    vi.spyOn(forumService, 'fetchThread').mockResolvedValue(mockThread);
-    vi.spyOn(forumService, 'fetchPosts').mockResolvedValue(mockPosts);
-    vi.spyOn(forumService, 'createPost').mockResolvedValue(newPost);
-
-    const { container } = renderThreadDetailPage('plant-care', 'watering-tips', {
-      user: { id: 1, email: 'testuser@example.com', username: 'testuser' },
-      isAuthenticated: true,
-    });
-
-    await waitFor(() => {
-      expect(screen.getByText(/5 replies/i)).toBeInTheDocument();
-    });
-
-    // Submit a reply
-    const editor = container.querySelector('.ProseMirror');
-    await userEvent.click(editor);
-    await userEvent.keyboard('New post');
-
-    const submitButton = screen.getByText('Post Reply');
-    await userEvent.click(submitButton);
-
-    // Post count should increment to 6
-    await waitFor(() => {
-      expect(screen.getByText(/6 replies/i)).toBeInTheDocument();
-    });
-  });
-
-  it('toggles a reaction and updates the count for authenticated users', async () => {
-    const mockThread = createMockThread({ id: 'thread-1' });
-    const mockPosts = {
-      items: [createMockPost({ id: 'post-1', reaction_counts: {} })],
-      meta: { count: 1 },
-    };
-
-    vi.spyOn(forumService, 'fetchThread').mockResolvedValue(mockThread);
-    vi.spyOn(forumService, 'fetchPosts').mockResolvedValue(mockPosts);
-    const toggleSpy = vi.spyOn(forumService, 'toggleReaction').mockResolvedValue({
-      action: 'added',
-      reaction_type: 'like',
-      reaction_counts: { like: 1 },
-      user_reactions: ['like'],
-    });
-
-    renderThreadDetailPage('3-plant-care', '12-watering-tips', {
-      user: { id: 1, email: 'testuser@example.com', username: 'testuser' },
-      isAuthenticated: true,
-    });
-
-    await waitFor(() => {
-      expect(screen.getByLabelText('React like')).toBeInTheDocument();
-    });
-
-    await userEvent.click(screen.getByLabelText('React like'));
-
-    await waitFor(() => {
-      expect(toggleSpy).toHaveBeenCalledWith('post-1', 'like');
-    });
-    expect(screen.getByLabelText('React like')).toHaveTextContent('1');
-  });
-
-  it('does not call the API when an unauthenticated user reacts', async () => {
-    const mockThread = createMockThread({ id: 'thread-1' });
-    const mockPosts = {
-      items: [createMockPost({ id: 'post-1', reaction_counts: {} })],
-      meta: { count: 1 },
-    };
-
-    vi.spyOn(forumService, 'fetchThread').mockResolvedValue(mockThread);
-    vi.spyOn(forumService, 'fetchPosts').mockResolvedValue(mockPosts);
-    const toggleSpy = vi.spyOn(forumService, 'toggleReaction');
-
-    renderThreadDetailPage('3-plant-care', '12-watering-tips', {
-      user: null,
-      isAuthenticated: false,
-    });
-
-    await waitFor(() => {
-      expect(screen.getByLabelText('React like')).toBeInTheDocument();
-    });
-
-    await userEvent.click(screen.getByLabelText('React like'));
-
-    expect(toggleSpy).not.toHaveBeenCalled();
-  });
-
-  it('shows an inline error without unmounting the thread when a reaction fails', async () => {
-    const mockThread = createMockThread({ id: 'thread-1', title: 'Stay Visible' });
-    const mockPosts = {
-      items: [createMockPost({ id: 'post-1', reaction_counts: {} })],
-      meta: { count: 1 },
-    };
-
-    vi.spyOn(forumService, 'fetchThread').mockResolvedValue(mockThread);
-    vi.spyOn(forumService, 'fetchPosts').mockResolvedValue(mockPosts);
-    vi.spyOn(forumService, 'toggleReaction').mockRejectedValue(new Error('Reaction failed'));
-
-    renderThreadDetailPage('3-plant-care', '12-watering-tips', {
-      user: { id: 1, email: 'testuser@example.com', username: 'testuser' },
-      isAuthenticated: true,
-    });
-
-    await waitFor(() => {
-      expect(screen.getByLabelText('React like')).toBeInTheDocument();
-    });
-
-    await userEvent.click(screen.getByLabelText('React like'));
-
-    await waitFor(() => {
-      expect(screen.getByText('Reaction failed')).toBeInTheDocument();
-    });
-    // The thread view stays mounted — not replaced by the page-level error panel.
-    expect(screen.getByRole('heading', { level: 1, name: 'Stay Visible' })).toBeInTheDocument();
   });
 });

--- a/web/src/pages/forum/ThreadDetailPage.tsx
+++ b/web/src/pages/forum/ThreadDetailPage.tsx
@@ -325,7 +325,7 @@ export default function ThreadDetailPage() {
           >
             {loadingMore
               ? 'Loading...'
-              : `Load More Posts (${totalPosts - posts.length} remaining)`}
+              : `Load More Posts (${Math.max(0, totalPosts - posts.length)} remaining)`}
           </Button>
         </div>
       )}

--- a/web/src/pages/forum/ThreadDetailPage.tsx
+++ b/web/src/pages/forum/ThreadDetailPage.tsx
@@ -1,16 +1,8 @@
-import { useState, useEffect, useCallback, FormEvent } from 'react';
-import { useParams, useNavigate, Link } from 'react-router-dom';
-import {
-  fetchThread,
-  fetchPosts,
-  createPost,
-  deletePost,
-  toggleReaction,
-} from '../../services/forumService';
+import { useState, useEffect, useCallback } from 'react';
+import { useParams, Link } from 'react-router-dom';
+import { fetchThread, fetchPosts } from '../../services/forumService';
 import { parseLeadingId } from '../../utils/forumUrls';
-import { useAuth } from '../../contexts/AuthContext';
 import PostCard from '../../components/forum/PostCard';
-import TipTapEditor from '../../components/forum/TipTapEditor';
 import LoadingSpinner from '../../components/ui/LoadingSpinner';
 import Button from '../../components/ui/Button';
 import { logger } from '../../utils/logger';
@@ -20,13 +12,14 @@ import type { PaginatedResponse } from '@/types/forum';
 /**
  * ThreadDetailPage Component
  *
- * Displays a thread with its posts and allows replying.
+ * Displays a thread with its posts (read-only for Phase 1).
  * Route: /forum/:categorySlug/:threadSlug
+ *
+ * Phase 2: reply/react/delete write UI removed for read-only Phase 1 —
+ * restore from git history (commit 36f0a54) + the Phase 2 plan.
  */
 export default function ThreadDetailPage() {
   const { categorySlug, threadSlug } = useParams<{ categorySlug: string; threadSlug: string }>();
-  const navigate = useNavigate();
-  const { isAuthenticated } = useAuth();
 
   // The route param is a hybrid "id-slug"; lookups use the leading topic id.
   const topicId = parseLeadingId(threadSlug);
@@ -35,20 +28,12 @@ export default function ThreadDetailPage() {
   const [posts, setPosts] = useState<Post[]>([]);
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
-  // Reaction failures are shown inline; they must not clobber the whole-page
-  // `error` state, which unmounts the thread view.
-  const [reactionError, setReactionError] = useState<string | null>(null);
 
   // Cursor pagination state
   const [nextCursor, setNextCursor] = useState<string | null>(null);
   // totalPosts is seeded from thread.post_count (meta.count is hardcoded 0 by the service)
   const [totalPosts, setTotalPosts] = useState<number>(0);
   const [loadingMore, setLoadingMore] = useState<boolean>(false);
-
-  // Reply form state
-  const [replyContent, setReplyContent] = useState<string>('');
-  const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
-  const [replyError, setReplyError] = useState<string | null>(null);
 
   // Load thread and initial posts
   useEffect(() => {
@@ -87,100 +72,6 @@ export default function ThreadDetailPage() {
 
     loadData();
   }, [topicId, threadSlug, categorySlug]);
-
-  // Handle reply submission
-  const handleReplySubmit = useCallback(
-    async (e: FormEvent<HTMLFormElement>) => {
-      e.preventDefault();
-
-      if (!isAuthenticated) {
-        navigate('/login', { state: { from: window.location.pathname } });
-        return;
-      }
-
-      if (!replyContent.trim()) {
-        setReplyError('Reply content is required');
-        return;
-      }
-
-      if (!thread || topicId == null) {
-        setReplyError('Thread not found');
-        return;
-      }
-
-      try {
-        setIsSubmitting(true);
-        setReplyError(null);
-
-        const newPost = (await createPost({
-          thread: topicId,
-          content_raw: replyContent,
-          content_format: 'html', // TipTap outputs HTML
-        })) as Post;
-
-        setPosts((prev) => [...prev, newPost]);
-        setTotalPosts((prev) => prev + 1);
-        setReplyContent(''); // Clear editor
-
-        // Scroll to new post
-        setTimeout(() => {
-          const element = document.getElementById(`post-${newPost.id}`);
-          element?.scrollIntoView({ behavior: 'smooth', block: 'center' });
-        }, 100);
-      } catch (err) {
-        logger.error('Error creating post', {
-          component: 'ThreadDetailPage',
-          error: err,
-          context: { threadId: thread?.id, contentLength: replyContent?.length },
-        });
-        setReplyError(err instanceof Error ? err.message : 'Failed to create post');
-      } finally {
-        setIsSubmitting(false);
-      }
-    },
-    [isAuthenticated, navigate, replyContent, thread, topicId]
-  );
-
-  // Handle post deletion
-  const handleDeletePost = useCallback(async (post: Post) => {
-    if (!window.confirm('Are you sure you want to delete this post?')) {
-      return;
-    }
-
-    try {
-      await deletePost(post.id);
-      setPosts((prev) => prev.filter((p) => p.id !== post.id));
-      setTotalPosts((prev) => prev - 1);
-    } catch (err) {
-      logger.error('Error deleting post', {
-        component: 'ThreadDetailPage',
-        error: err,
-        context: { postId: post.id },
-      });
-      alert(`Failed to delete post: ${err instanceof Error ? err.message : 'Unknown error'}`);
-    }
-  }, []);
-
-  // Toggle a reaction on a post and reflect the new counts in place.
-  const handleReact = useCallback(
-    async (postId: string, reactionType: string) => {
-      if (!isAuthenticated) {
-        navigate('/login', { state: { from: window.location.pathname } });
-        return;
-      }
-
-      setReactionError(null);
-      try {
-        const result = await toggleReaction(postId, reactionType);
-        setPosts((prev) =>
-          prev.map((p) => (p.id === postId ? { ...p, reaction_counts: result.reaction_counts } : p))
-        );
-      } catch (err) {
-        setReactionError(err instanceof Error ? err.message : 'Could not react');
-      }
-    },
-    [isAuthenticated, navigate]
-  );
 
   // Load more posts (cursor pagination) — Phase 2
   const handleLoadMore = useCallback(async () => {
@@ -290,25 +181,11 @@ export default function ThreadDetailPage() {
         </div>
       </div>
 
-      {/* Inline reaction error — never replaces the page */}
-      {reactionError && (
-        <div className="mb-4 flex items-center justify-between bg-error/10 border border-error/30 text-ink px-4 py-3 rounded">
-          <span>{reactionError}</span>
-          <button
-            type="button"
-            onClick={() => setReactionError(null)}
-            className="text-sm text-error hover:text-error/80 underline"
-          >
-            Dismiss
-          </button>
-        </div>
-      )}
-
       {/* Posts List */}
       <div className="space-y-4 mb-8">
         {posts.map((post) => (
           <div key={post.id} id={`post-${post.id}`}>
-            <PostCard post={post} onDelete={handleDeletePost} onReact={handleReact} />
+            <PostCard post={post} />
           </div>
         ))}
       </div>
@@ -330,62 +207,10 @@ export default function ThreadDetailPage() {
         </div>
       )}
 
-      {/* Reply Form */}
-      {!thread.is_locked && (
-        <div className="bg-surface-2 rounded-lg shadow-md p-6">
-          <h3 className="text-xl font-bold mb-4 text-ink">Post Your Reply</h3>
-
-          {!isAuthenticated ? (
-            <div className="text-center py-8">
-              <p className="text-ink-2 mb-4">You must be logged in to reply to this thread.</p>
-              <Link to="/login" state={{ from: window.location.pathname }}>
-                <Button variant="primary">Log In</Button>
-              </Link>
-            </div>
-          ) : (
-            <form onSubmit={handleReplySubmit}>
-              <TipTapEditor
-                content={replyContent}
-                onChange={setReplyContent}
-                placeholder="Write your reply..."
-                className="mb-4"
-              />
-
-              {replyError && (
-                <div className="mb-4 p-3 bg-error/10 border border-error/30 text-ink rounded">
-                  {replyError}
-                </div>
-              )}
-
-              <div className="flex gap-2">
-                <Button
-                  type="submit"
-                  variant="primary"
-                  loading={isSubmitting}
-                  disabled={!replyContent.trim()}
-                >
-                  {isSubmitting ? 'Posting...' : 'Post Reply'}
-                </Button>
-
-                <Button
-                  type="button"
-                  variant="outline"
-                  onClick={() => setReplyContent('')}
-                  disabled={isSubmitting}
-                >
-                  Clear
-                </Button>
-              </div>
-            </form>
-          )}
-        </div>
-      )}
-
-      {thread.is_locked && (
-        <div className="bg-surface-2 border border-line-2 text-ink-2 px-6 py-4 rounded-lg text-center">
-          🔒 This thread is locked. No new replies can be posted.
-        </div>
-      )}
+      {/* Read-only notice — Phase 2 will restore reply/react/delete write UI */}
+      <div className="mt-8 rounded-lg border border-line bg-surface-2 p-6 text-center">
+        <p className="text-ink-2">🔒 Replies are coming soon — the forum is read-only for now.</p>
+      </div>
     </div>
   );
 }

--- a/web/src/pages/forum/ThreadDetailPage.tsx
+++ b/web/src/pages/forum/ThreadDetailPage.tsx
@@ -15,13 +15,7 @@ import LoadingSpinner from '../../components/ui/LoadingSpinner';
 import Button from '../../components/ui/Button';
 import { logger } from '../../utils/logger';
 import type { Thread, Post } from '@/types';
-
-interface PostsData {
-  items: Post[];
-  meta: {
-    count: number;
-  };
-}
+import type { PaginatedResponse } from '@/types/forum';
 
 /**
  * ThreadDetailPage Component
@@ -45,8 +39,9 @@ export default function ThreadDetailPage() {
   // `error` state, which unmounts the thread view.
   const [reactionError, setReactionError] = useState<string | null>(null);
 
-  // Pagination state
-  const [currentPage, setCurrentPage] = useState<number>(1);
+  // Cursor pagination state
+  const [nextCursor, setNextCursor] = useState<string | null>(null);
+  // totalPosts is seeded from thread.post_count (meta.count is hardcoded 0 by the service)
   const [totalPosts, setTotalPosts] = useState<number>(0);
   const [loadingMore, setLoadingMore] = useState<boolean>(false);
 
@@ -70,13 +65,14 @@ export default function ThreadDetailPage() {
 
         const [threadData, postsData] = (await Promise.all([
           fetchThread(topicId),
-          fetchPosts({ thread: topicId, page: 1 }),
-        ])) as [Thread, PostsData];
+          fetchPosts({ thread: topicId }),
+        ])) as [Thread, PaginatedResponse<Post>];
 
         setThread(threadData);
         setPosts(postsData.items);
-        setTotalPosts(postsData.meta.count);
-        setCurrentPage(1);
+        // meta.count is hardcoded 0 by the service; seed from thread.post_count instead
+        setTotalPosts(threadData.post_count ?? 0);
+        setNextCursor(postsData.meta.next ?? null);
       } catch (err) {
         logger.error('Error loading thread data', {
           component: 'ThreadDetailPage',
@@ -186,32 +182,30 @@ export default function ThreadDetailPage() {
     [isAuthenticated, navigate]
   );
 
-  // Load more posts (pagination)
+  // Load more posts (cursor pagination) — Phase 2
   const handleLoadMore = useCallback(async () => {
-    if (topicId == null) return;
+    if (topicId == null || !nextCursor) return;
 
     try {
       setLoadingMore(true);
-      const nextPage = currentPage + 1;
-
       const postsData = (await fetchPosts({
         thread: topicId,
-        page: nextPage,
-      })) as PostsData;
+        cursor: nextCursor,
+      })) as PaginatedResponse<Post>;
 
       setPosts((prev) => [...prev, ...postsData.items]);
-      setCurrentPage(nextPage);
+      setNextCursor(postsData.meta.next ?? null);
     } catch (err) {
       logger.error('Error loading more posts', {
         component: 'ThreadDetailPage',
         error: err,
-        context: { threadId: thread?.id, page: currentPage + 1 },
+        context: { threadId: thread?.id },
       });
       alert(`Failed to load more posts: ${err instanceof Error ? err.message : 'Unknown error'}`);
     } finally {
       setLoadingMore(false);
     }
-  }, [currentPage, topicId, thread?.id]);
+  }, [nextCursor, topicId, thread?.id]);
 
   if (loading) {
     return (
@@ -319,8 +313,8 @@ export default function ThreadDetailPage() {
         ))}
       </div>
 
-      {/* Load More Button */}
-      {posts.length < totalPosts && (
+      {/* Load More Button (cursor pagination) */}
+      {nextCursor && (
         <div className="mb-8 text-center">
           <Button
             onClick={handleLoadMore}

--- a/web/src/pages/forum/ThreadListPage.test.tsx
+++ b/web/src/pages/forum/ThreadListPage.test.tsx
@@ -48,7 +48,7 @@ describe('ThreadListPage', () => {
     expect(screen.getByRole('status')).toBeInTheDocument();
   });
 
-  it('fetches category and threads in parallel on mount', async () => {
+  it('fetches category then threads by board slug on mount', async () => {
     const mockCategory = createMockCategory({
       slug: 'plant-care',
       name: 'Plant Care',
@@ -67,12 +67,7 @@ describe('ThreadListPage', () => {
 
     await waitFor(() => {
       expect(fetchCategorySpy).toHaveBeenCalledWith(3);
-      expect(fetchThreadsSpy).toHaveBeenCalledWith({
-        category: 3,
-        page: 1,
-        search: undefined,
-        ordering: '-last_activity_at',
-      });
+      expect(fetchThreadsSpy).toHaveBeenCalledWith({ board: 'plant-care' });
     });
   });
 
@@ -271,39 +266,67 @@ describe('ThreadListPage', () => {
     });
   });
 
-  it('renders pagination buttons when multiple pages exist', async () => {
+  it('shows Load More button when meta.next is present', async () => {
     const mockCategory = createMockCategory({ slug: 'plant-care' });
 
     vi.spyOn(forumService, 'fetchCategory').mockResolvedValue(mockCategory);
     vi.spyOn(forumService, 'fetchThreads').mockResolvedValue({
       items: Array(20).fill(createMockThread()),
-      meta: { count: 45, next: 'next-url', previous: null },
+      meta: { count: 0, next: 'http://api/next-cursor', previous: null },
     });
 
     renderThreadListPage();
 
     await waitFor(() => {
-      expect(screen.getByText(/Page 1 of/i)).toBeInTheDocument();
+      expect(screen.getByText('Load More')).toBeInTheDocument();
     });
-
-    expect(screen.getByText('Previous')).toBeInTheDocument();
-    expect(screen.getByText('Next')).toBeInTheDocument();
   });
 
-  it('disables Previous button on first page', async () => {
+  it('calls fetchThreads with cursor when Load More is clicked', async () => {
+    const mockCategory = createMockCategory({ slug: 'plant-care' });
+    const nextCursorUrl = 'http://api/next-cursor';
+
+    vi.spyOn(forumService, 'fetchCategory').mockResolvedValue(mockCategory);
+    const fetchThreadsSpy = vi
+      .spyOn(forumService, 'fetchThreads')
+      .mockResolvedValueOnce({
+        items: Array(20).fill(createMockThread()),
+        meta: { count: 0, next: nextCursorUrl, previous: null },
+      })
+      .mockResolvedValueOnce({
+        items: [createMockThread({ id: 'extra' })],
+        meta: { count: 0, next: null, previous: null },
+      });
+
+    renderThreadListPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('Load More')).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByText('Load More'));
+
+    await waitFor(() => {
+      expect(fetchThreadsSpy).toHaveBeenCalledWith({
+        board: 'plant-care',
+        cursor: nextCursorUrl,
+      });
+    });
+  });
+
+  it('hides Load More button when meta.next is null', async () => {
     const mockCategory = createMockCategory({ slug: 'plant-care' });
 
     vi.spyOn(forumService, 'fetchCategory').mockResolvedValue(mockCategory);
     vi.spyOn(forumService, 'fetchThreads').mockResolvedValue({
       items: Array(20).fill(createMockThread()),
-      meta: { count: 45 },
+      meta: { count: 0, next: null, previous: null },
     });
 
     renderThreadListPage();
 
     await waitFor(() => {
-      const previousButton = screen.getByText('Previous');
-      expect(previousButton).toBeDisabled();
+      expect(screen.queryByText('Load More')).not.toBeInTheDocument();
     });
   });
 

--- a/web/src/pages/forum/ThreadListPage.tsx
+++ b/web/src/pages/forum/ThreadListPage.tsx
@@ -55,7 +55,9 @@ export default function ThreadListPage() {
         const threadsData = await fetchThreads({ board: categoryData.slug });
 
         setCategory(categoryData);
-        setThreads(threadsData.items);
+        // Stamp the resolved category onto each thread so threadPath builds
+        // correct URLs (/forum/{id}-{slug}/...) instead of /forum/-topic/...
+        setThreads(threadsData.items.map((t) => ({ ...t, category: categoryData })));
         setNextCursor(threadsData.meta.next ?? null);
       } catch (err) {
         logger.error('Error loading thread list data', {
@@ -113,7 +115,11 @@ export default function ThreadListPage() {
     try {
       setLoadingMore(true);
       const threadsData = await fetchThreads({ board: boardSlug, cursor: nextCursor });
-      setThreads((prev) => [...prev, ...threadsData.items]);
+      // Stamp category so Load More threads also get correct threadPath URLs.
+      setThreads((prev) => [
+        ...prev,
+        ...threadsData.items.map((t) => ({ ...t, category: category! })),
+      ]);
       setNextCursor(threadsData.meta.next ?? null);
     } catch (err) {
       logger.error('Error loading more threads', {
@@ -124,7 +130,7 @@ export default function ThreadListPage() {
     } finally {
       setLoadingMore(false);
     }
-  }, [nextCursor, categorySlug]);
+  }, [nextCursor, categorySlug, category]);
 
   if (loading && !category) {
     return (

--- a/web/src/pages/forum/ThreadListPage.tsx
+++ b/web/src/pages/forum/ThreadListPage.tsx
@@ -1,26 +1,17 @@
-import { useState, useEffect, useCallback, useMemo, FormEvent } from 'react';
+import { useState, useEffect, useCallback, useRef, FormEvent } from 'react';
 import { useParams, useSearchParams, Link } from 'react-router-dom';
 import { fetchThreads, fetchCategory } from '../../services/forumService';
 import { parseLeadingId } from '../../utils/forumUrls';
 import ThreadCard from '../../components/forum/ThreadCard';
 import LoadingSpinner from '../../components/ui/LoadingSpinner';
 import Button from '../../components/ui/Button';
-import { Pagination } from '../../components/ui/Pagination';
-import { useHandlePageChange } from '../../hooks/useHandlePageChange';
 import { logger } from '../../utils/logger';
 import type { Thread, Category } from '@/types';
-
-interface ThreadsData {
-  items: Thread[];
-  meta: {
-    count: number;
-  };
-}
 
 /**
  * ThreadListPage Component
  *
- * Displays threads in a category with search, filters, and pagination.
+ * Displays threads in a category with search, filters, and cursor pagination.
  * Route: /forum/:categorySlug
  */
 export default function ThreadListPage() {
@@ -31,21 +22,21 @@ export default function ThreadListPage() {
   const [threads, setThreads] = useState<Thread[]>([]);
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
-  const [totalCount, setTotalCount] = useState<number>(0);
+  const [nextCursor, setNextCursor] = useState<string | null>(null);
+  const [loadingMore, setLoadingMore] = useState<boolean>(false);
 
-  // Get search params
-  const page = parseInt(searchParams.get('page') || '1', 10);
+  // URL-driven search/ordering (client-side UI only — not passed to fetchThreads)
   const search = searchParams.get('search') || '';
   const ordering = searchParams.get('order') || '-last_activity_at';
 
-  const limit = 20;
+  // Track the resolved board slug so Load More can reuse it without re-fetching category
+  const boardSlugRef = useRef<string | null>(null);
 
-  // Load category and threads
+  // Load category and initial threads
   useEffect(() => {
     const loadData = async () => {
       if (!categorySlug) return;
 
-      // The route param is a hybrid "id-slug"; lookups use the leading id.
       const forumId = parseLeadingId(categorySlug);
       if (forumId == null) {
         setError('Invalid category URL');
@@ -57,20 +48,20 @@ export default function ThreadListPage() {
         setLoading(true);
         setError(null);
 
-        // Load category info and threads in parallel
-        const [categoryData, threadsData] = (await Promise.all([
-          fetchCategory(forumId),
-          fetchThreads({ category: forumId, page, search: search || undefined, ordering }),
-        ])) as [Category, ThreadsData];
+        // Resolve the true board slug first, then fetch threads by slug.
+        const categoryData = await fetchCategory(forumId);
+        boardSlugRef.current = categoryData.slug;
+
+        const threadsData = await fetchThreads({ board: categoryData.slug });
 
         setCategory(categoryData);
         setThreads(threadsData.items);
-        setTotalCount(threadsData.meta.count);
+        setNextCursor(threadsData.meta.next ?? null);
       } catch (err) {
         logger.error('Error loading thread list data', {
           component: 'ThreadListPage',
           error: err,
-          context: { categorySlug, page, search },
+          context: { categorySlug },
         });
         setError(err instanceof Error ? err.message : 'Failed to load threads');
       } finally {
@@ -79,9 +70,9 @@ export default function ThreadListPage() {
     };
 
     loadData();
-  }, [categorySlug, page, search, ordering]);
+  }, [categorySlug]);
 
-  // Handle search form submission
+  // Handle search form submission (URL/UI only)
   const handleSearch = useCallback(
     (e: FormEvent<HTMLFormElement>) => {
       e.preventDefault();
@@ -95,34 +86,45 @@ export default function ThreadListPage() {
         } else {
           newParams.delete('search');
         }
-        newParams.set('page', '1'); // Reset to page 1
         return newParams;
       });
     },
     [setSearchParams]
   );
 
-  // Handle ordering change
+  // Handle ordering change (URL/UI only)
   const handleOrderChange = useCallback(
     (e: React.ChangeEvent<HTMLSelectElement>) => {
       const newOrder = e.target.value;
       setSearchParams((prev) => {
         const newParams = new URLSearchParams(prev);
         newParams.set('order', newOrder);
-        newParams.set('page', '1'); // Reset to page 1
         return newParams;
       });
     },
     [setSearchParams]
   );
 
-  // Handle pagination (shared hook — todo 222 / M14)
-  const handlePageChange = useHandlePageChange(setSearchParams);
+  // Load more threads using the cursor from the last response
+  const handleLoadMore = useCallback(async () => {
+    const boardSlug = boardSlugRef.current;
+    if (!nextCursor || !boardSlug) return;
 
-  // Calculate pagination
-  const totalPages = useMemo(() => {
-    return Math.ceil(totalCount / limit);
-  }, [totalCount, limit]);
+    try {
+      setLoadingMore(true);
+      const threadsData = await fetchThreads({ board: boardSlug, cursor: nextCursor });
+      setThreads((prev) => [...prev, ...threadsData.items]);
+      setNextCursor(threadsData.meta.next ?? null);
+    } catch (err) {
+      logger.error('Error loading more threads', {
+        component: 'ThreadListPage',
+        error: err,
+        context: { categorySlug },
+      });
+    } finally {
+      setLoadingMore(false);
+    }
+  }, [nextCursor, categorySlug]);
 
   if (loading && !category) {
     return (
@@ -222,7 +224,6 @@ export default function ThreadListPage() {
               setSearchParams((prev) => {
                 const newParams = new URLSearchParams(prev);
                 newParams.delete('search');
-                newParams.set('page', '1');
                 return newParams;
               });
             }}
@@ -251,16 +252,19 @@ export default function ThreadListPage() {
         </div>
       )}
 
-      {/* Pagination */}
-      {totalPages > 1 && (
-        <Pagination
-          page={page}
-          totalPages={totalPages}
-          onPageChange={handlePageChange}
-          hasPrevious={page > 1}
-          hasNext={page < totalPages}
-          variant="outline"
-        />
+      {/* Load More (cursor pagination) */}
+      {nextCursor && (
+        <div className="mt-8 text-center">
+          <Button
+            onClick={handleLoadMore}
+            variant="outline"
+            loading={loadingMore}
+            disabled={loadingMore}
+            className="min-h-11"
+          >
+            {loadingMore ? 'Loading...' : 'Load More'}
+          </Button>
+        </div>
       )}
     </div>
   );

--- a/web/src/services/forumMappers.test.ts
+++ b/web/src/services/forumMappers.test.ts
@@ -1,127 +1,263 @@
 import { describe, it, expect } from 'vitest';
 import {
-  mapUser,
-  mapForumToCategory,
-  mapTopicToThread,
+  mapBoardToCategory,
+  mapTopicListItemToThread,
+  mapTopicDetailToThread,
   mapPostToPost,
+  mapSearchTopicToThread,
+  mapSearchPostToPost,
   mapImageToAttachment,
 } from './forumMappers';
 
-describe('forumMappers', () => {
-  it('maps a backend user to a forum author with a display name', () => {
-    expect(
-      mapUser({ id: 1, username: 'jdoe', first_name: 'Jane', last_name: 'Doe' })
-    ).toMatchObject({
-      id: '1',
-      username: 'jdoe',
-      display_name: 'Jane Doe',
-    });
-    expect(mapUser({ id: 2, username: 'nobody', first_name: '', last_name: '' }).display_name).toBe(
-      'nobody'
-    );
-    const deleted = mapUser(null);
-    expect(deleted.id).toBe('');
-    expect(deleted.username).toBe('[deleted]');
-    expect(deleted.display_name).toBe('[deleted]');
-  });
+describe('forumMappers (wagtail_forum contract)', () => {
+  // -------------------------------------------------------------------------
+  // Boards → Category
+  // -------------------------------------------------------------------------
 
-  it('maps a forum to a category (renames counts, derives slug)', () => {
-    const c = mapForumToCategory({
+  it('mapBoardToCategory maps id, title→name, slug, counts', () => {
+    const c = mapBoardToCategory({
       id: 3,
-      name: 'Plant Care',
+      title: 'Plant Care',
+      slug: 'plant-care',
       description: 'Tips',
-      topics_count: 10,
-      posts_count: 42,
-      last_activity: '2026-01-02T00:00:00Z',
+      topic_count: 10,
+      post_count: 42,
     });
     expect(c).toMatchObject({
       id: '3',
       name: 'Plant Care',
       slug: 'plant-care',
+      description: 'Tips',
       thread_count: 10,
       post_count: 42,
     });
   });
 
-  it('maps a topic to a thread (subject->title, last_post_on->last_activity_at)', () => {
-    const t = mapTopicToThread({
+  it('mapBoardToCategory defaults counts to 0 when absent', () => {
+    const c = mapBoardToCategory({ id: 1, title: 'X', slug: 'x' });
+    expect(c.thread_count).toBe(0);
+    expect(c.post_count).toBe(0);
+  });
+
+  // -------------------------------------------------------------------------
+  // TopicListItem → Thread
+  // -------------------------------------------------------------------------
+
+  it('mapTopicListItemToThread maps core fields', () => {
+    const t = mapTopicListItemToThread({
       id: 12,
-      subject: 'Succulent help',
-      poster: { id: 1, username: 'jdoe', first_name: 'Jane', last_name: 'Doe' },
-      forum: { id: 3, name: 'Plant Care', slug: 'plant-care' },
-      created: '2026-01-01T00:00:00Z',
-      posts_count: 5,
-      last_post_on: '2026-01-02T00:00:00Z',
-      replies_count: 4,
-      views_count: 99,
+      title: 'Succulent help',
+      slug: 'succulent-help',
+      author: 'jdoe',
+      is_pinned: false,
+      is_closed: false,
+      reply_count: 4,
+      view_count: 99,
+      last_post_at: '2026-01-02T00:00:00Z',
+      last_post_author: 'jdoe',
     });
     expect(t).toMatchObject({
       id: '12',
       title: 'Succulent help',
       slug: 'succulent-help',
-      category: { id: '3', name: 'Plant Care', slug: 'plant-care' },
+      post_count: 4,
+      view_count: 99,
+      last_activity_at: '2026-01-02T00:00:00Z',
+      is_pinned: false,
+      is_locked: false,
+    });
+    expect(t.author?.username).toBe('jdoe');
+  });
+
+  it('mapTopicListItemToThread handles null author ([deleted])', () => {
+    const t = mapTopicListItemToThread({
+      id: 1,
+      title: 'T',
+      slug: 't',
+      author: null,
+      is_pinned: false,
+      is_closed: false,
+      reply_count: 0,
+      view_count: 0,
+      last_post_at: null,
+      last_post_author: null,
+    });
+    expect(t.author?.username).toBe('[deleted]');
+  });
+
+  it('mapTopicListItemToThread maps is_closed → is_locked', () => {
+    const base = {
+      id: 1,
+      title: 'T',
+      slug: 't',
+      author: 'u',
+      is_pinned: false,
+      is_closed: true,
+      reply_count: 0,
+      view_count: 0,
+      last_post_at: null,
+      last_post_author: null,
+    };
+    expect(mapTopicListItemToThread(base).is_locked).toBe(true);
+    expect(mapTopicListItemToThread({ ...base, is_closed: false }).is_locked).toBe(false);
+    expect(mapTopicListItemToThread({ ...base, is_pinned: true }).is_pinned).toBe(true);
+  });
+
+  // -------------------------------------------------------------------------
+  // TopicDetail → Thread
+  // -------------------------------------------------------------------------
+
+  it('mapTopicDetailToThread maps board→category and all fields', () => {
+    const t = mapTopicDetailToThread({
+      id: 12,
+      title: 'Succulent help',
+      slug: 'succulent-help',
+      board: { id: 3, slug: 'plant-care', title: 'Plant Care' },
+      author: 'jdoe',
+      is_pinned: true,
+      is_closed: false,
+      locked: false,
+      reply_count: 5,
+      view_count: 99,
+      created_at: '2026-01-01T00:00:00Z',
+      last_post_at: '2026-01-02T00:00:00Z',
+      last_post_author: 'jdoe',
+      opening_post_id: 50,
+    });
+    expect(t).toMatchObject({
+      id: '12',
+      title: 'Succulent help',
+      slug: 'succulent-help',
+      created_at: '2026-01-01T00:00:00Z',
       last_activity_at: '2026-01-02T00:00:00Z',
       post_count: 5,
       view_count: 99,
+      is_pinned: true,
+      is_locked: false,
     });
-    expect(t.author?.display_name).toBe('Jane Doe');
-    expect(t.is_pinned).toBe(false);
-    expect(t.is_locked).toBe(false);
+    expect(t.category).toMatchObject({ id: '3', slug: 'plant-care', name: 'Plant Care' });
   });
 
-  it('maps topic type=1 (sticky) to is_pinned=true, status=1 (locked) to is_locked=true', () => {
-    const base = {
+  it('mapTopicDetailToThread treats locked=true as is_locked', () => {
+    const t = mapTopicDetailToThread({
       id: 1,
-      subject: 'S',
-      poster: null,
-      forum: null,
-      created: '2026-01-01T00:00:00Z',
-    };
-    expect(mapTopicToThread({ ...base, type: 1 }).is_pinned).toBe(true);
-    expect(mapTopicToThread({ ...base, type: 0 }).is_pinned).toBe(false);
-    expect(mapTopicToThread({ ...base, type: 2 }).is_pinned).toBe(false);
-    expect(mapTopicToThread({ ...base, status: 1 }).is_locked).toBe(true);
-    expect(mapTopicToThread({ ...base, status: 0 }).is_locked).toBe(false);
+      title: 'T',
+      slug: 't',
+      board: { id: 1, slug: 'b', title: 'B' },
+      author: null,
+      is_pinned: false,
+      is_closed: false,
+      locked: true,
+      reply_count: 0,
+      view_count: 0,
+      created_at: '2026-01-01T00:00:00Z',
+      last_post_at: null,
+      last_post_author: null,
+      opening_post_id: null,
+    });
+    expect(t.is_locked).toBe(true);
   });
 
-  it('maps a post (content->content_raw, created->created_at)', () => {
+  // -------------------------------------------------------------------------
+  // BackendPost → Post
+  // -------------------------------------------------------------------------
+
+  it('mapPostToPost maps id, thread, author object, body, reaction_counts', () => {
     const p = mapPostToPost(
       {
         id: 50,
-        content: '<p>hello</p>',
-        poster: { id: 1, username: 'jdoe', first_name: '', last_name: '' },
-        created: '2026-01-01T00:00:00Z',
-        updated: '2026-01-01T00:00:00Z',
-        content_format: 'html',
+        topic_id: 12,
+        author: { username: 'jdoe', display_name: 'Jane Doe', trust_level: 'member' },
+        body: [{ type: 'paragraph', value: 'hello', id: 'blk-1' }],
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-01T00:00:00Z',
+        edited_at: null,
+        is_opening_post: true,
+        status: 'live',
+        reaction_counts: { like: 3 },
+        can_edit: true,
+        can_delete: false,
       },
       '12'
     );
     expect(p).toMatchObject({
       id: '50',
       thread: '12',
-      content_raw: '<p>hello</p>',
-      content_format: 'html',
-      reaction_counts: {},
+      is_first_post: true,
+      is_active: true,
+      reaction_counts: { like: 3 },
+      can_edit: true,
+      can_delete: false,
     });
+    expect(p.author?.username).toBe('jdoe');
+    expect(p.author?.display_name).toBe('Jane Doe');
+    expect(p.body).toHaveLength(1);
+    expect(p.body?.[0].type).toBe('paragraph');
   });
 
-  it('maps reaction_counts from the backend post when present', () => {
+  it('mapPostToPost maps [deleted] author object', () => {
     const p = mapPostToPost(
       {
         id: 51,
-        content: '<p>hi</p>',
-        poster: { id: 1, username: 'jdoe', first_name: '', last_name: '' },
-        created: '2026-01-01T00:00:00Z',
-        updated: '2026-01-01T00:00:00Z',
-        content_format: 'html',
-        reaction_counts: { like: 3, love: 1 },
+        topic_id: 12,
+        author: { username: '[deleted]', display_name: '[deleted]', trust_level: null },
+        body: [],
+        created_at: '2026-01-01T00:00:00Z',
+        is_opening_post: false,
+        status: 'live',
+        reaction_counts: {},
+        can_edit: false,
+        can_delete: false,
       },
       '12'
     );
-    expect(p.reaction_counts).toEqual({ like: 3, love: 1 });
+    expect(p.author?.username).toBe('[deleted]');
+    expect(p.author?.display_name).toBe('[deleted]');
   });
 
-  it('maps an image to an attachment (image_url->image, upload_order->display_order)', () => {
+  it('mapPostToPost sets is_active=false for pending posts', () => {
+    const p = mapPostToPost(
+      {
+        id: 52,
+        topic_id: 12,
+        author: { username: 'u', display_name: 'U', trust_level: null },
+        body: [],
+        created_at: '2026-01-01T00:00:00Z',
+        is_opening_post: false,
+        status: 'pending',
+        reaction_counts: {},
+        can_edit: false,
+        can_delete: false,
+      },
+      '12'
+    );
+    expect(p.is_active).toBe(false);
+  });
+
+  // -------------------------------------------------------------------------
+  // Search mappers
+  // -------------------------------------------------------------------------
+
+  it('mapSearchTopicToThread maps id, title, slug', () => {
+    const t = mapSearchTopicToThread({ id: 7, slug: 'my-topic', title: 'My Topic' });
+    expect(t).toMatchObject({ id: '7', title: 'My Topic', slug: 'my-topic' });
+  });
+
+  it('mapSearchPostToPost maps id, topic_id→thread, excerpt→content_raw', () => {
+    const p = mapSearchPostToPost({
+      id: 99,
+      topic_id: 7,
+      topic_title: 'My Topic',
+      excerpt: 'Some excerpt',
+    });
+    expect(p).toMatchObject({ id: '99', thread: '7', content_raw: 'Some excerpt' });
+  });
+
+  // -------------------------------------------------------------------------
+  // Image → Attachment (unchanged)
+  // -------------------------------------------------------------------------
+
+  it('mapImageToAttachment maps image_url, thumbnail_url, upload_order→display_order', () => {
     const a = mapImageToAttachment({
       id: 7,
       image_url: 'http://x/a.jpg',

--- a/web/src/services/forumMappers.ts
+++ b/web/src/services/forumMappers.ts
@@ -1,4 +1,5 @@
-import type { Category, Thread, Post, Attachment, StreamFieldBlock } from '../types/forum';
+import type { StreamFieldBlock } from '../types/blog';
+import type { Category, Thread, Post, Attachment } from '../types/forum';
 
 // ---------------------------------------------------------------------------
 // Backend shapes — wagtail_forum API contract
@@ -43,9 +44,8 @@ export interface BackendTopicDetail {
   opening_post_id: number | null;
 }
 
-// StreamFieldBlock is defined in types/forum.ts and re-exported below for
-// consumers that import backend shapes from this module.
-export type { StreamFieldBlock } from '../types/forum';
+// StreamFieldBlock re-exported for consumers that import backend shapes from this module.
+export type { StreamFieldBlock } from '../types/blog';
 
 export interface BackendPostAuthor {
   username: string;

--- a/web/src/services/forumMappers.ts
+++ b/web/src/services/forumMappers.ts
@@ -1,49 +1,87 @@
-import { slugifyTitle } from '../utils/forumUrls';
-import type { Category, Thread, Post, Attachment } from '../types/forum';
+import type { Category, Thread, Post, Attachment, StreamFieldBlock } from '../types/forum';
 
-// Backend response shapes (machina-flavored). Kept local — internal to the service layer.
-export interface BackendUser {
+// ---------------------------------------------------------------------------
+// Backend shapes — wagtail_forum API contract
+// ---------------------------------------------------------------------------
+
+export interface BackendBoard {
   id: number;
-  username: string;
-  first_name?: string;
-  last_name?: string;
-}
-export interface BackendForum {
-  id: number;
-  name: string;
+  title: string;
+  slug: string;
   description?: string;
-  topics_count?: number;
-  posts_count?: number;
-  last_activity?: string | null;
-  slug?: string | null;
+  topic_count?: number;
+  post_count?: number;
 }
-export interface BackendTopic {
+
+export interface BackendTopicListItem {
   id: number;
-  subject: string;
-  poster: BackendUser | null;
-  forum: { id: number; name: string; slug?: string | null } | null;
-  created: string;
-  posts_count?: number;
-  last_post_on?: string | null;
-  replies_count?: number;
-  views_count?: number;
-  /** Machina Topic.type: 0=post, 1=sticky, 2=announce */
-  type?: number;
-  /** Machina Topic.status: 0=unlocked, 1=locked */
-  status?: number;
+  title: string;
+  slug: string;
+  author: string | null;
+  is_pinned: boolean;
+  is_closed: boolean;
+  reply_count: number;
+  view_count: number;
+  last_post_at: string | null;
+  last_post_author: string | null;
 }
+
+export interface BackendTopicDetail {
+  id: number;
+  title: string;
+  slug: string;
+  board: { id: number; slug: string; title: string };
+  author: string | null;
+  is_pinned: boolean;
+  is_closed: boolean;
+  locked: boolean;
+  reply_count: number;
+  view_count: number;
+  created_at: string;
+  last_post_at: string | null;
+  last_post_author: string | null;
+  opening_post_id: number | null;
+}
+
+// StreamFieldBlock is defined in types/forum.ts and re-exported below for
+// consumers that import backend shapes from this module.
+export type { StreamFieldBlock } from '../types/forum';
+
+export interface BackendPostAuthor {
+  username: string;
+  display_name: string;
+  trust_level: string | null;
+}
+
 export interface BackendPost {
   id: number;
-  content: string;
-  poster: BackendUser | null;
-  created: string;
-  updated?: string;
-  content_format?: string;
-  /** Map of reaction_type -> active count, e.g. { like: 5, love: 2 }. */
-  reaction_counts?: Record<string, number>;
-  /** The post's topic (thread) id (todo 112). */
-  topic_id?: number;
+  topic_id: number;
+  author: BackendPostAuthor;
+  body: StreamFieldBlock[];
+  created_at: string;
+  updated_at?: string;
+  edited_at?: string | null;
+  is_opening_post: boolean;
+  status: 'live' | 'pending';
+  reaction_counts: Record<string, number>;
+  can_edit: boolean;
+  can_delete: boolean;
 }
+
+export interface BackendSearchTopic {
+  id: number;
+  slug: string;
+  title: string;
+}
+
+export interface BackendSearchPost {
+  id: number;
+  topic_id: number;
+  topic_title: string;
+  excerpt: string;
+}
+
+// Image shape stays — used by write functions (Phase 2/3).
 export interface BackendImage {
   id: number;
   image_url?: string | null;
@@ -56,59 +94,87 @@ export interface BackendImage {
   created_at?: string;
 }
 
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
 type ForumAuthor = Thread['author'];
 
-const DELETED_USER = {
-  id: '',
-  username: '[deleted]',
-  display_name: '[deleted]',
-} as unknown as ForumAuthor;
+/** Build a forum author from a plain string username (topic list/detail). */
+function authorFromString(username: string | null): ForumAuthor {
+  if (!username) {
+    return { id: '', username: '[deleted]', display_name: '[deleted]' } as unknown as ForumAuthor;
+  }
+  return { id: '', username, display_name: username } as unknown as ForumAuthor;
+}
 
-export function mapUser(u: BackendUser | null): ForumAuthor {
-  if (!u) return DELETED_USER;
-  const fullName = [u.first_name, u.last_name].filter(Boolean).join(' ').trim();
-  // Translation boundary: the backend user shape is narrower than the auth `User`
-  // type the forum reuses, and forum ids are strings. Cast through `unknown`.
+/** Build a forum author from the post author object. */
+function authorFromObject(a: BackendPostAuthor): ForumAuthor {
+  if (a.username === '[deleted]') {
+    return { id: '', username: '[deleted]', display_name: '[deleted]' } as unknown as ForumAuthor;
+  }
   return {
-    id: String(u.id),
-    username: u.username,
-    display_name: fullName || u.username,
+    id: '',
+    username: a.username,
+    display_name: a.display_name || a.username,
+    trust_level: a.trust_level ?? undefined,
   } as unknown as ForumAuthor;
 }
 
-export function mapForumToCategory(f: BackendForum): Category {
+// ---------------------------------------------------------------------------
+// Mappers
+// ---------------------------------------------------------------------------
+
+export function mapBoardToCategory(b: BackendBoard): Category {
   return {
-    id: String(f.id),
-    name: f.name,
-    slug: f.slug || slugifyTitle(f.name),
-    description: f.description,
-    thread_count: f.topics_count ?? 0,
-    post_count: f.posts_count ?? 0,
-    created_at: f.last_activity || '',
+    id: String(b.id),
+    name: b.title,
+    slug: b.slug,
+    description: b.description,
+    thread_count: b.topic_count ?? 0,
+    post_count: b.post_count ?? 0,
+    created_at: '',
   };
 }
 
-export function mapTopicToThread(t: BackendTopic): Thread {
-  const category: Category = t.forum
-    ? {
-        id: String(t.forum.id),
-        name: t.forum.name,
-        slug: t.forum.slug || slugifyTitle(t.forum.name),
-        created_at: '',
-      }
-    : { id: '', name: '', slug: '', created_at: '' };
+export function mapTopicListItemToThread(t: BackendTopicListItem): Thread {
   return {
     id: String(t.id),
-    title: t.subject,
-    slug: slugifyTitle(t.subject),
+    title: t.title,
+    slug: t.slug,
+    // No category info on the list item — caller must supply or leave empty
+    category: { id: '', name: '', slug: '', created_at: '' },
+    author: authorFromString(t.author),
+    // list item has no created_at; use last_post_at as best proxy
+    created_at: t.last_post_at || '',
+    last_activity_at: t.last_post_at || '',
+    post_count: t.reply_count,
+    view_count: t.view_count,
+    is_pinned: t.is_pinned,
+    is_locked: t.is_closed,
+    is_active: true,
+  };
+}
+
+export function mapTopicDetailToThread(t: BackendTopicDetail): Thread {
+  const category: Category = {
+    id: String(t.board.id),
+    name: t.board.title,
+    slug: t.board.slug,
+    created_at: '',
+  };
+  return {
+    id: String(t.id),
+    title: t.title,
+    slug: t.slug,
     category,
-    author: mapUser(t.poster),
-    created_at: t.created,
-    last_activity_at: t.last_post_on || t.created,
-    post_count: t.posts_count ?? 0,
-    view_count: t.views_count ?? 0,
-    is_pinned: (t.type ?? 0) === 1,
-    is_locked: (t.status ?? 0) === 1,
+    author: authorFromString(t.author),
+    created_at: t.created_at,
+    last_activity_at: t.last_post_at || t.created_at,
+    post_count: t.reply_count,
+    view_count: t.view_count,
+    is_pinned: t.is_pinned,
+    is_locked: t.is_closed || t.locked,
     is_active: true,
   };
 }
@@ -117,14 +183,48 @@ export function mapPostToPost(p: BackendPost, threadId: string): Post {
   return {
     id: String(p.id),
     thread: threadId,
-    author: mapUser(p.poster),
-    content_raw: p.content,
-    content_html: p.content,
-    content_format: p.content_format || 'html',
-    created_at: p.created,
-    updated_at: p.updated,
-    is_active: true,
+    author: authorFromObject(p.author),
+    content_raw: '', // StreamField body — no plain-text equivalent; Task 6 renders body blocks
+    content_html: undefined,
+    content_format: 'draftail',
+    body: p.body,
+    created_at: p.created_at,
+    updated_at: p.updated_at,
+    edited_at: p.edited_at ?? undefined,
+    is_first_post: p.is_opening_post,
+    is_active: p.status === 'live',
     reaction_counts: p.reaction_counts ?? {},
+    can_edit: p.can_edit,
+    can_delete: p.can_delete,
+  };
+}
+
+export function mapSearchTopicToThread(t: BackendSearchTopic): Thread {
+  return {
+    id: String(t.id),
+    title: t.title,
+    slug: t.slug,
+    category: { id: '', name: '', slug: '', created_at: '' },
+    author: authorFromString(null),
+    created_at: '',
+    last_activity_at: '',
+    is_active: true,
+  };
+}
+
+export function mapSearchPostToPost(p: BackendSearchPost): Post {
+  return {
+    id: String(p.id),
+    thread: String(p.topic_id),
+    author: authorFromString(null),
+    content_raw: p.excerpt,
+    content_format: 'plain',
+    body: [],
+    created_at: '',
+    is_active: true,
+    reaction_counts: {},
+    can_edit: false,
+    can_delete: false,
   };
 }
 

--- a/web/src/services/forumMappers.ts
+++ b/web/src/services/forumMappers.ts
@@ -225,6 +225,7 @@ export function mapSearchPostToPost(p: BackendSearchPost): Post {
     reaction_counts: {},
     can_edit: false,
     can_delete: false,
+    topic_title: p.topic_title,
   };
 }
 

--- a/web/src/services/forumService.test.ts
+++ b/web/src/services/forumService.test.ts
@@ -17,35 +17,67 @@ import {
 } from './forumService';
 import { clearCsrfToken } from '../utils/csrf';
 
-const backendUser = { id: 1, username: 'jdoe', first_name: 'Jane', last_name: 'Doe' };
-const backendForum = {
+// ---------------------------------------------------------------------------
+// Backend fixture shapes (wagtail_forum contract)
+// ---------------------------------------------------------------------------
+
+const backendBoard = {
   id: 3,
-  name: 'Plant Care',
+  title: 'Plant Care',
+  slug: 'plant-care',
   description: 'Tips',
-  topics_count: 2,
-  posts_count: 9,
-  last_activity: '2026-01-02T00:00:00Z',
+  topic_count: 2,
+  post_count: 9,
 };
-const backendTopic = {
+
+const backendTopicListItem = {
   id: 12,
-  subject: 'Succulent help',
-  poster: backendUser,
-  forum: { id: 3, name: 'Plant Care', slug: 'plant-care' },
-  created: '2026-01-01T00:00:00Z',
-  posts_count: 5,
-  last_post_on: '2026-01-02T00:00:00Z',
-  replies_count: 4,
-  views_count: 99,
+  title: 'Succulent help',
+  slug: 'succulent-help',
+  author: 'jdoe',
+  is_pinned: false,
+  is_closed: false,
+  reply_count: 4,
+  view_count: 99,
+  last_post_at: '2026-01-02T00:00:00Z',
+  last_post_author: 'jdoe',
 };
+
+const backendTopicDetail = {
+  id: 12,
+  title: 'Succulent help',
+  slug: 'succulent-help',
+  board: { id: 3, slug: 'plant-care', title: 'Plant Care' },
+  author: 'jdoe',
+  is_pinned: false,
+  is_closed: false,
+  locked: false,
+  reply_count: 4,
+  view_count: 99,
+  created_at: '2026-01-01T00:00:00Z',
+  last_post_at: '2026-01-02T00:00:00Z',
+  last_post_author: 'jdoe',
+  opening_post_id: 50,
+};
+
 const backendPost = {
   id: 50,
-  content: '<p>hello</p>',
-  poster: backendUser,
-  created: '2026-01-01T00:00:00Z',
-  updated: '2026-01-01T00:00:00Z',
-  content_format: 'html',
   topic_id: 12,
+  author: { username: 'jdoe', display_name: 'Jane Doe', trust_level: 'member' },
+  body: [{ type: 'paragraph', value: 'hello', id: 'blk-1' }],
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+  edited_at: null,
+  is_opening_post: false,
+  status: 'live' as const,
+  reaction_counts: {},
+  can_edit: false,
+  can_delete: false,
 };
+
+// ---------------------------------------------------------------------------
+// Test harness
+// ---------------------------------------------------------------------------
 
 let fetchMock: ReturnType<typeof vi.fn>;
 let cookie: string;
@@ -80,66 +112,159 @@ function okJson(body: unknown) {
   return { ok: true, status: 200, json: async () => body };
 }
 
-describe('forumService (translation layer)', () => {
-  it('fetchCategories unwraps DRF results and maps fields', async () => {
-    fetchMock.mockResolvedValueOnce(okJson({ results: [backendForum], count: 1 }));
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('forumService (wagtail_forum API contract)', () => {
+  // --- Categories (boards) --------------------------------------------------
+
+  it('fetchCategories hits /boards/ and maps board→category', async () => {
+    fetchMock.mockResolvedValueOnce(okJson({ results: [backendBoard] }));
     const result = await fetchCategories();
     expect(result[0]).toMatchObject({
       id: '3',
       name: 'Plant Care',
+      slug: 'plant-care',
       thread_count: 2,
       post_count: 9,
     });
     expect(fetchMock).toHaveBeenCalledWith(
-      expect.stringContaining('/api/v1/forum/categories/'),
+      expect.stringContaining('/api/v1/forum/boards/'),
       expect.objectContaining({ credentials: 'include' })
     );
   });
 
-  it('fetchCategory resolves by integer id from the list', async () => {
-    fetchMock.mockResolvedValueOnce(okJson({ results: [backendForum], count: 1 }));
+  it('fetchCategory resolves by integer id from /boards/', async () => {
+    fetchMock.mockResolvedValueOnce(okJson({ results: [backendBoard] }));
     const c = await fetchCategory(3);
     expect(c.id).toBe('3');
+    expect(c.slug).toBe('plant-care');
   });
 
-  it('fetchThreads hits the category topics endpoint and maps topics->threads', async () => {
+  it('fetchCategory throws when id not found', async () => {
+    fetchMock.mockResolvedValueOnce(okJson({ results: [backendBoard] }));
+    await expect(fetchCategory(999)).rejects.toThrow('Category not found');
+  });
+
+  // --- Threads (topics) -----------------------------------------------------
+
+  it('fetchThreads hits /boards/{board}/topics/ and maps list items', async () => {
     fetchMock.mockResolvedValueOnce(
-      okJson({ results: [backendTopic], count: 1, next: null, previous: null })
+      okJson({ results: [backendTopicListItem], next: null, previous: null })
     );
-    const result = await fetchThreads({ category: 3, page: 1 });
-    expect(result.items[0]).toMatchObject({ id: '12', title: 'Succulent help', post_count: 5 });
-    expect(result.meta.count).toBe(1);
+    const result = await fetchThreads({ board: 'plant-care' });
+    expect(result.items[0]).toMatchObject({
+      id: '12',
+      title: 'Succulent help',
+      post_count: 4,
+      view_count: 99,
+    });
+    expect(result.meta.next).toBeNull();
     expect(fetchMock).toHaveBeenCalledWith(
-      expect.stringContaining('/categories/3/topics/?page=1'),
+      expect.stringContaining('/boards/plant-care/topics/'),
       expect.any(Object)
     );
   });
 
-  it('fetchThreads without category hits /topics/', async () => {
-    fetchMock.mockResolvedValueOnce(okJson({ results: [backendTopic], count: 1 }));
-    await fetchThreads({ page: 2 });
-    expect(fetchMock).toHaveBeenCalledWith(
-      expect.stringContaining('/topics/?page=2'),
-      expect.any(Object)
-    );
+  it('fetchThreads throws when board is omitted', async () => {
+    await expect(fetchThreads()).rejects.toThrow('A board slug is required');
   });
 
-  it('fetchThread unwraps {topic} from the detail endpoint', async () => {
+  it('fetchThreads uses cursor URL directly (absolute URL, no double-prefix)', async () => {
+    // DRF cursor `next` is an absolute URL. authenticatedFetch passes the url
+    // arg straight to fetch() with no base prepended — so the absolute URL
+    // must reach fetch() unchanged.
+    const absoluteCursor = 'http://localhost:8000/api/v1/forum/topics/12/posts/?cursor=abc123';
     fetchMock.mockResolvedValueOnce(
-      okJson({ topic: backendTopic, posts: { results: [], count: 0 } })
+      okJson({ results: [backendTopicListItem], next: null, previous: null })
     );
+    await fetchThreads({ board: 'plant-care', cursor: absoluteCursor });
+    expect(fetchMock).toHaveBeenCalledWith(absoluteCursor, expect.any(Object));
+  });
+
+  // --- Thread detail --------------------------------------------------------
+
+  it('fetchThread hits /topics/{id}/ and maps detail shape', async () => {
+    fetchMock.mockResolvedValueOnce(okJson(backendTopicDetail));
     const t = await fetchThread(12);
-    expect(t).toMatchObject({ id: '12', title: 'Succulent help' });
+    expect(t).toMatchObject({
+      id: '12',
+      title: 'Succulent help',
+      post_count: 4,
+    });
+    expect(t.category).toMatchObject({ id: '3', slug: 'plant-care' });
     expect(fetchMock).toHaveBeenCalledWith(
       expect.stringContaining('/topics/12/'),
       expect.any(Object)
     );
   });
 
-  it('createThread posts subject/content to the create endpoint', async () => {
-    fetchMock.mockResolvedValueOnce(
-      okJson({ message: 'ok', topic: backendTopic, first_post_id: 50 })
+  // --- Posts ----------------------------------------------------------------
+
+  it('fetchPosts hits /topics/{id}/posts/ and maps posts', async () => {
+    fetchMock.mockResolvedValueOnce(okJson({ results: [backendPost], next: null, previous: null }));
+    const result = await fetchPosts({ thread: 12 });
+    expect(result.items[0]).toMatchObject({ id: '50', thread: '12' });
+    expect(result.items[0].body).toHaveLength(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining('/topics/12/posts/'),
+      expect.any(Object)
     );
+  });
+
+  it('fetchPosts uses absolute cursor URL directly (no double-prefix)', async () => {
+    const absoluteCursor = 'http://localhost:8000/api/v1/forum/topics/12/posts/?cursor=xyz789';
+    fetchMock.mockResolvedValueOnce(okJson({ results: [backendPost], next: null, previous: null }));
+    await fetchPosts({ thread: 12, cursor: absoluteCursor });
+    expect(fetchMock).toHaveBeenCalledWith(absoluteCursor, expect.any(Object));
+  });
+
+  it('fetchPosts throws when thread is missing', async () => {
+    // @ts-expect-error — intentionally passing bad args to test runtime guard
+    await expect(fetchPosts({})).rejects.toThrow('Thread id is required');
+  });
+
+  it('fetchPosts carries cursor links in meta', async () => {
+    const nextUrl = 'http://localhost:8000/api/v1/forum/topics/12/posts/?cursor=next';
+    fetchMock.mockResolvedValueOnce(
+      okJson({ results: [backendPost], next: nextUrl, previous: null })
+    );
+    const result = await fetchPosts({ thread: 12 });
+    expect(result.meta.next).toBe(nextUrl);
+    expect(result.meta.previous).toBeNull();
+  });
+
+  // --- Search ---------------------------------------------------------------
+
+  it('searchForum hits /search/?q= and maps topics→threads, posts→posts', async () => {
+    fetchMock.mockResolvedValueOnce(
+      okJson({
+        topics: [{ id: 12, slug: 'succulent-help', title: 'Succulent help' }],
+        posts: [{ id: 50, topic_id: 12, topic_title: 'Succulent help', excerpt: 'hello' }],
+      })
+    );
+    const r = await searchForum({ q: 'succ' });
+    expect(r.threads[0].id).toBe('12');
+    expect(r.posts[0].id).toBe('50');
+    expect(r.posts[0].thread).toBe('12');
+    expect(r.posts[0].content_raw).toBe('hello');
+    expect(r.total_threads).toBe(1);
+    expect(r.total_posts).toBe(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining('/search/?q=succ'),
+      expect.any(Object)
+    );
+  });
+
+  it('searchForum rejects empty queries', async () => {
+    await expect(searchForum({ q: '   ' })).rejects.toThrow('Search query is required');
+  });
+
+  // --- Write functions (structurally intact, Phase 2) -----------------------
+
+  it('createThread posts to /categories/{id}/topics/create/ (Phase 2 placeholder)', async () => {
+    fetchMock.mockResolvedValueOnce(okJson({ topic: backendTopicDetail }));
     const t = await createThread({
       title: 'Succulent help',
       category: 3,
@@ -150,14 +275,6 @@ describe('forumService (translation layer)', () => {
     const [url, opts] = fetchMock.mock.calls[0];
     expect(url).toContain('/categories/3/topics/create/');
     expect(opts.method).toBe('POST');
-    expect(JSON.parse(opts.body)).toMatchObject({ subject: 'Succulent help', content: 'hello' });
-  });
-
-  it('fetchPosts queries by topic id and maps posts', async () => {
-    fetchMock.mockResolvedValueOnce(okJson({ results: [backendPost], count: 1 }));
-    const result = await fetchPosts({ thread: 12, page: 1 });
-    expect(result.items[0]).toMatchObject({ id: '50', thread: '12', content_raw: '<p>hello</p>' });
-    expect(fetchMock).toHaveBeenCalledWith(expect.stringContaining('topic=12'), expect.any(Object));
   });
 
   it('createPost posts to /posts/create/ and unwraps {data}', async () => {
@@ -170,21 +287,15 @@ describe('forumService (translation layer)', () => {
   });
 
   it('createPost throws a clear error when the response is missing {data}', async () => {
-    // Defensive guard (todo 111): the old {message, post} shape (no `data`) must
-    // throw clearly rather than crash inside mapPostToPost on undefined.id.
     fetchMock.mockResolvedValueOnce(okJson({ message: 'ok', post: backendPost }));
     await expect(
       createPost({ thread: 12, content_raw: 'hi', content_format: 'html' })
     ).rejects.toThrow(/missing "data"/);
   });
 
-  it('updatePost maps topic_id to a non-empty thread (todo 112)', async () => {
-    fetchMock.mockResolvedValueOnce(
-      okJson({ message: 'ok', data: { ...backendPost, content: '<p>edited</p>', topic_id: 77 } })
-    );
+  it('updatePost maps topic_id to thread', async () => {
+    fetchMock.mockResolvedValueOnce(okJson({ data: { ...backendPost, topic_id: 77 } }));
     const p = await updatePost('50', { content_raw: '<p>edited</p>', content_format: 'html' });
-    expect(p.content_raw).toBe('<p>edited</p>');
-    // todo 112: was '' (broken). Now the real topic id from the response.
     expect(p.thread).toBe('77');
     const [url, opts] = fetchMock.mock.calls[0];
     expect(url).toContain('/posts/50/');
@@ -203,7 +314,6 @@ describe('forumService (translation layer)', () => {
   it('toggleReaction posts reaction_type and normalizes counts', async () => {
     fetchMock.mockResolvedValueOnce(
       okJson({
-        success: true,
         action: 'added',
         reaction_type: 'like',
         reactions: { like: { count: 3, users: [] } },
@@ -224,10 +334,8 @@ describe('forumService (translation layer)', () => {
   it('fetchReactions normalizes counts and user_reactions', async () => {
     fetchMock.mockResolvedValueOnce(
       okJson({
-        post_id: 50,
         reactions: { like: { count: 3, users: [] } },
         user_reactions: [],
-        total_reactions: 3,
       })
     );
     const r = await fetchReactions('50');
@@ -238,11 +346,9 @@ describe('forumService (translation layer)', () => {
     const file = new File(['x'], 'a.jpg', { type: 'image/jpeg' });
     fetchMock.mockResolvedValueOnce(
       okJson({
-        message: 'ok',
         images: [
           { id: 7, image_url: 'http://x/a.jpg', thumbnail_url: 'http://x/t.jpg', upload_order: 0 },
         ],
-        post_id: 50,
       })
     );
     const a = await uploadPostImage('50', file);
@@ -262,25 +368,7 @@ describe('forumService (translation layer)', () => {
     );
   });
 
-  it('searchForum maps topics->threads and posts->posts', async () => {
-    fetchMock.mockResolvedValueOnce(
-      okJson({ query: 'succ', topics: [backendTopic], posts: [backendPost] })
-    );
-    const r = await searchForum({ q: 'succ' });
-    expect(r.threads[0].id).toBe('12');
-    expect(r.posts[0].id).toBe('50');
-    // todo 112: search posts get a real thread id from topic_id, not ''.
-    expect(r.posts[0].thread).toBe('12');
-    expect(r.total_threads).toBe(1);
-    expect(fetchMock).toHaveBeenCalledWith(
-      expect.stringContaining('/search/?q=succ'),
-      expect.any(Object)
-    );
-  });
-
-  it('searchForum rejects empty queries', async () => {
-    await expect(searchForum({ q: '   ' })).rejects.toThrow('Search query is required');
-  });
+  // --- Error propagation ----------------------------------------------------
 
   it('propagates backend errors with detail', async () => {
     fetchMock.mockResolvedValueOnce({
@@ -297,12 +385,7 @@ describe('forumService (translation layer)', () => {
     fetchMock.mockResolvedValueOnce({
       ok: false,
       status: 403,
-      json: async () => ({
-        error: true,
-        message: 'Permission denied',
-        code: 'forbidden',
-        status_code: 403,
-      }),
+      json: async () => ({ message: 'Permission denied' }),
     });
     await expect(createPost({ thread: 12, content_raw: 'x' })).rejects.toThrow('Permission denied');
   });

--- a/web/src/services/forumService.ts
+++ b/web/src/services/forumService.ts
@@ -1,21 +1,28 @@
 /**
  * Forum API Service — translation layer.
  *
- * The backend serves an id-based, machina-shaped API; this module calls those
- * real endpoints and maps responses to the clean React domain types.
- * Lookups use integer ids (parsed from hybrid id+slug route params).
+ * READ functions target the wagtail_forum API contract (Tasks 1-4).
+ * WRITE functions (createThread, createPost, updatePost, deletePost,
+ * toggleReaction, image fns) are Phase 2/3 — left structurally intact
+ * so they still compile, but their endpoints will 404 until Phase 2 lands.
  *
  * Cookie-based JWT auth with CSRF on mutating requests.
  */
 import { getCsrfToken } from '../utils/csrf';
 import {
-  mapForumToCategory,
-  mapTopicToThread,
+  mapBoardToCategory,
+  mapTopicListItemToThread,
+  mapTopicDetailToThread,
   mapPostToPost,
+  mapSearchTopicToThread,
+  mapSearchPostToPost,
   mapImageToAttachment,
-  type BackendForum,
-  type BackendTopic,
+  type BackendBoard,
+  type BackendTopicListItem,
+  type BackendTopicDetail,
   type BackendPost,
+  type BackendSearchTopic,
+  type BackendSearchPost,
   type BackendImage,
 } from './forumMappers';
 import type {
@@ -61,20 +68,24 @@ async function authenticatedFetch<T>(url: string, options: RequestInit = {}): Pr
 }
 
 // ---------------------------------------------------------------------------
-// Categories
+// Categories (boards)
 // ---------------------------------------------------------------------------
 
 export async function fetchCategories(): Promise<Category[]> {
-  const data = await authenticatedFetch<DrfPage<BackendForum>>(`${FORUM_BASE}/categories/`);
-  return (data.results || []).map(mapForumToCategory);
+  // BoardListView returns {results: [...]} (pagination_class = None, but still
+  // wraps in {results} via its custom list() override — verified in views.py:111).
+  const data = await authenticatedFetch<{ results: BackendBoard[] }>(`${FORUM_BASE}/boards/`);
+  return (data.results || []).map(mapBoardToCategory);
 }
 
 /** No backend tree endpoint — returns the flat list (no children). */
-export async function fetchCategoryTree(): Promise<Category[]> {
-  return fetchCategories();
-}
+export const fetchCategoryTree = fetchCategories;
 
-/** Resolve a single category by its integer id (from the hybrid route param). */
+/**
+ * Resolve a single category by its integer id.
+ * Fetches the boards list and scans for the matching id string.
+ * (Slug-based lookup is Task 6 — callers still pass a numeric id from parseLeadingId.)
+ */
 export async function fetchCategory(forumId: number): Promise<Category> {
   const categories = await fetchCategories();
   const match = categories.find((c) => c.id === String(forumId));
@@ -86,29 +97,42 @@ export async function fetchCategory(forumId: number): Promise<Category> {
 // Threads (topics)
 // ---------------------------------------------------------------------------
 
+/**
+ * Fetch topics for a board.
+ *
+ * New signature: { board: string; cursor?: string }
+ * Legacy fields (category, page, search, ordering) are accepted for backward
+ * compat with existing callers (ThreadListPage) so global type-check passes;
+ * they are ignored until Task 6 updates the callers.
+ *
+ * CURSOR NOTE: DRF cursor `next`/`previous` are absolute URLs.
+ * `authenticatedFetch` passes its `url` argument straight to `fetch()` with no
+ * base prepended, so absolute cursor URLs are safe to pass through unchanged.
+ */
 export async function fetchThreads(
-  options: { page?: number; category?: number; search?: string; ordering?: string } = {}
+  options: {
+    board?: string;
+    cursor?: string;
+    // Legacy caller fields — accepted but ignored until Task 6 updates callers.
+    category?: number;
+    page?: number;
+    search?: string;
+    ordering?: string;
+  } = {}
 ): Promise<PaginatedResponse<Thread>> {
-  const { page = 1, category, search, ordering } = options;
-  const params = new URLSearchParams({ page: String(page) });
-  if (search) params.set('search', search);
-  if (ordering) params.set('ordering', ordering);
-  const path =
-    category != null
-      ? `${FORUM_BASE}/categories/${category}/topics/?${params}`
-      : `${FORUM_BASE}/topics/?${params}`;
-  const data = await authenticatedFetch<DrfPage<BackendTopic>>(path);
+  const { board, cursor } = options;
+  if (!board) throw new Error('A board slug is required');
+  const url = cursor || `${FORUM_BASE}/boards/${board}/topics/`;
+  const data = await authenticatedFetch<DrfPage<BackendTopicListItem>>(url);
   return {
-    items: (data.results || []).map(mapTopicToThread),
-    meta: { count: data.count || 0, next: data.next, previous: data.previous },
+    items: (data.results || []).map(mapTopicListItemToThread),
+    meta: { count: 0, next: data.next, previous: data.previous },
   };
 }
 
 export async function fetchThread(topicId: number): Promise<Thread> {
-  const data = await authenticatedFetch<{ topic: BackendTopic }>(
-    `${FORUM_BASE}/topics/${topicId}/`
-  );
-  return mapTopicToThread(data.topic);
+  const data = await authenticatedFetch<BackendTopicDetail>(`${FORUM_BASE}/topics/${topicId}/`);
+  return mapTopicDetailToThread(data);
 }
 
 export async function createThread(data: {
@@ -117,8 +141,10 @@ export async function createThread(data: {
   first_post_content: string;
   first_post_format?: string;
 }): Promise<Thread> {
+  // Phase 2 will migrate this to POST /boards/{slug}/topics/ with a body[] payload.
+  // Left structurally intact so it compiles; endpoint will 404 until Phase 2.
   const { title, category, first_post_content, first_post_format = 'plain' } = data;
-  const res = await authenticatedFetch<{ topic: BackendTopic }>(
+  const res = await authenticatedFetch<{ topic: BackendTopicDetail }>(
     `${FORUM_BASE}/categories/${category}/topics/create/`,
     {
       method: 'POST',
@@ -129,24 +155,34 @@ export async function createThread(data: {
       }),
     }
   );
-  return mapTopicToThread(res.topic);
+  return mapTopicDetailToThread(res.topic);
 }
 
 // ---------------------------------------------------------------------------
 // Posts
 // ---------------------------------------------------------------------------
 
+/**
+ * Fetch posts for a topic (cursor-paginated).
+ *
+ * New signature: { thread: number; cursor?: string }
+ * `page` is accepted for backward compat (ThreadDetailPage); ignored until Task 6.
+ *
+ * CURSOR NOTE: absolute cursor URLs are passed through unchanged — see fetchThreads.
+ */
 export async function fetchPosts(options: {
   thread: number;
+  cursor?: string;
+  // Legacy caller field — accepted but ignored until Task 6.
   page?: number;
 }): Promise<PaginatedResponse<Post>> {
-  const { thread, page = 1 } = options;
+  const { thread, cursor } = options;
   if (thread == null) throw new Error('Thread id is required');
-  const params = new URLSearchParams({ topic: String(thread), page: String(page) });
-  const data = await authenticatedFetch<DrfPage<BackendPost>>(`${FORUM_BASE}/posts/?${params}`);
+  const url = cursor || `${FORUM_BASE}/topics/${thread}/posts/`;
+  const data = await authenticatedFetch<DrfPage<BackendPost>>(url);
   return {
     items: (data.results || []).map((p) => mapPostToPost(p, String(thread))),
-    meta: { count: data.count || 0, next: data.next, previous: data.previous },
+    meta: { count: 0, next: data.next, previous: data.previous },
   };
 }
 
@@ -155,14 +191,13 @@ export async function createPost(data: {
   content_raw: string;
   content_format?: string;
 }): Promise<Post> {
+  // Phase 2 will migrate to POST /topics/{id}/replies/ with a body[] payload.
   const { thread, content_raw, content_format = 'plain' } = data;
   const res = await authenticatedFetch<{ data: BackendPost }>(`${FORUM_BASE}/posts/create/`, {
     method: 'POST',
     body: JSON.stringify({ topic: thread, content: content_raw, content_format }),
   });
   if (!res?.data) {
-    // Defensive guard (todo 111): a response without `data` (e.g. the old
-    // {message, post} shape) must fail clearly, not crash in mapPostToPost.
     throw new Error('createPost: response is missing "data" — unexpected response shape');
   }
   return mapPostToPost(res.data, String(thread));
@@ -174,8 +209,6 @@ export async function updatePost(postId: string, data: UpdatePostInput): Promise
     method: 'PATCH',
     body: JSON.stringify({ content: content_raw, content_format }),
   });
-  // todo 112: map the real topic id from the response (was '', which produced
-  // Post.thread === '' and broke any downstream navigation/re-fetch).
   return mapPostToPost(res.data, String(res.data.topic_id));
 }
 
@@ -282,27 +315,26 @@ export async function reorderPostImages(
 // ---------------------------------------------------------------------------
 
 export async function searchForum(options: SearchForumOptions): Promise<SearchForumResponse> {
-  const { q, page = 1, page_size = 20 } = options;
+  // Note: SearchForumOptions includes category/author/date_from/date_to/page/page_size
+  // for backward compat with SearchPage; the backend only supports `q` currently.
+  const { q } = options;
   if (!q || q.trim() === '') throw new Error('Search query is required');
   const params = new URLSearchParams({ q: q.trim() });
-  if (page > 1) params.set('page', String(page));
-  if (page_size !== 20) params.set('page_size', String(page_size));
-  const data = await authenticatedFetch<{ topics: BackendTopic[]; posts: BackendPost[] }>(
-    `${FORUM_BASE}/search/?${params}`
-  );
-  const threads = (data.topics || []).map(mapTopicToThread);
-  // todo 112: search posts carry topic_id (PostSerializer), so map a real thread
-  // id rather than '' (same empty-thread bug as updatePost, flagged in review).
-  const posts = (data.posts || []).map((p) => mapPostToPost(p, String(p.topic_id)));
+  const data = await authenticatedFetch<{
+    topics: BackendSearchTopic[];
+    posts: BackendSearchPost[];
+  }>(`${FORUM_BASE}/search/?${params}`);
+  const threads = (data.topics || []).map(mapSearchTopicToThread);
+  const posts = (data.posts || []).map(mapSearchPostToPost);
   return {
     query: q.trim(),
     threads,
     posts,
     total_threads: threads.length,
     total_posts: posts.length,
-    has_next_threads: threads.length >= page_size,
-    has_next_posts: posts.length >= page_size,
-    page,
-    page_size: page_size ?? threads.length + posts.length,
-  } as SearchForumResponse;
+    has_next_threads: false,
+    has_next_posts: false,
+    page: options.page ?? 1,
+    page_size: options.page_size ?? threads.length + posts.length,
+  };
 }

--- a/web/src/types/forum.ts
+++ b/web/src/types/forum.ts
@@ -56,6 +56,11 @@ export interface Post {
   content_format?: string;
   /** StreamField body blocks from wagtail_forum; rendered by StreamFieldRenderer. */
   body?: BlogStreamFieldBlock[];
+  /**
+   * Set only on search-result posts (from mapSearchPostToPost).
+   * The topic title is carried so SearchPage can render a link without a PostCard.
+   */
+  topic_title?: string;
   created_at: string;
   updated_at?: string;
   edited_at?: string;

--- a/web/src/types/forum.ts
+++ b/web/src/types/forum.ts
@@ -40,6 +40,16 @@ export interface Thread {
 }
 
 /**
+ * One block in a Wagtail StreamField body (wagtail_forum ForumBodyBlock).
+ * The `value` is block-type-specific; consumers must switch on `type`.
+ */
+export interface StreamFieldBlock {
+  type: string;
+  value: unknown;
+  id: string;
+}
+
+/**
  * Forum post
  */
 export interface Post {
@@ -53,6 +63,8 @@ export interface Post {
   content_raw: string;
   content_html?: string;
   content_format?: string;
+  /** StreamField body blocks from wagtail_forum; rendered by Task 6. */
+  body?: StreamFieldBlock[];
   created_at: string;
   updated_at?: string;
   edited_at?: string;
@@ -65,6 +77,9 @@ export interface Post {
   is_first_post?: boolean;
   is_active?: boolean;
   reaction_counts?: Record<string, number>;
+  /** Permission flags from the backend (wagtail_forum PostSerializer). */
+  can_edit?: boolean;
+  can_delete?: boolean;
 }
 
 /**

--- a/web/src/types/forum.ts
+++ b/web/src/types/forum.ts
@@ -3,6 +3,7 @@
  */
 
 import type { User } from './auth';
+import type { StreamFieldBlock as BlogStreamFieldBlock } from './blog';
 
 /**
  * Forum category
@@ -40,16 +41,6 @@ export interface Thread {
 }
 
 /**
- * One block in a Wagtail StreamField body (wagtail_forum ForumBodyBlock).
- * The `value` is block-type-specific; consumers must switch on `type`.
- */
-export interface StreamFieldBlock {
-  type: string;
-  value: unknown;
-  id: string;
-}
-
-/**
  * Forum post
  */
 export interface Post {
@@ -63,8 +54,8 @@ export interface Post {
   content_raw: string;
   content_html?: string;
   content_format?: string;
-  /** StreamField body blocks from wagtail_forum; rendered by Task 6. */
-  body?: StreamFieldBlock[];
+  /** StreamField body blocks from wagtail_forum; rendered by StreamFieldRenderer. */
+  body?: BlogStreamFieldBlock[];
   created_at: string;
   updated_at?: string;
   edited_at?: string;


### PR DESCRIPTION
## What & why

The deployed React forum (`houseplant-md.com/forum`) was throwing **"Error loading categories: Request failed"** — the client still called the retired machina API while the new `wagtail_forum` package only served `boards/`. This PR is **Phase 1 (read path)** of forum Spec 2: it builds the missing read endpoints and migrates the web read client onto them, making the forum browsable again.

Spec & plan (in-repo): `docs/superpowers/specs/2026-06-20-forum-spec2-read-write-client-design.md`, `docs/superpowers/plans/2026-06-20-forum-spec2-phase1-read-path.md`. Tracks **todo 231** (kept open — Phase 2/3 remain).

## What's in this PR

**Backend (`wagtail_forum` package + `forum_host`):**
- `GET /topics/{id}/` — topic detail (`TopicDetailSerializer`, board object + `opening_post_id`).
- `GET /topics/{id}/posts/` — cursor-paginated post list; bodies serialized from StreamField with RichText run through Wagtail `expand_db_html()` (security: link rewriter), then re-sanitized client-side. Query count pinned **exactly** (==3).
- `GET /search/?q=` — now returns `{topics, posts}` (full parity); required adding `index.RelatedFields("topic", [live, board_id])` to `Post.search_fields` so the DB backend can visibility-filter post hits (no migration).
- `seed_default_forum` idempotent management command, wired into the Railway release `startCommand` (after `migrate`).
- All new views set `versioning_class = None`; route-parity guard green.

**Web (`web/src/`):**
- Read service/mappers/types rewritten to the new contract (boards/topics/posts/search); machina read paths gone; post bodies render via `StreamFieldRenderer`; cursor pagination on list + detail.
- **Thread view is read-only for Phase 1** (user-decided): reply form replaced with a "replies coming soon" notice; react/delete controls hidden behind handler-presence guards (PostCard keeps full capability for Phase 2). The write endpoints don't exist until Phase 2, so this avoids shipping controls that 404.

## Visibility / security
`live().public()` + 404-not-403 enforced consistently across topic-detail, post-list, and both arms of search (topics **and** posts). Two pre-existing `test_visibility.py` tests were updated to the new search shape and strengthened to exercise the post-body visibility filter (not just topic titles).

## Testing
- Backend forum suite: **114 passed**. `manage.py check` clean; `spectacular` exits 0 (new endpoints in schema).
- Web: `type-check` 0 errors, `lint` clean, **623 tests pass**.
- Reviewed task-by-task (subagent-driven) + a final whole-branch review; all Critical/Important findings fixed.

## Intentional deviations (from the plan)
- Board seeding is a **management command** (not `post_migrate`) to avoid duplicate-board collisions in the test DB; wired into the Railway release.
- `Post.search_fields` gained `RelatedFields` (beyond the plan's listed files) — required for visibility-filtered post search; keeping the filters (vs dropping them) is the secure choice. No migration/reindex (Wagtail DB search backend).

## Deferred (NOT in this PR — tracked in todo 231)
- **Phase 2:** write path (create/edit/delete post, reactions) + re-enable the write UI. `grep categories/ web/src/services/` still hits the un-rewritten `createThread`.
- **Phase 3:** image upload + rendition serialization; restore the `image` case in `StreamFieldRenderer`.
- Compound `(updated_at, id)` sync cursor + livelock test; route rationalization (audit L10).
- Small follow-ups: topic-detail query pin includes a redundant 4th query (constant-cost); `@extend_schema` annotations for richer OpenAPI; search-result thread/post URLs lack a board slug (needs a backend search-shape change).

## Deploy note
Prod is inert until Railway redeploys (release now runs `seed_default_forum`) **and** the Cloudflare web bundle rebuilds with the new client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)