### PR TITLE
fix(web): login form wrongly rejects passwords under 14 chars (locks out existing accounts)

### DIFF
--- a/web/src/pages/auth/LoginPage.tsx
+++ b/web/src/pages/auth/LoginPage.tsx
@@ -3,7 +3,7 @@ import { Link, useNavigate, useLocation } from 'react-router-dom';
 import { useAuth } from '../../contexts/AuthContext';
 import Button from '../../components/ui/Button';
 import Input from '../../components/ui/Input';
-import { getEmailError, getPasswordError } from '../../utils/validation';
+import { getEmailError } from '../../utils/validation';
 import { sanitizeInput, sanitizeError } from '../../utils/sanitize';
 import { logger } from '../../utils/logger';
 
@@ -91,9 +91,12 @@ export default function LoginPage() {
       newErrors.email = emailError;
     }
 
-    const passwordError = getPasswordError(formData.password);
-    if (passwordError) {
-      newErrors.password = passwordError;
+    // Login authenticates against an EXISTING password — only require that one was
+    // entered. The 14-char strength rule (getPasswordError) applies to NEW
+    // passwords on signup/reset only; running it here locked out accounts whose
+    // password predates that rule.
+    if (!formData.password) {
+      newErrors.password = 'Password is required'; // pragma: allowlist secret
     }
 
     setErrors(newErrors);


### PR DESCRIPTION
## The bug
The **Sign in** form runs `getPasswordError()` — the *new-password* strength rule
(14-character minimum) — during login validation. So any account whose password is
shorter than 14 characters (accounts created before the rule, or the bootstrap
superuser) **cannot log in to the React app** — the form refuses to submit and
shows *"Password must be at least 14 characters long"*.

Found live: the project admin was locked out of their own account this way.

## The fix
Login authenticates against an **existing** password, so the form should only
require that a password was entered — not that it meets the new-password strength
rule. One-line change in `LoginPage.validateForm()`; the strength rule stays where
it belongs (signup / password reset — `SignupPage` is unchanged).

Verified: `tsc` clean, ESLint + Prettier + kimi-review pass.

> Note: the inline `// pragma: allowlist secret` is for detect-secrets, which
> false-positives on the string literal next to `newErrors.password` (it's a UI
> message, not a secret).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
