### PR TITLE
docs: codify auth-error-display + useAuth component-test patterns

### DIFF
--- a/docs/LEARNINGS.md
+++ b/docs/LEARNINGS.md
@@ -61,6 +61,13 @@ This file is append-only. New entries are added by main Claude after each code r
 **Rule**: All timers (setTimeout, setInterval) in React components must be stored in `useRef`. Never store timer IDs in `useState`.
 **Agent**: react-typescript-reviewer
 
+### [2026-06-21] Rendering a structured error object showed the literal "[object Object]" (PR #381)
+
+**Mistake**: `LoginPage`/`SignupPage` passed the whole structured `AuthError` (`{message, code, details}`) to `setServerError(String(sanitizeError(result.error)))`. `sanitizeError()` returns non-strings UNCHANGED (`if (typeof error !== 'string') return error`), so it neither sanitized nor coerced — and `String({...})` rendered the literal `[object Object]` to the user on every server-side auth failure (e.g. "email already exists", bad credentials). The bug was duplicated across both auth pages.
+**Fix**: Render `result.error?.message` — `authService` already builds a readable string there (signup even flattens DRF field errors into it). Added `LoginPage.test.tsx` / `SignupPage.test.tsx` to guard it.
+**Rule**: Display `error.message` (a string) for any structured error, never the error object. A `sanitize*`/transform helper that returns non-strings unchanged is a no-op on objects — coerce to the string field BEFORE passing it in.
+**Agent**: react-typescript-reviewer
+
 ---
 
 ## Flutter/Firebase

--- a/docs/rules/react.md
+++ b/docs/rules/react.md
@@ -12,3 +12,6 @@ Compact checklist auto-injected before edits. Long-form:
 - **Send CSRF headers** on state-changing requests (`X-CSRFToken`).
 - Clean up effects — abort fetches, clear timers, remove listeners on unmount.
 - Tailwind CSS 4 conventions; no hardcoded hex colors where a token exists.
+- **Render `error.message`, not the error object.** `String({message,code})` is the
+  literal `[object Object]`; a `sanitize*` helper that returns non-strings unchanged
+  won't save you — pass the string field in.

--- a/docs/rules/testing.md
+++ b/docs/rules/testing.md
@@ -37,3 +37,8 @@ Compact checklist auto-injected before edits.
   lookup). An exact `assertNumQueries`/`captured_queries` pin on any endpoint that
   gates visibility via `.public()` must include it — a topic-detail endpoint
   measured 4, not the naive 3.
+- **Testing a `useAuth`/context page**: create the mock fn with `vi.hoisted` (the
+  `vi.mock` factory is hoisted above imports, so a bare top-level `const` throws),
+  wrap in `MemoryRouter` for `useNavigate`/`useLocation`, and query by
+  placeholder/role — `getByLabelText` is brittle when a label carries a
+  required-`*` span. See `web/docs/patterns/testing.md`.

--- a/docs/rules/triggers.json
+++ b/docs/rules/triggers.json
@@ -234,5 +234,22 @@
     "source": "pre-commit friction reduction 2026-06-13",
     "added": "2026-06-13",
     "severity": "warn"
+  },
+  {
+    "id": "render-error-message-not-object",
+    "domains": [
+      "react",
+      "typescript"
+    ],
+    "path_glob": [
+      "web/src/**/*.tsx"
+    ],
+    "content_present": "String\\(\\s*sanitizeError\\(",
+    "content_absent": "sanitizeError\\([^)]*\\.message",
+    "message": "String(sanitizeError(...)) renders the literal '[object Object]' if you pass the error OBJECT. Render result.error?.message (a string) instead — sanitize* helpers no-op on non-strings.",
+    "pattern_ref": "web/docs/patterns/react-typescript.md",
+    "source": "codify: docs/codify-auth-error-patterns",
+    "added": "2026-06-21",
+    "severity": "warn"
   }
 ]

--- a/web/docs/patterns/react-typescript.md
+++ b/web/docs/patterns/react-typescript.md
@@ -109,3 +109,33 @@ Never hardcode API URLs — always use the Vite environment variable:
 ```typescript
 const apiUrl = import.meta.env.VITE_API_URL;
 ```
