### PR TITLE
fix(auth): readable auth errors (no "[object Object]") + login password-rule regression tests

### DIFF
--- a/web/src/pages/auth/LoginPage.test.tsx
+++ b/web/src/pages/auth/LoginPage.test.tsx
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { AuthErrorCode } from '../../types/auth';
+import LoginPage from './LoginPage';
+
+// Mock useAuth so we can drive login() outcomes and assert call behavior.
+// vi.hoisted is required: the vi.mock factory is hoisted above the imports, so it
+// cannot close over a plain top-level const (temporal-dead-zone error).
+const { mockLogin } = vi.hoisted(() => ({ mockLogin: vi.fn() }));
+
+vi.mock('../../contexts/AuthContext', () => ({
+  useAuth: () => ({ login: mockLogin }),
+}));
+
+function renderLoginPage() {
+  return render(
+    <MemoryRouter>
+      <LoginPage />
+    </MemoryRouter>
+  );
+}
+
+// Query by placeholder, not label: the field label includes a required "*" span,
+// which makes an exact getByLabelText('Password') match brittle.
+function fillForm(email: string, password: string) {
+  fireEvent.change(screen.getByPlaceholderText('you@example.com'), {
+    target: { value: email },
+  });
+  fireEvent.change(screen.getByPlaceholderText('Enter your password'), {
+    target: { value: password },
+  });
+}
+
+const submit = () => fireEvent.click(screen.getByRole('button', { name: /sign in/i }));
+
+describe('LoginPage', () => {
+  beforeEach(() => {
+    mockLogin.mockReset();
+  });
+
+  // Regression for PR #379: the login form wrongly ran the 14-char *new-password*
+  // strength rule, locking out every account whose password predates that rule
+  // (including the bootstrap superuser). Login must accept any non-empty password.
+  it('accepts a short existing password — the 14-char rule must not apply on login', async () => {
+    mockLogin.mockResolvedValue({ success: true });
+    renderLoginPage();
+
+    fillForm('test@example.com', 'shortpw'); // 7 chars — under the 14-char rule
+
+    submit();
+
+    expect(screen.queryByText(/14 characters/i)).not.toBeInTheDocument();
+    await waitFor(() =>
+      expect(mockLogin).toHaveBeenCalledWith({
+        email: 'test@example.com',
+        password: 'shortpw', // pragma: allowlist secret
+      })
+    );
+  });
+
+  it('still requires that a password was entered', () => {
+    renderLoginPage();
+
+    fillForm('test@example.com', '');
+
+    submit();
+
+    expect(screen.getByText('Password is required')).toBeInTheDocument();
+    expect(mockLogin).not.toHaveBeenCalled();
+  });
+
+  // Guards the "[object Object]" fix: the page must render error.message, not the
+  // whole AuthError object.
+  it('shows the readable server error message, not "[object Object]"', async () => {
+    mockLogin.mockResolvedValue({
+      success: false,
+      error: {
+        message: 'Invalid email or password.',
+        code: AuthErrorCode.INVALID_CREDENTIALS,
+      },
+    });
+    renderLoginPage();
+
+    fillForm('test@example.com', 'somepassword');
+
+    submit();
+
+    expect(await screen.findByText('Invalid email or password.')).toBeInTheDocument();
+    expect(screen.queryByText(/\[object Object\]/)).not.toBeInTheDocument();
+  });
+});

