### PR TITLE
docs: codify findings from forum Spec 2 Phase 1

### DIFF
--- a/.claude/agents/wagtail-reviewer.md
+++ b/.claude/agents/wagtail-reviewer.md
@@ -82,6 +82,18 @@ You review: `apps/blog/`, Wagtail page models, StreamField blocks, signals, Wagt
   (e.g. the TITLE) skipping the spam/moderation screen `workflow.start()` would
   have run?
 
+### Forum Spec 2 additions (2026-06-21)
+
+- Search querysets that `.filter()` on a RELATED model's field (e.g.
+  `backend.search(q, Post.objects.filter(topic__live=True, topic__board__in=...))`)
+  must have `index.RelatedFields(rel, [FilterField(...)])` declared on the searched
+  model's `search_fields` — a bare related filter raises `FilterFieldError` at
+  query-compile. Flag any "fix" that DROPS the visibility filter to silence it
+  (leaks hidden content) instead of declaring the field.
+- Response-shape changes (renamed/removed top-level keys): are ALL consumers
+  updated, including tests in OTHER files not in this diff? (Diff-scoped review
+  can't see them — call out that a whole-suite run is required.)
+
 ## Output Format (Review Mode)
 
 Return ONLY this JSON structure (no surrounding prose, no markdown fences in the actual response — the example fences below show the schema):

--- a/docs/LEARNINGS.md
+++ b/docs/LEARNINGS.md
@@ -456,3 +456,23 @@ This file is append-only. New entries are added by main Claude after each code r
 
 **Rule**: Never treat `StreamBlock.to_python()` as validation for API-submitted bodies; validate type-membership and value types yourself.
 **Agent**: wagtail-reviewer
+
+## Forum Spec 2 Phase 1 (2026-06-21 additions)
+
+### [2026-06-21] Wagtail DB search rejects relation-field filters without `index.RelatedFields`
+
+**Mistake**: Extending forum search to post bodies required visibility-filtering the searched queryset (`Post.objects.filter(live=True, topic__live=True, topic__board__in=_visible_boards())`). The Wagtail database search backend raised `FilterFieldError: Cannot filter search results with field "board_id"` at query-compile — `Post.search_fields` only declared `FilterField("live")`, so the related `topic__live`/`topic__board_id` filters were undeclared. The plan's listed files didn't include the model, so the task got BLOCKED mid-implementation.
+
+**Fix**: Added `index.RelatedFields("topic", [index.FilterField("live"), index.FilterField("board_id")])` to `Post.search_fields`. No migration/reindex (`search_fields` is not schema on the DB backend). Dropping the filters to silence the error would have leaked hidden-board / draft-topic posts into search — the wrong fix.
+
+**Rule**: To filter a Wagtail search queryset on a related model's field, declare `index.RelatedFields(rel, [FilterField(...)])` on the searched model — never drop the filter to silence `FilterFieldError`.
+**Agent**: wagtail-reviewer
+
+### [2026-06-21] A response-shape rename broke security tests in a file the diff never touched
+
+**Mistake**: Forum search changed from `{"results": [...]}` (topics only) to `{"topics": [...], "posts": [...]}`. The task updated the assertions in `test_search_sync.py`, and BOTH the per-task review and the independent kimi-review (both diff-scoped) passed clean. But two pre-existing SECURITY visibility tests in `test_visibility.py` — not in the diff — still asserted `resp.data["results"]` and `KeyError`'d. Only the whole-app suite run (final verification) caught it. The negative post-search assertions were also vacuous (the hidden content's body never contained the search term, so `posts == []` passed without exercising the visibility filter).
+
+**Fix**: Updated the two tests to the new shape AND strengthened them to assert exclusion from both `topics` and `posts`, with the search term present in the hidden content's post body so the filter is genuinely exercised.
+
+**Rule**: A response-key rename is a cross-file contract change — grep the WHOLE suite for old-shape consumers and run the full app suite, not just touched files. Diff-scoped review (human or kimi) structurally cannot see out-of-diff consumers.
+**Agent**: (process — full-suite run before "done")

