### PR TITLE
226: consolidate domain-routing tables into routing.json

### DIFF
--- a/.claude/hooks/inject-patterns.sh
+++ b/.claude/hooks/inject-patterns.sh
@@ -35,62 +35,15 @@ RULES_DIR="$PROJECT_ROOT/docs/rules"
 # as-is and simply fall through to no domain match.
 REL="${FILE_PATH#"$PROJECT_ROOT"/}"
 
-# Map file path to domains. Independent if-blocks so multiple rows can match.
+# Map file path to docs/rules/ domains via the shared matcher. Single source of
+# truth: docs/rules/routing.json (also consumed by kimi-review.sh and the codify
+# skill). Fail-open: missing python3 or unreadable routing → empty DOMAINS, so the
+# hook still emits the discipline floor + any matched triggers below.
 DOMAINS=""
-add_domain() {
-  case ",$DOMAINS," in
-    *,"$1",*) ;;
-    *) DOMAINS="${DOMAINS:+$DOMAINS,}$1" ;;
-  esac
-}
-
-[[ "$REL" == backend/apps/blog/* ]] && \
-  { add_domain wagtail; add_domain api; add_domain security; }
-
-[[ "$REL" == backend/apps/forum/* || "$REL" == backend/apps/forum_host/* || \
-   "$REL" == backend/packages/wagtail_forum/* ]] && \
-  { add_domain forum; add_domain wagtail; }
-
-[[ "$REL" == */migrations/* ]] && \
-  { add_domain database; add_domain security; }
-
-[[ "$REL" == */serializers.py ]] && add_domain api
-
-[[ "$REL" == */tasks.py || "$REL" == *celery* || "$REL" == */beat*.py ]] && \
-  add_domain celery
-
-[[ "$REL" == */views.py || "$REL" == */viewsets.py || \
-   "$REL" == */permissions.py ]] && \
-  { add_domain api; add_domain security; }
-
-[[ "$REL" == */models.py ]] && { add_domain database; add_domain security; }
-
-[[ "$REL" == */cache*.py || "$REL" == */signals.py ]] && add_domain caching
-
-# Generic backend Python catch-all (only if nothing more specific matched).
-if [ -z "$DOMAINS" ]; then
-  [[ "$REL" == backend/*.py ]] && \
-    { add_domain api; add_domain security; add_domain database; }
-fi
-
-[[ "$REL" == firebase/* || "$REL" == *firebase* ]] && \
-  { add_domain firebase; add_domain security; }
-
-[[ "$REL" == *.dart ]] && add_domain flutter
-
-[[ "$REL" == web/src/*.tsx ]] && { add_domain react; add_domain typescript; }
-
-# Test files accumulate the testing domain regardless of enclosing directory.
-[[ "$REL" == */tests/* || "$REL" == *test_*.py || "$REL" == *_test.py || \
-   "$REL" == *.test.ts || "$REL" == *.test.tsx || \
-   "$REL" == *.spec.ts || "$REL" == *.spec.tsx ]] && \
-  add_domain testing
-
-# typescript fallback for .ts/.tsx files when no more-specific domain matched.
-if [ -z "$DOMAINS" ]; then
-  case "$REL" in
-    *.ts|*.tsx) add_domain typescript ;;
-  esac
+if command -v python3 >/dev/null 2>&1; then
+  DOMAINS=$(printf '%s\n' "$REL" \
+    | python3 "$PROJECT_ROOT/scripts/inject/route_domains.py" 2>/dev/null) \
+    || DOMAINS=""
 fi
 
 # Build context in a temp file (avoids subshell newline stripping)

--- a/.claude/hooks/kimi-review.sh
+++ b/.claude/hooks/kimi-review.sh
@@ -33,51 +33,20 @@ GIT_COMMIT_RE='^([[:space:]]*[A-Za-z_][A-Za-z0-9_]*=[^[:space:]]+[[:space:]]+)*g
 FILES=$(git diff --cached --name-only 2>/dev/null)
 [ -n "$FILES" ] || exit 0
 
-# 6) Map staged files to docs/rules/ domains
+# 6) Map staged files to docs/rules/ domains via the shared matcher. Single source
+#    of truth: docs/rules/routing.json (also consumed by inject-patterns.sh and the
+#    codify skill). The matcher is additive (this normalizes the old first-match-wins
+#    case to the additive model inject-patterns.sh already used — strictly more
+#    thorough for the gate). Fail-open: missing python3 or unreadable routing →
+#    empty PATTERNS, so the review below still runs, just unscoped.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 PATTERNS=''
-add_pattern() {
-  case ",$PATTERNS," in
-    *,$1,*) ;;
-    *) PATTERNS="${PATTERNS:+$PATTERNS,}$1" ;;
-  esac
-}
-
-while IFS= read -r file; do
-  # Directory/file-role classification — first match wins per file.
-  case "$file" in
-    backend/apps/blog/*)
-      add_pattern wagtail; add_pattern api; add_pattern security ;;
-    backend/apps/forum/*|backend/apps/forum_host/*|backend/packages/wagtail_forum/*)
-      add_pattern forum; add_pattern wagtail; add_pattern security ;;
-    */migrations/*)
-      add_pattern database; add_pattern security ;;
-    */serializers.py)
-      add_pattern api ;;
-    */tasks.py|*celery*|*/beat*.py)
-      add_pattern celery ;;
-    */views.py|*/viewsets.py|*/api/*.py|*/permissions.py)
-      add_pattern api; add_pattern security ;;
-    */models.py)
-      add_pattern database; add_pattern security ;;
-    */cache*.py|*/signals.py)
-      add_pattern caching ;;
-    backend/*.py)
-      add_pattern api; add_pattern security; add_pattern database; add_pattern caching ;;
-    firebase/*|*firebase*)
-      add_pattern firebase; add_pattern security ;;
-    web/src/*.tsx)
-      add_pattern react; add_pattern typescript ;;
-    web/src/*.ts)
-      add_pattern typescript ;;
-    plant_community_mobile/*.dart)
-      add_pattern flutter ;;
-  esac
-  # Extension/test classification — additive, runs for every file.
-  case "$file" in
-    *test_*.py|*_test.py|*/tests/*|*.test.ts|*.test.tsx|*.spec.ts|*.spec.tsx)
-      add_pattern testing ;;
-  esac
-done <<< "$FILES"
+if command -v python3 >/dev/null 2>&1; then
+  PATTERNS=$(printf '%s' "$FILES" \
+    | python3 "$PROJECT_ROOT/scripts/inject/route_domains.py" 2>/dev/null) \
+    || PATTERNS=''
+fi
 
 # 7) Run review on the staged diff with Tier A deterministic verification. Only
 #    CRITICAL + WARNING (project convention). docs/rules/ holds the compact

--- a/.claude/hooks/test-inject-patterns.sh
+++ b/.claude/hooks/test-inject-patterns.sh
@@ -114,6 +114,20 @@ check "backend test file → testing rules" \
   '{"tool_name":"Edit","tool_input":{"file_path":"backend/apps/forum/tests/test_views.py"}}' \
   "RULES — testing"
 
+# Ordered-fallback regression: a backend *.py that ALSO matches *firebase* must get
+# BOTH the backend/*.py fallback domains (database) AND the firebase additive domains
+# (firebase). The backend/*.py fallback is positioned BEFORE the firebase rule in
+# routing.json, so firebase stacks on top of it. A "fallback only if no rule matched
+# anywhere" model would drop database here — these two checks guard against that
+# regression (see docs/rules/routing.json: ORDER IS LOAD-BEARING).
+check "backend firebase .py → database (fallback fires)" \
+  '{"tool_name":"Edit","tool_input":{"file_path":"backend/apps/garden/firebase_config.py"}}' \
+  "RULES — database"
+
+check "backend firebase .py → firebase (stacks on fallback)" \
+  '{"tool_name":"Edit","tool_input":{"file_path":"backend/apps/garden/firebase_config.py"}}' \
+  "RULES — firebase"
+
 # Output is valid JSON
 check "output is valid JSON with hookSpecificOutput" \
   '{"tool_name":"Edit","tool_input":{"file_path":"backend/apps/users/views.py"}}' \

--- a/.claude/hooks/test-kimi-review.sh
+++ b/.claude/hooks/test-kimi-review.sh
@@ -110,7 +110,11 @@ OUT=$(run_hook clean '{"tool_input":{"command":"git push origin main"}}')
 assert_empty "git push does NOT match" "$OUT"
 
 # ---------- Skip semantics ----------
-OUT=$(SKIP_KIMI_REVIEW=1 echo '{"tool_input":{"command":"git commit -m x"}}' | bash "$HOOK" 2>/dev/null)
+# NB: the env var must bind to the HOOK, not to `echo`. The old form
+# (`SKIP_KIMI_REVIEW=1 echo ... | bash "$HOOK"`) set it only for `echo`, so the
+# hook ran unset — silently passing only because a clean tree exits at the
+# "no staged files" gate. With anything staged it reached kimi-review and failed.
+OUT=$(echo '{"tool_input":{"command":"git commit -m x"}}' | SKIP_KIMI_REVIEW=1 bash "$HOOK" 2>/dev/null)
 assert_empty "SKIP_KIMI_REVIEW=1 skips" "$OUT"
 
 EMPTY_DIR=$(mktemp -d)

--- a/.claude/skills/codify/SKILL.md
+++ b/.claude/skills/codify/SKILL.md
@@ -16,27 +16,18 @@ Run:
 git diff main...HEAD --stat
 ```
 
-Build a list of changed-file domains (read top-to-bottom, a path may match
-several rows):
+Derive the changed-file domains from the single source of truth
+(`docs/rules/routing.json`) with the shared matcher — the same one the
+`inject-patterns.sh` and `kimi-review.sh` hooks use. Do **not** keep a copy of the
+path→domain table here:
 
-| Changed path matches                                    | Domain label(s)            |
-| -------------------------------------------------------- | -------------------------- |
-| `backend/apps/**/migrations/*`                           | `database`, `security`     |
-| `backend/apps/blog/**`                                   | `wagtail`, `api`           |
-| `backend/apps/**/serializers.py`, `**/api/**`            | `api`                      |
-| `backend/apps/**/views.py`, `**/viewsets.py`, `**/permissions.py` | `api`, `security` |
-| `backend/apps/**/models.py`                              | `database`, `security`     |
-| `backend/apps/**/tasks.py`, `**/celery*`                 | `celery`                   |
-| `backend/apps/**/cache*.py`, `**/signals.py`             | `caching`                  |
-| `backend/**/*.py` (other)                                | `security`                 |
-| `web/src/**/*.tsx`                                       | `react`, `typescript`      |
-| `web/src/**/*.ts`                                        | `typescript`               |
-| `plant_community_mobile/**/*.dart`                       | `flutter`                  |
-| `firebase/**`, `**/firebase*`                            | `firebase`, `security`     |
-| `**/tests/**`, `**/test_*.py`, `**/*.test.ts*`, `**/*.spec.ts*` | `testing`           |
+```bash
+git diff main...HEAD --name-only | python3 scripts/inject/route_domains.py
+```
 
-Combine all matched labels. If the diff is empty, output "Nothing to codify —
-no changes on this branch." and stop.
+This prints the comma-separated domain labels (deduped, e.g. `api,security,database`),
+which double as `docs/rules/<domain>` names. If the diff is empty (no output / no
+changed files), output "Nothing to codify — no changes on this branch." and stop.
 
 ## Step 2 — Run kimi-review on the branch diff
 

--- a/docs/rules/routing.json
+++ b/docs/rules/routing.json
@@ -1,0 +1,42 @@
+{
+  "_comment": [
+    "Single source of truth for path -> docs/rules/<domain> routing.",
+    "Consumers: .claude/hooks/inject-patterns.sh (edit-time), .claude/hooks/kimi-review.sh",
+    "(commit gate), and .claude/skills/codify/SKILL.md Step 1 — all via",
+    "scripts/inject/route_domains.py. Adding/renaming a domain = edit THIS file only.",
+    "",
+    "ORDER IS LOAD-BEARING. Rules are evaluated top-to-bottom per path:",
+    "  - mode 'additive': if any glob matches, its domains are added (deduped).",
+    "  - mode 'fallback': applied ONLY if no domain has been collected YET at this",
+    "    position. A fallback must stay BELOW the additive rules it defers to, and",
+    "    additive rules placed AFTER a fallback still stack on top of it. This is why",
+    "    e.g. backend/apps/garden/firebase_config.py resolves to",
+    "    api,security,database (backend/*.py fallback) + firebase,security (stacked).",
+    "    Reordering changes behavior — see test-inject-patterns.sh firebase regression.",
+    "",
+    "Globs use fnmatch semantics (matched case-sensitively, '*' spans '/'), matching",
+    "bash [[ == ]] in the original hooks. todo 229 will add 'agents'/'exclusions'.",
+    "",
+    "Consequence of the testing-rule-before-ts-fallback order: a web non-.tsx test",
+    "file (e.g. web/src/App.spec.ts) resolves to 'testing' only — the *.ts fallback",
+    "is suppressed by the earlier testing match. This matches the old inject hook;",
+    "the old kimi/codify tables gave typescript+testing. Blessed (fail-safe: drops a",
+    "checklist hint, never blocks). .tsx web specs keep typescript via web/src/*.tsx."
+  ],
+  "rules": [
+    { "globs": ["backend/apps/blog/*"], "domains": ["wagtail", "api", "security"], "mode": "additive" },
+    { "globs": ["backend/apps/forum/*", "backend/apps/forum_host/*", "backend/packages/wagtail_forum/*"], "domains": ["forum", "wagtail", "security"], "mode": "additive" },
+    { "globs": ["*/migrations/*"], "domains": ["database", "security"], "mode": "additive" },
+    { "globs": ["*/serializers.py"], "domains": ["api"], "mode": "additive" },
+    { "globs": ["*/tasks.py", "*celery*", "*/beat*.py"], "domains": ["celery"], "mode": "additive" },
+    { "globs": ["*/views.py", "*/viewsets.py", "*/api/*.py", "*/permissions.py"], "domains": ["api", "security"], "mode": "additive" },
+    { "globs": ["*/models.py"], "domains": ["database", "security"], "mode": "additive" },
+    { "globs": ["*/cache*.py", "*/signals.py"], "domains": ["caching"], "mode": "additive" },
+    { "globs": ["backend/*.py"], "domains": ["api", "security", "database"], "mode": "fallback" },
+    { "globs": ["firebase/*", "*firebase*"], "domains": ["firebase", "security"], "mode": "additive" },
+    { "globs": ["*.dart"], "domains": ["flutter"], "mode": "additive" },
+    { "globs": ["web/src/*.tsx"], "domains": ["react", "typescript"], "mode": "additive" },
+    { "globs": ["*/tests/*", "*test_*.py", "*_test.py", "*.test.ts", "*.test.tsx", "*.spec.ts", "*.spec.tsx"], "domains": ["testing"], "mode": "additive" },
+    { "globs": ["*.ts", "*.tsx"], "domains": ["typescript"], "mode": "fallback" }
+  ]
+}

--- a/scripts/inject/route_domains.py
+++ b/scripts/inject/route_domains.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Resolve repo-relative paths to docs/rules/ domain labels.
+
+Single source of truth = docs/rules/routing.json. This is the one matcher shared
+by .claude/hooks/inject-patterns.sh (edit-time), .claude/hooks/kimi-review.sh
+(commit gate), and .claude/skills/codify/SKILL.md Step 1. Adding/renaming a domain
+means editing routing.json only — never this script.
+
+Input : repo-relative paths, one per line on stdin (or as argv). kimi passes the
+        whole staged file list; inject passes a single path.
+Output : the deduped union of matched domains, comma-joined, on one line.
+        Empty output when nothing matches.
+
+Matching (per path, then unioned):
+  Rules are evaluated top-to-bottom. ORDER IS LOAD-BEARING.
+    - mode "additive": if any glob matches, add its domains.
+    - mode "fallback": apply only if NO domain collected yet at this position.
+  This reproduces the original ordered if-blocks exactly, including the
+  backend/*.py fallback stacking with a later firebase additive rule.
+
+Fail-open: any error (missing/unparseable routing.json, bad input) prints nothing
+and exits 0. Both hooks treat empty output as "no domain rules" and proceed.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from fnmatch import fnmatchcase
+from pathlib import Path
+
+ROUTING_JSON = Path(__file__).resolve().parents[2] / "docs" / "rules" / "routing.json"
+
+
+def _domains_for(path: str, rules: list) -> list:
+    """Ordered matcher for one path. fnmatchcase == bash [[ == ]] (case-sensitive,
+    '*' spans '/'). Fallback rules fire only while the set is still empty."""
+    acc: list = []
+    for rule in rules:
+        mode = rule.get("mode", "additive")
+        if mode == "fallback" and acc:
+            continue
+        globs = rule.get("globs", [])
+        if any(fnmatchcase(path, g) for g in globs):
+            for domain in rule.get("domains", []):
+                if domain not in acc:
+                    acc.append(domain)
+    return acc
+
+
+def main() -> int:
+    try:
+        rules = json.loads(ROUTING_JSON.read_text(encoding="utf-8")).get("rules", [])
+    except Exception:
+        return 0  # fail-open: no routing → no domains
+
+    if len(sys.argv) > 1:
+        paths = sys.argv[1:]
+    else:
+        paths = sys.stdin.read().splitlines()
+
+    union: list = []
+    for raw in paths:
+        path = raw.strip()
+        if not path:
+            continue
+        for domain in _domains_for(path, rules):
+            if domain not in union:
+                union.append(domain)
+
+    if union:
+        sys.stdout.write(",".join(union))
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception:
+        sys.exit(0)  # never let the matcher break a hook

--- a/scripts/inject/test_route_domains.py
+++ b/scripts/inject/test_route_domains.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Tests for route_domains — the shared path→docs/rules domain matcher.
+
+Run: python3 scripts/inject/test_route_domains.py
+
+_domains_for() is tested directly with an inline rules fixture (so the tests pin
+the ordered/additive/fallback semantics independent of routing.json's contents).
+Two subprocess tests drive the real script end-to-end: one against the real
+routing.json (the firebase ordered-stacking regression), one proving fail-open
+when routing.json is unreadable.
+"""
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import route_domains as rd  # noqa: E402
+
+SCRIPT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "route_domains.py")
+
+# Inline fixture mirroring the shape of routing.json (order is load-bearing).
+RULES = [
+    {"globs": ["backend/apps/blog/*"], "domains": ["wagtail", "api", "security"], "mode": "additive"},
+    {"globs": ["*/migrations/*"], "domains": ["database", "security"], "mode": "additive"},
+    {"globs": ["*/views.py"], "domains": ["api", "security"], "mode": "additive"},
+    {"globs": ["backend/*.py"], "domains": ["api", "security", "database"], "mode": "fallback"},
+    {"globs": ["firebase/*", "*firebase*"], "domains": ["firebase", "security"], "mode": "additive"},
+    {"globs": ["*/tests/*", "*test_*.py"], "domains": ["testing"], "mode": "additive"},
+    {"globs": ["*.ts", "*.tsx"], "domains": ["typescript"], "mode": "fallback"},
+]
+
+
+class DomainsForTests(unittest.TestCase):
+    def test_additive_stacks_multiple_rules(self):
+        # blog/views.py matches blog + views → union, deduped, order-preserving.
+        self.assertEqual(
+            rd._domains_for("backend/apps/blog/views.py", RULES),
+            ["wagtail", "api", "security"],
+        )
+
+    def test_fallback_fires_only_when_empty(self):
+        # A plain backend .py matching nothing earlier → fallback fires.
+        self.assertEqual(
+            rd._domains_for("backend/manage.py", RULES),
+            ["api", "security", "database"],
+        )
+
+    def test_fallback_suppressed_by_earlier_match(self):
+        # migrations matched first → backend/*.py fallback must NOT fire.
+        self.assertEqual(
+            rd._domains_for("backend/apps/x/migrations/0001.py", RULES),
+            ["database", "security"],
+        )
+
+    def test_firebase_stacks_on_fallback_ordered(self):
+        # THE crux: fallback fires (empty), THEN firebase additive stacks on top.
+        # A "fallback only if nothing matched anywhere" model would drop database.
+        self.assertEqual(
+            rd._domains_for("backend/apps/garden/firebase_config.py", RULES),
+            ["api", "security", "database", "firebase"],
+        )
+
+    def test_backend_test_file_stacks_testing_on_fallback(self):
+        self.assertEqual(
+            rd._domains_for("backend/x/tests/test_foo.py", RULES),
+            ["api", "security", "database", "testing"],
+        )
+
+    def test_ts_fallback_only_when_otherwise_empty(self):
+        self.assertEqual(rd._domains_for("scripts/foo.ts", RULES), ["typescript"])
+
+    def test_no_match_returns_empty(self):
+        self.assertEqual(rd._domains_for("README.md", RULES), [])
+
+
+class SubprocessTests(unittest.TestCase):
+    def _run(self, stdin, env=None):
+        return subprocess.run(
+            [sys.executable, SCRIPT],
+            input=stdin,
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+
+    def test_real_routing_firebase_regression(self):
+        # End-to-end against the REAL docs/rules/routing.json.
+        r = self._run("backend/apps/garden/firebase_config.py\n")
+        self.assertEqual(r.returncode, 0)
+        out = set(r.stdout.split(","))
+        self.assertIn("database", out)  # fallback fired
+        self.assertIn("firebase", out)  # stacked on top
+
+    def test_union_across_multiple_paths(self):
+        # kimi passes the whole staged list in one call; per-path then unioned.
+        r = self._run("backend/apps/users/views.py\nweb/src/x.ts\n")
+        self.assertEqual(r.returncode, 0)
+        out = set(filter(None, r.stdout.split(",")))
+        self.assertEqual(out, {"api", "security", "typescript"})
+
+    def test_fail_open_on_unreadable_routing(self):
+        # Point the module's resolver at a missing file via a temp HOME-less cwd:
+        # simplest is to run a tiny inline script that monkeypatches ROUTING_JSON.
+        code = (
+            "import sys, pathlib; sys.path.insert(0, %r);"
+            "import route_domains as rd;"
+            "rd.ROUTING_JSON = pathlib.Path('/nonexistent/routing.json');"
+            "sys.exit(rd.main())" % os.path.dirname(SCRIPT)
+        )
+        r = subprocess.run(
+            [sys.executable, "-c", code],
+            input="backend/apps/users/views.py\n",
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(r.returncode, 0)
+        self.assertEqual(r.stdout, "")  # fail-open: no domains, no error
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/todos/archive/226-completed-p2-consolidate-domain-routing-tables.md
+++ b/todos/archive/226-completed-p2-consolidate-domain-routing-tables.md
@@ -1,5 +1,5 @@
 ---
-status: pending
+status: completed
 priority: p2
 issue_id: "226"
 tags: [harness, hooks, maintainability]
@@ -50,13 +50,105 @@ cause remains).
 
 ## Acceptance Criteria
 
-- [ ] One file defines all path→domain/agent mappings; both hooks and all three
-      markdown consumers reference it.
-- [ ] `bash .claude/hooks/test-inject-patterns.sh` and `test-kimi-review.sh` pass.
-- [ ] Adding a fake domain entry in routing.json is picked up by both hooks with
+- [x] **(Option A — domains only)** One file (`docs/rules/routing.json`) defines all
+      path→**domain** mappings; both hooks (`inject-patterns.sh`, `kimi-review.sh`)
+      and the codify Step-1 markdown consumer reference it. **Scope amendment:**
+      path→**agent** mappings (Type B: `code-review-orchestrator.md`,
+      `full-review-orchestrator.md` + its exclusion list) and finding-domain→agent
+      (Type C: codify Step 4) are deferred to **todo 229**, which owns the fleet and
+      will extend `routing.json` with an `agents`/`exclusions` block.
+- [x] `bash .claude/hooks/test-inject-patterns.sh` and `test-kimi-review.sh` pass.
+- [x] Adding a fake domain entry in routing.json is picked up by both hooks with
       no other edits (manual smoke test documented in work log).
 
 ## Work Log
+
+### 2026-06-23 - Completed by completing-todos skill (run 2026-06-23-0033)
+
+- Verification: all 3 acceptance criteria passed (Option-A scope). Tests green:
+  route_domains 10/10, inject 22/22 (incl. firebase regression), kimi 20/20;
+  fake-domain smoke test confirmed both hooks pick up a new routing.json entry.
+- Review: code-review-orchestrator → 0 blocking (0 critical/high/medium/low),
+  2 INFO — #1 (extra web-spec-ts divergence) recorded in routing.json; #2 (test
+  fixture drift) accepted, guarded by subprocess tests.
+- Type B (orchestrator agent routing) + Type C (codify Step 4) remain for todo 229.
+
+### 2026-06-23 - Started by completing-todos skill (run 2026-06-23-0033)
+
+- Picked up by automated workflow. Scope confirmed by user: **Option A — domains-only**
+  (Type A); agents/orchestrators (Type B) + codify Step 4 (Type C) deferred to todo 229.
+  Auto Mode off. Branch `chore/226-consolidate-routing-tables` off `origin/main`.
+- **Design correction (within Option A):** the 2026-06-22 "no primary matched → apply
+  fallback (single post-pass)" wording is subtly wrong. `inject-patterns.sh` evaluates
+  the `backend/*.py` fallback (block 9) *before* the firebase/dart/web/testing blocks
+  (10–13), so `backend/apps/garden/firebase_config.py` today gets
+  `api,security,database` (fallback) **+** `firebase,security` (stacked) =
+  `{api,security,database,firebase}`. A post-pass model would drop `api,database`.
+  Verified 6 real backend `*.py` firebase files exist (garden/firebase_config.py,
+  users/firebase_auth_views.py, garden/services/firebase_*.py, …). **Fix:** model rules
+  as an *ordered* list where `fallback` rules fire only if the domain set is empty
+  *at their position* — reproduces inject exactly. Advisor independently re-traced
+  and confirmed. Added a regression test (`firebase_config.py` ⇒ both `database` +
+  `firebase`) that discriminates the ordered model from the buggy post-pass.
+- **Blessed reconciliations** (two diverged tables → one): forum gains `security`
+  (matches kimi); `*/api/*.py` ⇒ `api,security` explicit (matches kimi; inject side-effect:
+  `backend/apps/*/api/*non-view*.py` loses `database` vs old fallback); `*.dart` any path
+  (matches inject); `backend/*.py` fallback ⇒ `api,security,database` (drops kimi's
+  `+caching`); blog ⇒ `wagtail,api,security` (codify gains `api`+`security`).
+  kimi normalized first-match-wins → additive; for backend-firebase files kimi now
+  gains `firebase` and loses `caching`. kimi gains a `python3` dependency (guarded,
+  fail-open to unscoped review).
+
+**Implemented (Type A only):**
+
+- New `docs/rules/routing.json` (ordered `rules`; `additive`/`fallback` modes;
+  load-bearing-order comment) — single source of truth.
+- New `scripts/inject/route_domains.py` — the one shared matcher (stdin paths →
+  comma-joined deduped domains; fail-open on missing/unparseable routing).
+- New `scripts/inject/test_route_domains.py` — 10 unit + subprocess tests
+  (ordered firebase stacking, fallback suppression, per-path union, fail-open).
+- `inject-patterns.sh`: ~57 lines of if-blocks → one guarded matcher call.
+- `kimi-review.sh`: `add_pattern` fn + per-file `case` loop → one guarded matcher
+  call (+ added `PROJECT_ROOT`).
+- `test-inject-patterns.sh`: added the firebase ordered-fallback regression
+  (database **and** firebase must both appear).
+- `test-kimi-review.sh`: fixed a **pre-existing latent test bug** surfaced by this
+  run — `SKIP_KIMI_REVIEW=1 echo … | bash "$HOOK"` bound the env var to `echo`, not
+  the hook; only passed on a clean tree (exits at the no-staged-files gate). Proven
+  pre-existing: `git show HEAD:.claude/hooks/kimi-review.sh` fails identically with
+  anything staged. Fixed to `echo … | SKIP_KIMI_REVIEW=1 bash "$HOOK"`.
+- `codify/SKILL.md` Step 1: divergent inline table → `git diff … --name-only |
+  python3 scripts/inject/route_domains.py` (codify now uses the same matcher).
+- NOT touched (deferred to 229): both orchestrators, codify Step 4, exclusions.
+
+**Verification (Acceptance Criteria):**
+
+- AC2 — `python3 scripts/inject/test_route_domains.py` → `Ran 10 tests … OK`;
+  `bash .claude/hooks/test-inject-patterns.sh` → `Results: 22 passed, 0 failed`
+  (incl. both firebase regression checks); `bash .claude/hooks/test-kimi-review.sh`
+  → `Results: 20 passed, 0 failed`.
+- AC1/AC3 — matcher spot-checks match the pre-change hooks exactly, e.g.
+  `firebase_config.py` → `api,security,database,firebase`. Fake-domain smoke test:
+  added one `*.smoketestext` rule to routing.json → `inject-patterns.sh` emitted
+  `RULES — smoketest` and `kimi-review.sh`'s matcher returned `smoketest` with **no
+  other edits**; routing.json restored byte-identically (no residue, valid JSON).
+
+**Code review (code-review-orchestrator):** 0 critical / 0 high / 0 medium / 0 low;
+2 INFO (doc-only). Reviewer independently audited injection-safety (hostile
+`file_path` like `$(touch …)`, backticks, `;rm -rf /` → rc 0, no execution, valid
+JSON out), fail-open (missing python3 / corrupt JSON / non-dict JSON all → empty +
+rc 0), and behavior-preservation (~45 paths through old inject/kimi/codify tables
+vs new matcher; all divergences are ordering-only or blessed).
+
+- INFO #1 (addressed): one more divergence — web non-`.tsx` test files
+  (`web/src/App.spec.ts`) now resolve to `testing` only, not `typescript,testing`.
+  Matches old inject exactly; fail-safe (drops a checklist hint, never blocks).
+  **Recorded** as a blessed reconciliation in `routing.json`'s comment (not left
+  silent). Verified: `web/src/App.spec.ts` → `testing`.
+- INFO #2 (accepted): `test_route_domains.py`'s inline `RULES` fixture is a
+  hand-copy of routing.json that could drift. Mitigated by the two subprocess tests
+  that drive the REAL routing.json end-to-end (firebase regression + union) — those
+  are the drift guard. Intentional unit/integration split; left as-is.
 
 ### 2026-06-22 - Re-scoped during sweep run 2026-06-22-0205; DEFERRED again (Type-A design ready)
 


### PR DESCRIPTION
## What & why

Domain routing (path → `docs/rules/<domain>`) was hand-copied across five places and had **diverged** — the structural cause of bugs like machina-era forum rules continuing to inject after the machina retirement. This collapses the duplicated tables into one source of truth.

- **`docs/rules/routing.json`** (new) — ordered `rules` (path-glob → domains, `additive`/`fallback` modes). Adding/renaming a domain = edit this file only.
- **`scripts/inject/route_domains.py`** (new) — the single shared matcher. Reads paths on stdin, prints deduped domains, **fails open** on any error.
- Wired consumers: `inject-patterns.sh` (edit-time hook), `kimi-review.sh` (commit-gate hook), and `codify/SKILL.md` Step 1 — all now call the matcher instead of carrying inline tables.

## Scope — Option A (domains only)

Per the todo's amended Acceptance Criterion 1, this does **Type A (path→domains)** only. Agent routing (the two review orchestrators) and codify Step 4 are **deferred to todo 229**, which owns the agent fleet and will extend `routing.json` with an `agents`/`exclusions` block.

## Behavior preservation (the core risk)

The matcher uses an **ordered** rule list where `fallback` rules fire only if no domain was collected *at that position*. This reproduces the old `inject-patterns.sh` exactly — including the subtle case where the `backend/*.py` fallback stacks with a *later* `firebase` additive rule:

```
backend/apps/garden/firebase_config.py → api,security,database,firebase
```

A naive "fallback only if nothing matched anywhere" model would silently drop `api,database` here. A new **firebase regression test** guards the ordered model against that.

Diverged-table reconciliations are blessed/documented (forum +security; `*/api/*.py`→api,security; `*.dart` any path; backend `*.py` fallback drops caching; blog gains security; web non-`.tsx` specs → `testing` only). `kimi-review.sh` normalizes first-match-wins → additive (strictly more rule context for the gate).

## Also fixed

A pre-existing latent bug in `test-kimi-review.sh`: `SKIP_KIMI_REVIEW=1 echo … | bash "$HOOK"` bound the env var to `echo`, not the hook — it only passed on a clean tree. Now binds to the hook.

## Tests

- `python3 scripts/inject/test_route_domains.py` → 10/10 (ordered firebase stacking, fallback suppression, per-path union, fail-open)
- `bash .claude/hooks/test-inject-patterns.sh` → 22/22 (incl. both firebase regression checks)
- `bash .claude/hooks/test-kimi-review.sh` → 20/20
- Fake-domain smoke test: a single new `routing.json` entry is picked up by both hooks with no other edits.

Code-review-orchestrator: 0 blocking findings (injection-safety + fail-open independently audited).

🤖 Generated with [Claude Code](https://claude.com/claude-code)