### PR TITLE
fix(218): trusted real-client header + IP-resolution diagnostic for Railway

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1178,7 +1178,7 @@
         "filename": "backend/plant_community_backend/settings.py",
         "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
         "is_verified": false,
-        "line_number": 1365
+        "line_number": 1375
       }
     ],
     "backend/run_migrations.py": [
@@ -1514,5 +1514,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-21T16:44:38Z"
+  "generated_at": "2026-06-21T23:01:19Z"
 }

--- a/backend/apps/core/ratelimit.py
+++ b/backend/apps/core/ratelimit.py
@@ -11,6 +11,7 @@ signature, so every decorator that uses the imported name benefits automatically
 """
 
 import ipaddress
+import logging
 from functools import wraps
 from typing import Optional
 
@@ -19,6 +20,8 @@ from django.http import HttpRequest
 from django_ratelimit import ALL
 from django_ratelimit.decorators import ratelimit as _ratelimit
 from django_ratelimit.exceptions import Ratelimited
+
+logger = logging.getLogger(__name__)
 
 
 class RatelimitedWithRate(Ratelimited):
@@ -83,30 +86,65 @@ def get_trusted_client_ip(request: HttpRequest) -> Optional[str]:
     observed. Indexing from the right means any extra left-prepended (spoofed)
     entries cannot shift the result, so a forged header cannot rotate the key.
 
-    SECURITY: ``RATELIMIT_TRUSTED_PROXY_COUNT`` MUST equal the number of proxies
-    that actually append to XFF in the live environment. If it is too high, the
-    limit groups unrelated clients; if a deployment does not append XFF at all, no
-    count is safe and a dedicated header must be used instead. The default of 0
-    (no trusted proxy → ``REMOTE_ADDR``) keeps local/dev/test correct.
+    Two resolution strategies (use whichever fits the live proxy):
+
+    1. ``RATELIMIT_CLIENT_IP_META_KEY`` — a single trusted META key that already
+       holds the real client (e.g. Railway/Envoy's ``HTTP_X_ENVOY_EXTERNAL_ADDRESS``).
+       Positional XFF counting is unreliable on proxies that vary the chain, so a
+       deployment that exposes a clean header should point at it directly. Only
+       honored when it parses as an IP; the proxy MUST set it authoritatively
+       (overwrite any client-sent value) or it is spoofable.
+    2. ``RATELIMIT_TRUSTED_PROXY_COUNT`` — count this many hops from the RIGHT of
+       ``X-Forwarded-For`` and take that entry. Indexing from the right means
+       left-prepended (spoofed) entries cannot shift the result. The count MUST
+       equal the number of proxies that actually append to XFF.
+
+    Default (neither set) → ``REMOTE_ADDR``, which keeps local/dev/test correct.
+    Set ``RATELIMIT_LOG_RESOLUTION=True`` to log how each request resolved (a
+    one-time diagnostic for confirming a proxy's real shape, then turn it off).
 
     Returns the validated client IP, or ``None`` when it cannot be determined.
     """
     remote_addr = request.META.get("REMOTE_ADDR", "")
+    meta_key = getattr(settings, "RATELIMIT_CLIENT_IP_META_KEY", "")
     proxy_count = getattr(settings, "RATELIMIT_TRUSTED_PROXY_COUNT", 0)
 
-    if proxy_count > 0:
+    result = remote_addr or None
+
+    if meta_key:
+        # (1) Trusted single real-client header (e.g. Railway's Envoy header).
+        candidate = request.META.get(meta_key, "").strip()
+        if _is_valid_ip(candidate):
+            result = candidate
+    elif proxy_count > 0:
+        # (2) Positional X-Forwarded-For. The trusted position only exists if XFF
+        # carries at least proxy_count entries; fewer means a missing expected hop.
         xff = request.META.get("HTTP_X_FORWARDED_FOR", "")
         parts = [part.strip() for part in xff.split(",") if part.strip()]
-        # The trusted position only exists if XFF carries at least proxy_count
-        # entries; fewer means a missing expected hop — fall back to REMOTE_ADDR.
         if len(parts) >= proxy_count:
             candidate = parts[-proxy_count]
             if _is_valid_ip(candidate):
-                return candidate
-            # A non-IP in the trusted position is malformed/forged: fall through to
-            # REMOTE_ADDR rather than key on an attacker-supplied value.
+                result = candidate
+            # A non-IP in the trusted position is malformed/forged: keep REMOTE_ADDR
+            # rather than key on an attacker-supplied value.
 
-    return remote_addr or None
+    if getattr(settings, "RATELIMIT_LOG_RESOLUTION", False):
+        # Diagnostic only (off by default). Dumps the candidate forwarding headers
+        # so the real client-IP shape of an unknown proxy can be confirmed once.
+        logger.warning(
+            "[RATELIMIT-RESOLVE] remote_addr=%s x_forwarded_for=%r "
+            "x_envoy_external_address=%r x_real_ip=%r meta_key=%r proxy_count=%s "
+            "-> resolved=%s",
+            remote_addr,
+            request.META.get("HTTP_X_FORWARDED_FOR"),
+            request.META.get("HTTP_X_ENVOY_EXTERNAL_ADDRESS"),
+            request.META.get("HTTP_X_REAL_IP"),
+            meta_key,
+            proxy_count,
+            result,
+        )
+
+    return result
 
 
 def _mask_ip(ip: str) -> str:

--- a/backend/apps/core/tests/test_ratelimit_client_ip.py
+++ b/backend/apps/core/tests/test_ratelimit_client_ip.py
@@ -136,3 +136,48 @@ class UnknownBucketTests(SimpleTestCase):
         req = _request(remote_addr="", xff=None)
         self.assertIsNone(get_trusted_client_ip(req))
         self.assertEqual(client_ip_key(None, req), "unknown")
