### PR TITLE
ci(219): gate Flutter mobile CI as a required-able status check

### DIFF
--- a/.github/workflows/mobile-ci.yml
+++ b/.github/workflows/mobile-ci.yml
@@ -1,5 +1,19 @@
 name: Mobile Fresh Checkout CI
 
+# The heavy Flutter job (analyze + test + debug build, ~6.5 min) only needs to run
+# when mobile files change, so its work stays gated on a path check. But a
+# path-filtered *workflow trigger* can't back a required status check: GitHub waits
+# forever for a check that never reports on PRs whose diff doesn't match `paths:`,
+# deadlocking every non-mobile PR (see .github/workflows/harness-ci.yml for the same
+# trap and rationale).
+#
+# Fix (todo 219): run on EVERY pull_request (no path filter), detect whether mobile
+# files changed in a cheap `changes` job, gate the heavy Flutter job on that result,
+# and add a lightweight `mobile-ci-gate` job that ALWAYS reports a status.
+# `mobile-ci-gate` is the required status check on `main`: it passes quickly when no
+# mobile files changed (Flutter skipped) and fails when the Flutter job fails. The
+# `push` trigger stays path-filtered — required checks gate PRs, not post-merge pushes.
+
 'on':
   push:
     branches: [main, develop]
@@ -8,14 +22,29 @@ name: Mobile Fresh Checkout CI
       - '.github/workflows/mobile-ci.yml'
   pull_request:
     branches: [main, develop]
-    paths:
-      - 'plant_community_mobile/**'
-      - '.github/workflows/mobile-ci.yml'
   workflow_dispatch: {}
 
 jobs:
+  changes:
+    name: Detect mobile changes
+    runs-on: ubuntu-latest
+    outputs:
+      mobile: ${{ steps.filter.outputs.mobile }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            mobile:
+              - 'plant_community_mobile/**'
+              - '.github/workflows/mobile-ci.yml'
+
   flutter-fresh-checkout:
     name: Flutter analyze, test, and debug build
+    needs: changes
+    if: needs.changes.outputs.mobile == 'true' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
 
     defaults:
@@ -55,3 +84,30 @@ jobs:
           --dart-define=FIREBASE_MESSAGING_SENDER_ID=000000000000
           --dart-define=FIREBASE_PROJECT_ID=ci-placeholder-project
           --dart-define=FIREBASE_STORAGE_BUCKET=ci-placeholder-project.appspot.com
+
+  # Required status check for `main`. ALWAYS runs (no path filter on pull_request)
+  # so it always reports a status, and collapses the conditional Flutter job into a
+  # single honest gate: pass when mobile is untouched (Flutter skipped), fail when
+  # Flutter fails or change-detection itself failed (so a broken `changes` job can't
+  # pass the gate green). Keep the job id `mobile-ci-gate` — it IS the
+  # branch-protection context string.
+  mobile-ci-gate:
+    needs: [changes, flutter-fresh-checkout]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Gate on Flutter CI result
+        run: |
+          changes_result='${{ needs.changes.result }}'
+          flutter_result='${{ needs.flutter-fresh-checkout.result }}'
+          echo "changes job result: $changes_result"
+          echo "flutter job result: $flutter_result"
+          if [ "$changes_result" != 'success' ]; then
+            echo "::error::Change-detection job did not succeed ($changes_result); failing the gate instead of passing silently."
+            exit 1
+          fi
+          if [ "$flutter_result" = 'failure' ] || [ "$flutter_result" = 'cancelled' ]; then
+            echo "::error::Flutter CI did not pass ($flutter_result)."
+            exit 1
+          fi
+          echo "Mobile CI gate passed (Flutter job result: $flutter_result)."

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -156,7 +156,7 @@
         "filename": ".github/workflows/mobile-ci.yml",
         "hashed_secret": "98793fc9a37aa860c3d4a2f3caba9d8e64b54fb5",
         "is_verified": false,
-        "line_number": 50
+        "line_number": 79
       }
     ],
     "PLANNING/FIREBASE_SETUP.md": [
@@ -1514,5 +1514,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-21T23:01:19Z"
+  "generated_at": "2026-06-22T16:04:42Z"
 }

