### PR TITLE
docs: add error-object-render check to react-typescript-reviewer

### DIFF
--- a/.claude/agents/react-typescript-reviewer.md
+++ b/.claude/agents/react-typescript-reviewer.md
@@ -82,6 +82,7 @@ Use Grep as fallback for any LSP call that returns an error or empty/inconclusiv
 - [ ] React 19: no deprecated lifecycle methods, no class components in new code
 - [ ] `useCallback` dependencies must be correct — timer refs must NOT be in dependency arrays
 - [ ] Loading and error states required for any component that fetches data
+- [ ] Error display must render `error.message` (a string), never the structured error object — `String(errorObj)` renders the literal `[object Object]`; `sanitize*` helpers that return non-strings unchanged do NOT prevent this (PR #381)
 - [ ] Responsive design: mobile-first Tailwind classes, minimum tap target 44x44px
 
 ## Output Format (Review Mode)


### PR DESCRIPTION
Closes the one deferred target from the codify pass (PR #382): the
`react-typescript-reviewer` agent check, which was skipped while Auto Mode
blocked `.claude/` edits.

Adds one "React Patterns" checklist item so the reviewer flags rendering a
structured error object (`String(errorObj)` → `[object Object]`) instead of
`error.message`. The full pattern + the write-time JIT trigger already landed in
#382; this gives the code-review path the same coverage.

Docs-only, one line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
