### PR TITLE
todos: file offline-persistence follow-ups (236, 237)

### DIFF
--- a/todos/236-pending-p3-offline-roundtrip-emulator-test.md
+++ b/todos/236-pending-p3-offline-roundtrip-emulator-test.md
@@ -1,0 +1,90 @@
+---
+status: pending
+priority: p3
+issue_id: "236"
+tags: [mobile, testing, firestore, offline]
+dependencies: ["224"]
+---
+
+# Emulator-backed offline→online round-trip test for Firestore sync
+
+## Problem
+
+The offline→online *transition* — the Firestore SDK queuing a write while offline
+and flushing it to the server on reconnect — has no automated test. The current
+integration suite runs the real `FirestoreService` against an in-memory
+`FakeFirebaseFirestore`, which has no network layer, so it can verify "a saved
+plant is continuously readable from the local store" but cannot exercise a literal
+write-queue flush across a reconnect. That round-trip is exactly the behavior the
+offline feature promises, and it is currently unverified.
+
+## Findings
+
+- `plant_community_mobile/test/integration/offline_sync_test.dart` documents the
+  gap in its own header comment: the fake is always an in-memory store with no
+  network, so the queue-flush round-trip "is not reproducible in-process … A
+  literal network round-trip would require the Firebase emulator."
+- The `data persisted before reconnect is still present afterward` test there is a
+  stand-in (before/after read from the same persisted store), not a real
+  offline→online transition.
+- `PlantsSnapshot` already exposes the metadata a real test would assert on
+  (`isFromCache`, `hasPendingWrites`) — see
+  `plant_community_mobile/lib/services/firestore_service.dart`.
+- Discovered while wiring todo 224 (offline persistence); recorded as a follow-up
+  in `todos/archive/224-completed-p2-wire-offline-persistence-firestore.md` and in
+  project memory.
+
+## Recommended Action
+
+1. Add a Firebase **Firestore emulator** config (an `emulators` block in
+   `firebase.json`, or reuse an existing emulator setup) and a script to start it.
+2. Write a Flutter `integration_test` (not a widget/unit test) that:
+   - points `FirebaseFirestore.instance` at the emulator,
+   - calls `disableNetwork()`, then `savePlant(uid, plant)`,
+   - asserts the snapshot is readable with `hasPendingWrites == true` /
+     `isFromCache == true`,
+   - calls `enableNetwork()`, waits for `hasPendingWrites` to flip to `false`,
+   - asserts the document is present server-side (independent emulator read).
+3. Gate it so the default `flutter test` run stays green without the emulator
+   (skip/guard when `FIRESTORE_EMULATOR_HOST` is unset). Optionally wire an
+   emulator job into CI as a separate, non-blocking gate.
+
+## Technical Details
+
+- Toggle connectivity with `FirebaseFirestore.instance.disableNetwork()` /
+  `enableNetwork()`.
+- Assert on `DocumentSnapshot`/`QuerySnapshot` `.metadata.hasPendingWrites` and
+  `.isFromCache`, surfaced through `PlantsSnapshot` in
+  `plant_community_mobile/lib/services/firestore_service.dart`
+  (`getPlantsStream` → `plantsStreamProvider`).
+- Existing fake-based tests stay as the fast default suite:
+  `plant_community_mobile/test/integration/offline_sync_test.dart`,
+  `plant_community_mobile/test/services/firestore_service_test.dart`.
+- Relevant patterns: `plant_community_mobile/docs/patterns/firebase-auth.md`.
+
+## Acceptance Criteria
+
+- [ ] An emulator-backed integration test saves a plant while the network is
+      disabled and asserts it is readable from cache with `hasPendingWrites == true`.
+- [ ] The same test re-enables the network, waits for `hasPendingWrites` to become
+      `false`, and asserts the document reached the emulator server via an
+      independent read.
+- [ ] The test is emulator-gated (skipped when the emulator env var is absent), so
+      `flutter test` with no emulator still passes — verified by quoting a clean
+      `flutter test` run in the Work Log.
+
+## Work Log
+
+### 2026-06-22 - Filed
+
+- Created from a todo-224 implementation follow-up (real offline→online round-trip
+  coverage). Not yet started.
+
+## Notes
+
+- Priority p3: the UI-facing contract (data continuously readable from the local
+  store) is already covered by the fake-based suite; this closes the remaining gap
+  on the literal SDK reconnect flush, which is valuable but not a current
+  regression.
+- Related: todo 237 (reconcile Firestore plants with the backend on reconnect) —
+  both stem from the same offline-persistence wiring.