--- a/todos/219-in_progress-p2-mobile-ci-not-required-check.md
+++ b/todos/219-in_progress-p2-mobile-ci-not-required-check.md
@@ -1,5 +1,5 @@
 ---
-status: pending
+status: in_progress
 priority: p2
 issue_id: "219"
 tags: [ci, branch-protection, flutter, mobile, process]
@@ -134,6 +134,80 @@ is path-filtered, so making it required would deadlock every non-mobile PR.
   backend/web/harness checks; the Flutter job was advisory.
 - Confirmed `mobile-ci.yml` is path-filtered, so the simple "add to required
   checks" fix would deadlock non-mobile PRs. Captured the safe approaches above.
+
+### 2026-06-22 - Started by completing-todos skill (run 2026-06-22-1542)
+
+- Picked up by automated workflow. Implementing Option 1 (always-run
+  `mobile-ci-gate` job + conditional Flutter job via `dorny/paths-filter`).
+
+### 2026-06-22 - Implemented Option 1 (workflow change) — branch-protection step pending
+
+**Done (this PR, branch `todo-219-mobile-ci-required-gate`):**
+
+- Rewrote `.github/workflows/mobile-ci.yml` to the always-run gate pattern:
+  - Removed the `paths:` filter from the `pull_request` trigger (workflow now runs
+    on every PR); kept the `push` trigger path-filtered.
+  - Added a `changes` job (`dorny/paths-filter@v4`, current major — latest is
+    v4.0.1) exposing `outputs.mobile`.
+  - `flutter-fresh-checkout` now `needs: changes` and runs only when mobile files
+    changed (`if: needs.changes.outputs.mobile == 'true' || github.event_name ==
+    'workflow_dispatch'`). Job body unchanged.
+  - Added `mobile-ci-gate` (job id **is** the branch-protection context — no
+    `name:` override): `needs: [changes, flutter-fresh-checkout]`, `if: always()`.
+    Fails the gate if change-detection didn't succeed OR the Flutter job result is
+    `failure`/`cancelled`; passes otherwise (incl. Flutter `skipped` on non-mobile
+    PRs, so non-mobile PRs are never deadlocked).
+
+**Verification (local — proves implementation correctness, NOT the acceptance
+criteria, which are GitHub-side):**
+
+- `actionlint .github/workflows/mobile-ci.yml` → `OK (no issues)` (validates the
+  `needs`/context refs and the gate's shell).
+- `python3 -c "yaml.safe_load(...)"` → parses; jobs = `[changes,
+  flutter-fresh-checkout, mobile-ci-gate]`.
+- Gate decision logic simulated across all six scenarios — every one matched the
+  expected verdict: non-mobile PR → PASS (no deadlock); mobile pass → PASS; mobile
+  fail → FAIL; cancelled → FAIL; broken change-detection → FAIL (no silent green);
+  workflow_dispatch → PASS.
+
+**Code review:** No specialist reviewer matches a YAML workflow change
+(code-review-orchestrator routing → 0 agents). Self-assessment: gate wiring correct
+across every scenario; no GitHub Actions expression-injection risk (only the
+controlled `needs.*.result` enum is interpolated). 1 HIGH + 3 LOW:
+
+- HIGH — gate is inert until `mobile-ci-gate` is added to `main`'s required
+  contexts (verified live: required set is still the 4 backend/web/harness checks).
+  This is the tracked admin step below, **not** a code defect; nothing in this PR
+  can close it.
+- LOW (all accepted, no code change): (1) paths-filter false-negative is the only
+  residual slip-through vector — low prob, globs match scope + mirror the `push`
+  filter; (2) `dorny/paths-filter@v4` pinned to a major tag not a SHA — matches repo
+  convention; (3) `workflow_dispatch` may show a cosmetic red gate (non-gating,
+  manual only).
+
+**Remaining (NOT done — why this todo stays `in_progress`):** all four acceptance
+criteria are GitHub-side / repo-admin and cannot be verified locally. Required
+**ordered** handoff:
+
+1. Merge this PR to `main` (the gate workflow must live on the default branch
+   before it can back a required check).
+2. Open any PR after the merge and read the **exact** reported check name; confirm
+   it is literally `mobile-ci-gate`. (A required context that never matches =
+   permanent deadlock — the very failure this todo prevents.)
+3. Repo-admin adds it as a required context, only after step 2 confirms the string:
+
+   ```bash
+   gh api -X POST \
+     repos/Xertox1234/plant_id_community/branches/main/protection/required_status_checks/contexts \
+     -f 'contexts[]=mobile-ci-gate'
+   ```
+
+   Per the user's choice, Claude runs this with explicit go-ahead once steps 1–2
+   are confirmed.
+4. Live-verify the criteria: a docs-only PR shows `mobile-ci-gate` green quickly
+   (criterion #2); a mobile PR with a deliberately failing `flutter test` shows the
+   gate red and is blocked from merge (criterion #3). Then check off the criteria
+   and archive the todo.
 
 ## Notes
 


### PR DESCRIPTION
## What & why

Make the Flutter mobile CI eligible as a **required status check on `main`** without deadlocking non-mobile PRs. Implements todo 219.

A path-filtered workflow can't safely back a required check: GitHub waits forever for a status that never reports on PRs whose diff doesn't match the `paths:` filter, permanently blocking them (the same trap documented in `harness-ci.yml`). The mobile app is the primary platform, so a broken Flutter PR reaching `main` is a real risk — but the naive "add the job to required checks" fix would deadlock every non-mobile PR.

## How (Option 1 from todo 219)

- `pull_request` trigger no longer path-filtered → the workflow runs on every PR (consistent with backend-ci/web-ci/harness-ci, which already run on every PR). `push` stays path-filtered.
- New `changes` job (`dorny/paths-filter@v4`) outputs whether `plant_community_mobile/**` (or this workflow) changed.
- The heavy `flutter-fresh-checkout` job now runs only when mobile files changed (or on `workflow_dispatch`) — same effective cost as today.
- New always-run **`mobile-ci-gate`** job (`if: always()`): the job intended to become the required check. It passes when mobile is untouched (Flutter skipped) and fails if the Flutter job is `failure`/`cancelled` **or** change-detection itself didn't succeed (so a broken `changes` job can't pass the gate silently green). The job id is intentionally un-`name:`d so the branch-protection context is exactly `mobile-ci-gate`.

## Verification

- `actionlint` → clean (validates `needs`/context refs + the gate shell).
- Gate decision logic simulated across all 6 scenarios:

| scenario | changes | flutter | gate |
|---|---|---|---|
| non-mobile PR | success | skipped | **PASS** (no deadlock) |
| mobile, tests pass | success | success | PASS |
| mobile, tests fail | success | failure | **FAIL** |
| cancelled | success | cancelled | FAIL |
| broken change-detection | failure | skipped | **FAIL** (no silent green) |
| workflow_dispatch | success | success | PASS |

## Remaining (repo-admin, after merge — NOT in this PR)

Todo 219 stays `in_progress`; its acceptance criteria are GitHub-side and can't be satisfied by code:

1. Merge this PR (the gate must exist on `main`).
2. Confirm the exact reported check name is `mobile-ci-gate`.
3. Add it as a required context (admin):
   `gh api -X POST repos/Xertox1234/plant_id_community/branches/main/protection/required_status_checks/contexts -f 'contexts[]=mobile-ci-gate'`
4. Live-verify: docs-only PR → gate green fast; mobile PR with failing `flutter test` → gate red, merge blocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