+
+
+ENVOY_META = "HTTP_X_ENVOY_EXTERNAL_ADDRESS"
+
+
+@override_settings(
+    RATELIMIT_CLIENT_IP_META_KEY=ENVOY_META, RATELIMIT_TRUSTED_PROXY_COUNT=1
+)
+class ClientIpMetaKeyTests(SimpleTestCase):
+    """A configured single trusted header (e.g. Railway/Envoy) wins over XFF."""
+
+    def test_header_value_is_used(self):
+        req = RequestFactory().get("/", REMOTE_ADDR=PROXY_IP, **{ENVOY_META: CLIENT_IP})
+        self.assertEqual(get_trusted_client_ip(req), CLIENT_IP)
+
+    def test_header_takes_precedence_over_xff(self):
+        # XFF would resolve to SPOOF_IP under count=1, but the trusted header wins.
+        req = RequestFactory().get(
+            "/",
+            REMOTE_ADDR=PROXY_IP,
+            HTTP_X_FORWARDED_FOR=SPOOF_IP,
+            **{ENVOY_META: CLIENT_IP},
+        )
+        self.assertEqual(get_trusted_client_ip(req), CLIENT_IP)
+        self.assertEqual(client_ip_key(None, req), CLIENT_IP)
+
+    def test_missing_or_invalid_header_falls_back_to_remote_addr(self):
+        # Header absent → REMOTE_ADDR (does NOT fall through to XFF when a meta key
+        # is configured; the deployment is expected to set the header).
+        req = RequestFactory().get(
+            "/", REMOTE_ADDR=PROXY_IP, HTTP_X_FORWARDED_FOR=CLIENT_IP
+        )
+        self.assertEqual(get_trusted_client_ip(req), PROXY_IP)
+        bad = RequestFactory().get("/", REMOTE_ADDR=PROXY_IP, **{ENVOY_META: "nope"})
+        self.assertEqual(get_trusted_client_ip(bad), PROXY_IP)
+
+
+@override_settings(RATELIMIT_TRUSTED_PROXY_COUNT=1, RATELIMIT_LOG_RESOLUTION=True)
+class LogResolutionTests(SimpleTestCase):
+    """The diagnostic log is side-effect-only — resolution is unchanged."""
+
+    def test_resolution_unchanged_with_logging_on(self):
+        req = _request(remote_addr=PROXY_IP, xff=CLIENT_IP)
+        self.assertEqual(get_trusted_client_ip(req), CLIENT_IP)
+        self.assertEqual(client_ip_key(None, req), CLIENT_IP)

--- a/backend/plant_community_backend/settings.py
+++ b/backend/plant_community_backend/settings.py
@@ -977,6 +977,16 @@ if config("TRUST_PROXY_SSL_HEADER", default=False, cast=bool):
 RATELIMIT_TRUSTED_PROXY_COUNT = max(
     0, config("RATELIMIT_TRUSTED_PROXY_COUNT", default=0, cast=int)
 )
+# Alternative to the positional XFF count: a single trusted META key that already
+# holds the real client IP. Railway/Envoy expose it as X-Envoy-External-Address →
+# set RATELIMIT_CLIENT_IP_META_KEY=HTTP_X_ENVOY_EXTERNAL_ADDRESS. Takes precedence
+# over the count when set. The proxy MUST set this header authoritatively (else a
+# client could spoof it). Empty = use the XFF-count strategy.
+RATELIMIT_CLIENT_IP_META_KEY = config("RATELIMIT_CLIENT_IP_META_KEY", default="")
+# One-time diagnostic: log how each rate-limited request resolved its client IP
+# (REMOTE_ADDR + candidate forwarding headers). Enable briefly on a new proxy to
+# confirm its real shape, then set back to False. Default off.
+RATELIMIT_LOG_RESOLUTION = config("RATELIMIT_LOG_RESOLUTION", default=False, cast=bool)
 SESSION_COOKIE_SECURE = not DEBUG
 CSRF_COOKIE_SECURE = not DEBUG
 SESSION_COOKIE_HTTPONLY = True


### PR DESCRIPTION
Follow-up to #377. A **live test against production** showed that
`RATELIMIT_TRUSTED_PROXY_COUNT=1` does **not** trip the per-IP limit on Railway —
7 rapid login attempts from one IP all returned 401, no 429. Config is healthy
(rate limiting on, shared Redis), so positional `X-Forwarded-For` counting is just
unreliable on Railway (its proxy chain varies per request).

This adds two **opt-in** settings (default = no behavior change) so we can confirm
Railway's real shape and then activate the fix via env var:

- **`RATELIMIT_CLIENT_IP_META_KEY`** — resolve the client from a single trusted
  header the proxy sets authoritatively (Railway/Envoy: `HTTP_X_ENVOY_EXTERNAL_ADDRESS`).
  Takes precedence over the XFF count when set.
- **`RATELIMIT_LOG_RESOLUTION`** — one-time diagnostic logging of `REMOTE_ADDR` +
  candidate forwarding headers + the resolved IP, to see exactly what Railway sends.

## Plan after merge
1. Deploy (Railway picks up `main`).
2. Temporarily set `RATELIMIT_LOG_RESOLUTION=True`, do one login, read the
   `[RATELIMIT-RESOLVE]` log line → confirms which header holds the real client.
3. Set `RATELIMIT_CLIENT_IP_META_KEY` to that header (likely
   `HTTP_X_ENVOY_EXTERNAL_ADDRESS`), set logging back to `False`.
4. Re-run the live burst test → expect 429. Then close 218.

21 tests (4 new) cover the header-precedence + diagnostic paths; default behavior unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