--- a/web/src/pages/auth/LoginPage.tsx
+++ b/web/src/pages/auth/LoginPage.tsx
@@ -127,8 +127,9 @@ export default function LoginPage() {
         // Redirect to the page user was trying to access, or home
         navigate(from, { replace: true });
       } else {
-        // Show error from backend (sanitized to prevent XSS)
-        const rawError = result.error || 'Login failed. Please try again.';
+        // Show the readable message from the structured AuthError, not the whole
+        // object — String({message,code,...}) renders the literal "[object Object]".
+        const rawError = result.error?.message || 'Login failed. Please try again.';
         setServerError(String(sanitizeError(rawError)));
       }
     } catch (error) {

--- a/web/src/pages/auth/SignupPage.test.tsx
+++ b/web/src/pages/auth/SignupPage.test.tsx
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { AuthErrorCode } from '../../types/auth';
+import SignupPage from './SignupPage';
+
+// Mock useAuth so we can drive signup() outcomes. vi.hoisted is required because
+// the vi.mock factory is hoisted above the imports (see LoginPage.test.tsx).
+const { mockSignup } = vi.hoisted(() => ({ mockSignup: vi.fn() }));
+
+vi.mock('../../contexts/AuthContext', () => ({
+  useAuth: () => ({ signup: mockSignup }),
+}));
+
+function renderSignupPage() {
+  return render(
+    <MemoryRouter>
+      <SignupPage />
+    </MemoryRouter>
+  );
+}
+
+// Query by unique placeholders (labels carry a required "*" span).
+function setField(placeholder: string, value: string) {
+  fireEvent.change(screen.getByPlaceholderText(placeholder), { target: { value } });
+}
+
+// Strong enough to clear the 14-char rule — a test fixture, not a real credential.
+const STRONG_PASSWORD = 'a-very-strong-password'; // pragma: allowlist secret
+
+function fillValidForm(password = STRONG_PASSWORD) {
+  setField('johndoe', 'newuser');
+  setField('you@example.com', 'new@example.com');
+  setField('At least 14 characters', password);
+  setField('Re-enter your password', password);
+}
+
+const submit = () => fireEvent.click(screen.getByRole('button', { name: /create account/i }));
+
+describe('SignupPage', () => {
+  beforeEach(() => {
+    mockSignup.mockReset();
+  });
+
+  // Guards the "[object Object]" fix: the page must render error.message, not the
+  // whole AuthError object (String({message,code}) → the literal "[object Object]").
+  it('renders the readable server error message, not "[object Object]"', async () => {
+    mockSignup.mockResolvedValue({
+      success: false,
+      error: {
+        message: 'A user with that email already exists.',
+        code: AuthErrorCode.EMAIL_EXISTS,
+      },
+    });
+    renderSignupPage();
+
+    fillValidForm();
+
+    submit();
+
+    expect(await screen.findByText('A user with that email already exists.')).toBeInTheDocument();
+    expect(screen.queryByText(/\[object Object\]/)).not.toBeInTheDocument();
+  });
+
+  // The 14-char strength rule belongs on signup (new password), NOT on login.
+  it('enforces the 14-char password rule on signup', () => {
+    renderSignupPage();
+
+    fillValidForm('shortpw'); // 7 chars
+
+    submit();
+
+    expect(screen.getByText('Password must be at least 14 characters long')).toBeInTheDocument();
+    expect(mockSignup).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/pages/auth/SignupPage.tsx
+++ b/web/src/pages/auth/SignupPage.tsx
@@ -148,8 +148,9 @@ export default function SignupPage() {
         // Redirect to home page after successful signup
         navigate('/', { replace: true });
       } else {
-        // Show error from backend (sanitized to prevent XSS)
-        const rawError = result.error || 'Signup failed. Please try again.';
+        // Show the readable message from the structured AuthError, not the whole
+        // object — String({message,code,...}) renders the literal "[object Object]".
+        const rawError = result.error?.message || 'Signup failed. Please try again.';
         setServerError(String(sanitizeError(rawError)));
       }
     } catch (error) {


### PR DESCRIPTION
Fixes the two follow-ups from the rate-limit/login work.

## 1. "[object Object]" on auth errors
`SignupPage`/`LoginPage` passed the whole structured `AuthError` object to `String(sanitizeError(...))`. `sanitizeError` returns non-strings unchanged, so `String({message, code, ...})` rendered the literal **`[object Object]`** on any server-side auth failure (e.g. "email already exists", bad credentials).

`authService` already produces a clean readable string in `.message` (signup even flattens DRF field errors like "password too short"). Fix: the pages read `result.error?.message`.

## 2. Login password-rule regression tests
Locks in PR #379: the login form must **not** apply the 14-char *new-password* strength rule (that bug locked out every account whose password predates the rule, incl. the bootstrap superuser).

- `LoginPage.test.tsx` — short existing password is accepted (calls `login`, no 14-char error); empty password → "Password is required"; failed login renders the readable message, not `[object Object]`.
- `SignupPage.test.tsx` — readable-error guard; 14-char rule still enforced on signup (where it belongs).

## Verification
- Full web suite: **551 passed** (5 new).
- `npm run type-check` clean, ESLint clean, Prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
