### PR TITLE
[VERIFY/DO-NOT-MERGE] todo 219: prove mobile-ci-gate blocks a failing mobile PR

### DIFF
--- a/plant_community_mobile/test/core/theme/app_spacing_test.dart
+++ b/plant_community_mobile/test/core/theme/app_spacing_test.dart
@@ -3,7 +3,7 @@ import 'package:plant_community_mobile/core/constants/app_spacing.dart';
 
 void main() {
   group('AppSpacing radius tokens', () {
-    test('rXs is 6', () => expect(AppSpacing.rXs, 6.0));
+    test('rXs is 6', () => expect(AppSpacing.rXs, 7.0)); // DELIBERATE FAIL (todo 219 gate verification — do not merge)
     test('rSm is 10', () => expect(AppSpacing.rSm, 10.0));
     test('rMd is 16', () => expect(AppSpacing.rMd, 16.0));
     test('rLg is 22', () => expect(AppSpacing.rLg, 22.0));


### PR DESCRIPTION
**Throwaway verification PR — will be closed, not merged.**

Verifies todo 219 acceptance criterion #3: a mobile PR with a deliberately failing `flutter test` must turn the new required `mobile-ci-gate` check **red** and leave the PR `mergeStateStatus: BLOCKED`.

The single change flips one assertion in `app_spacing_test.dart` to a wrong value. Once the gate is confirmed red + blocked, this PR is closed and the branch deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)