### PR TITLE
todos(236): tighten emulator-config + env-var wording

### DIFF
--- a/todos/236-pending-p3-offline-roundtrip-emulator-test.md
+++ b/todos/236-pending-p3-offline-roundtrip-emulator-test.md
@@ -36,18 +36,21 @@ offline feature promises, and it is currently unverified.
 
 ## Recommended Action
 
-1. Add a Firebase **Firestore emulator** config (an `emulators` block in
-   `firebase.json`, or reuse an existing emulator setup) and a script to start it.
+1. Add a Firebase **Firestore emulator** config — neither `firebase.json` (root
+   or `plant_community_mobile/`) has an `emulators` block today, so this is
+   net-new: add one plus a script to start the emulator.
 2. Write a Flutter `integration_test` (not a widget/unit test) that:
-   - points `FirebaseFirestore.instance` at the emulator,
+   - points the client at the emulator via
+     `FirebaseFirestore.instance.useFirestoreEmulator(host, port)`,
    - calls `disableNetwork()`, then `savePlant(uid, plant)`,
    - asserts the snapshot is readable with `hasPendingWrites == true` /
      `isFromCache == true`,
    - calls `enableNetwork()`, waits for `hasPendingWrites` to flip to `false`,
    - asserts the document is present server-side (independent emulator read).
-3. Gate it so the default `flutter test` run stays green without the emulator
-   (skip/guard when `FIRESTORE_EMULATOR_HOST` is unset). Optionally wire an
-   emulator job into CI as a separate, non-blocking gate.
+3. Gate it so the default `flutter test` run stays green without the emulator —
+   use an env var (e.g. `FIRESTORE_EMULATOR_HOST`) purely as a *skip guard*; the
+   client connects via `useFirestoreEmulator`, not by reading that var. Optionally
+   wire an emulator job into CI as a separate, non-blocking gate.
 
 ## Technical Details
 
@@ -87,4 +90,6 @@ offline feature promises, and it is currently unverified.
   on the literal SDK reconnect flush, which is valuable but not a current
   regression.
 - Related: todo 237 (reconcile Firestore plants with the backend on reconnect) —
-  both stem from the same offline-persistence wiring.
+  both stem from the same offline-persistence wiring, and 237's reconcile test
+  needs the same emulator harness this todo builds. Whoever lands 236 first should
+  lay that infra so 237 can reuse it rather than standing up a second setup.


### PR DESCRIPTION
## Summary

Review polish for todo 236 (filed in #391, which auto-merged before this landed). Docs-only — wording accuracy on the offline→online round-trip test todo:

- Emulator config is **net-new** — neither `firebase.json` (root or mobile) has an `emulators` block, so it can't "reuse an existing setup."
- The Flutter client connects to the emulator via `useFirestoreEmulator(host, port)`; `FIRESTORE_EMULATOR_HOST` is clarified as *only* a test skip-guard, not the connection mechanism.
- Notes that 237's reconcile test should reuse 236's emulator harness rather than standing up a second one.

## Test plan

- Docs-only; no runtime impact. markdownlint + kimi-review gates passed locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)