--- a/docs/rules/api.md
+++ b/docs/rules/api.md
@@ -33,3 +33,7 @@ Compact checklist auto-injected before edits. Long-form:
   a different request); replay the ORIGINAL status code, not 200; `cache.add()`
   an in-flight sentinel (short TTL, placed AFTER validation) → 409 for
   concurrent twins. See wagtail_forum/api/idempotency.py for the reference shape.
+- **DRF cursor pagination `next`/`previous` are ABSOLUTE URLs** (built from the
+  request host). Clients fetch them verbatim — do NOT re-prefix the API base
+  (double-prefixing 404s). The page-fetch helper must accept either a relative
+  path (first page) or an absolute cursor URL (subsequent pages).

--- a/docs/rules/testing.md
+++ b/docs/rules/testing.md
@@ -28,3 +28,12 @@ Compact checklist auto-injected before edits.
   tests built on it can stay green while the real API path (born `live=False`)
   is broken. Cover every moderated behavior through the HTTP endpoint at least
   once, and assert the PARENT object's liveness, not a derived status string.
+- **A response-shape change breaks consumers OUTSIDE the diff.** Renaming a
+  response key (e.g. `{results}` → `{topics, posts}`) is a cross-file contract
+  change — grep the WHOLE suite for the old key and run the full app suite, not
+  just the touched files. Diff-scoped review (human or kimi) structurally can't
+  see out-of-diff consumers; only the full-suite run catches them.
+- **`.live().public()` filtering costs one extra query** (a `PageViewRestriction`
+  lookup). An exact `assertNumQueries`/`captured_queries` pin on any endpoint that
+  gates visibility via `.public()` must include it — a topic-detail endpoint
+  measured 4, not the naive 3.

--- a/docs/rules/wagtail.md
+++ b/docs/rules/wagtail.md
@@ -37,3 +37,15 @@ Compact checklist auto-injected before edits. Long-form:
   `save_revision().publish()` bypasses an assigned moderation workflow entirely.
   Anything user-visible that publishes programmatically (titles!) must be
   screened by the code doing the publish.
+- **Filtering a Wagtail search queryset on a RELATED model's field needs
+  `index.RelatedFields`.** `backend.search(q, Post.objects.filter(topic__live=True,
+  topic__board__in=...))` raises `FilterFieldError` at query-compile unless
+  `Post.search_fields` declares `index.RelatedFields("topic", [index.FilterField(
+  "live"), index.FilterField("board_id")])`. Declare it — never drop the
+  visibility filter to silence the error (that leaks hidden content). No
+  migration: `search_fields` is not schema on the DB backend.
+- **Never seed Wagtail pages in `post_migrate`.** It also runs against every TEST
+  database, colliding with test helpers that build the same (sibling-unique) slug
+  → `MultipleObjectsReturned`/409. Seed via an idempotent management command and
+  wire it into the deploy `startCommand` (`railway.json`) — a documented-but-unwired
+  seed command ships an empty forum to prod.


### PR DESCRIPTION
`/codify` output from the forum Spec 2 Phase 1 work (merged in #374). kimi-review on the branch diff: **clean** (no CRITICAL/WARNING). Docs/agent-only — no code.

Codified the genuinely-new, non-obvious lessons (skipping anything already in the rules):

**`docs/rules/`**
- `wagtail.md`: Wagtail search needs `index.RelatedFields` to filter a searched queryset on a related field (`FilterFieldError` otherwise); never seed Wagtail pages in `post_migrate` (collides with test fixtures) — use an idempotent command wired into the release `startCommand`.
- `testing.md`: a response-shape rename breaks consumers *outside the diff* — grep the whole suite + run the full app suite; `.live().public()` costs one extra `PageViewRestriction` query in count pins.
- `api.md`: DRF cursor `next`/`previous` are absolute URLs — fetch verbatim, don't re-prefix.

**`docs/LEARNINGS.md`** — two dated entries: the `RelatedFields`/`FilterFieldError` blocker, and the `test_visibility.py` shape regression that only the full-suite run caught (diff-scoped review — human and kimi — can't see out-of-diff consumers).

**`.claude/agents/wagtail-reviewer.md`** — a reusable check for related-field search filters + response-shape consumer sweeps.

No write-time triggers added: none of these findings has a clean single-file regex signature (the RelatedFields signature spans the view's `search()` call and the model's `search_fields`), so they stay prose per the codify rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)