+
+---
+
+## Displaying Errors — Render `.message`, Not the Object
+
+A structured error object (`{ message, code, ... }`) rendered as a string becomes
+the literal `[object Object]` — `String({ message: 'x' })` calls
+`Object.prototype.toString`, it does not reach into the object.
+
+A defensive-looking sanitizer can mask the bug without fixing it. Helpers that
+return non-strings **unchanged** are a no-op on objects:
+
+```typescript
+// utils/sanitize.ts — returns NON-strings unchanged (a no-op on objects)
+export function sanitizeError(error: unknown): unknown {
+  if (!error || typeof error !== 'string') return error; // ← an object passes straight through
+  return stripHtml(error);
+}
+
+// ❌ result.error is an AuthError object → renders "[object Object]" to the user
+setServerError(String(sanitizeError(result.error)));
+
+// ✅ extract the string field FIRST, then sanitize
+setServerError(String(sanitizeError(result.error?.message ?? 'Something went wrong.')));
+```
+
+Rule of thumb: pass the **string** you intend to display into a `sanitize*`/transform
+helper, never a structured object. This bit both `LoginPage` and `SignupPage`: the
+auth `error.message` was already a clean, readable string (the service layer even
+flattens DRF field errors into it); only the render call was wrong.

--- a/web/docs/patterns/testing.md
+++ b/web/docs/patterns/testing.md
@@ -67,3 +67,55 @@ New user-facing flows require a test case entry in `web/E2E_TESTING_GUIDE.md`. F
 **Steps**: 1. ... 2. ... 3. ...
 **Expected**: [visible outcome]
 ```
+
+---
+
+## Testing a Page That Uses `useAuth` + Router
+
+Component tests for a page that calls `useAuth()` and React Router hooks
+(`useNavigate`/`useLocation`) need three things. Canonical recipe — see
+`src/pages/auth/LoginPage.test.tsx`:
+
+```typescript
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import LoginPage from './LoginPage';
+
+// 1. vi.hoisted: the vi.mock factory is hoisted ABOVE the imports, so it cannot
+//    close over a plain top-level const (temporal-dead-zone error). Create the
+//    mock fn inside vi.hoisted so the factory can reference it.
+const { mockLogin } = vi.hoisted(() => ({ mockLogin: vi.fn() }));
+vi.mock('../../contexts/AuthContext', () => ({
+  useAuth: () => ({ login: mockLogin }),
+}));
+
+// 2. MemoryRouter supplies real useNavigate/useLocation — no need to mock them.
+const renderPage = () =>
+  render(
+    <MemoryRouter>
+      <LoginPage />
+    </MemoryRouter>
+  );
+
+it('submits with a short existing password', async () => {
+  mockLogin.mockResolvedValue({ success: true });
+  renderPage();
+  // 3. Query by PLACEHOLDER, not getByLabelText: the field <label> carries a
+  //    required "*" span, so an exact label match ("Password") fails.
+  fireEvent.change(screen.getByPlaceholderText('Enter your password'), {
+    target: { value: 'shortpw' },
+  });
+  fireEvent.click(screen.getByRole('button', { name: /sign in/i }));
+  await waitFor(() => expect(mockLogin).toHaveBeenCalled());
+});
+```
+
+Gotchas:
+
+- `vi.hoisted` is mandatory — a bare `const mockLogin = vi.fn()` referenced in the
+  factory throws "Cannot access 'mockLogin' before initialization".
+- Prefer `getByPlaceholderText` / `getByRole` over `getByLabelText` when labels
+  include a required-`*` span or other non-text nodes.
+- Test-fixture passwords (`password: '...'`) trip detect-secrets — add
+  `// pragma: allowlist secret` on the literal's line, and put it on a `const` so
+  Prettier can't shift the comment off that line.


### PR DESCRIPTION
Codifies the two reusable patterns from PR #381 (auth error fix + login regression tests). Docs-only.

## Pattern A — structured error object → `[object Object]`
`String({message, code})` renders the literal `[object Object]`, and `sanitizeError()` returns non-strings unchanged (a no-op on objects), so it masks rather than fixes. Render `error.message`.
- `docs/LEARNINGS.md` (React/TypeScript) — bug + root cause + fix
- `web/docs/patterns/react-typescript.md` — "Displaying Errors — Render `.message`"
- `docs/rules/react.md` — one-line rule
- `docs/rules/triggers.json` — write-time JIT trigger (warn) on `String(sanitizeError(...))` without `.message`; verified it fires on the bug shape and stays silent on the fix

## Pattern B — testing a `useAuth` + router page
No prior example existed in the 36-file suite. Recipe: `vi.hoisted` mock + `MemoryRouter` + query-by-placeholder.
- `web/docs/patterns/testing.md` — full recipe
- `docs/rules/testing.md` — one-line rule

## Not done here
The matching check could also be added to `.claude/agents/react-typescript-reviewer.md`, but editing `.claude/` is blocked by the auto-mode classifier — the rule + JIT trigger already cover write-time and `kimi-review --rules react`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