--- a/todos/237-pending-p2-reconcile-firestore-backend-reconnect.md
+++ b/todos/237-pending-p2-reconcile-firestore-backend-reconnect.md
@@ -1,0 +1,109 @@
+---
+status: pending
+priority: p2
+issue_id: "237"
+tags: [mobile, firestore, sync, api]
+dependencies: ["224"]
+---
+
+# Reconcile Firestore plant collection with the Django backend on reconnect
+
+## Problem
+
+An identified plant is written to **two independent stores** with no link between
+them: the Django backend (during the identify API call) and Firestore (offline-first,
+via `savePlant`). Nothing reconciles them when connectivity returns, so the two can
+drift — a plant can exist in Firestore but not in the backend's record (or vice
+versa), and the collection UI, which reads Firestore only, can disagree with the
+backend.
+
+## Findings
+
+- `plant_community_mobile/lib/features/camera/camera_screen.dart`: `_identifyPlant`
+  calls the backend `identifyPlant` (via `api_service`) **and** then
+  `_persistPlantOffline(plant)` → `savePlant` to Firestore (fire-and-forget). Two
+  writes, no shared id or reconciliation.
+- `plant_community_mobile/lib/features/collection/collection_screen.dart` reads
+  from Firestore only (`plantsStreamProvider`); the backend's identification
+  records are never merged in.
+- No connectivity-restored / sync-on-reconnect path exists in the mobile app.
+- `firebase/firestore.rules` already reserves a `sync_queue` collection
+  ("only backend can write", updated/deleted by cloud functions only — lines
+  67–73), which suggests an intended server-side sync mechanism that is not yet
+  wired to the plant collection.
+- Discovered while wiring todo 224 (offline persistence); recorded as a follow-up
+  in `todos/archive/224-completed-p2-wire-offline-persistence-firestore.md` and in
+  project memory.
+
+## Proposed Solutions
+
+### Option 1: Firestore as source of truth, backend mirrors (Recommended)
+
+- **Implementation:** the app writes only to Firestore; a Cloud Function (or the
+  existing `sync_queue`) mirrors new/changed plant docs into the Django backend.
+  On reconnect, the SDK flushes queued writes and the function fans them out.
+- **Pros:** single client write path; offline-first stays simple; reconciliation
+  is server-side and idempotent.
+- **Cons:** requires a Cloud Function + backend ingest endpoint; backend is
+  eventually-consistent with Firestore.
+- **Effort:** hours–day.
+- **Risk:** medium — needs idempotency keys to avoid duplicate backend records.
+
+### Option 2: Backend as source of truth, Firestore as cache
+
+- **Implementation:** on reconnect, pull the backend's identifications and
+  upsert them into Firestore; treat the local Firestore copy as a cache.
+- **Pros:** backend stays authoritative (matches web app / garden calendar).
+- **Cons:** more client-side reconcile logic; offline writes still need a queue to
+  reach the backend.
+- **Effort:** hours–day.
+- **Risk:** medium.
+
+## Recommended Action
+
+1. Decide the source of truth (lean Option 1 — Firestore-first with a backend
+   mirror) and document it.
+2. Add a reconnect trigger (e.g. a `connectivity_plus` listener, or react to
+   `hasPendingWrites` clearing) that runs a reconciliation pass.
+3. Reconcile by stable plant id so the operation is **idempotent** — no duplicate
+   records on either side after repeated runs.
+4. Add an integration test (fake or emulator) asserting a plant saved while offline
+   appears in the backend after reconnect + reconcile, with no duplicates.
+
+## Technical Details
+
+- Two write sites today:
+  `plant_community_mobile/lib/features/camera/camera_screen.dart`
+  (`_identifyPlant` → backend `identifyPlant`; `_persistPlantOffline` →
+  `firestoreServiceProvider.savePlant`).
+- Read site: `plant_community_mobile/lib/services/firestore_service.dart`
+  (`getPlantsStream` → `plantsStreamProvider`).
+- Backend API client: `plant_community_mobile/lib/services/api_service.dart`.
+- Reserved sync surface: `firebase/firestore.rules` `sync_queue` (lines 67–73).
+- Relevant patterns: `plant_community_mobile/docs/patterns/firebase-auth.md`,
+  `firebase/docs/patterns/cloud-functions.md` (idempotency, cold starts).
+
+## Acceptance Criteria
+
+- [ ] A documented decision on the source of truth (Firestore-mirror vs
+      backend-authoritative) lands in the relevant pattern doc or this todo.
+- [ ] A reconciliation pass runs when connectivity is restored.
+- [ ] An integration test asserts a plant saved offline is present in the backend
+      after reconnect + reconcile.
+- [ ] The reconcile is idempotent: running it twice produces no duplicate records
+      on either store — asserted by the test.
+
+## Work Log
+
+### 2026-06-22 - Filed
+
+- Created from a todo-224 implementation follow-up (Firestore↔backend drift). Not
+  yet started.
+
+## Notes
+
+- Priority p2 (above the sibling test-coverage follow-up 236): this is a real
+  data-consistency gap that can surface user-visible drift between the mobile
+  collection and the backend, not just a missing test. Downgrade to p3 if the
+  backend collection is confirmed not user-facing.
+- Related: todo 236 (emulator round-trip test) and archived todo 224.


### PR DESCRIPTION
## Summary

Files two roadmap follow-ups spun out of completed todo **224** (Flutter offline persistence wiring, merged in #390). Docs only — two new `todos/` entries, no code change.

- **236** [p3] — Emulator-backed offline→online round-trip test for Firestore sync. Closes the one gap the `fake_cloud_firestore` suite can't cover: the SDK write-queue flush on reconnect (the fake is in-memory with no network).
- **237** [p2] — Reconcile the Firestore plant collection with the Django backend on reconnect. Identifications are written to two independent stores (backend via `api_service`, Firestore via `savePlant`) with no reconciliation, so they can drift. Notes the `sync_queue` collection already reserved in `firestore.rules` as a natural hook.

Both are anchored to real file paths from the 224 work and list `224` as a satisfied dependency for lineage.

## Test plan

- Doc-only; no runtime impact.
- Both files pass the same `^status: pending` discovery grep that `/todo-next` uses.
- Pre-commit gates (markdownlint, kimi-review) passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)