### PR TITLE
231(PR-2a): forum backend write path — REST create routes + PostWriteView (edit/delete)

### DIFF
--- a/backend/apps/forum_host/api.py
+++ b/backend/apps/forum_host/api.py
@@ -40,6 +40,16 @@ class PostListView(forum_views.PostListView):
 
 
 @method_decorator(
+    ratelimit(key="user", rate=_rate("post_update"), method="PATCH"), name="patch"
+)
+@method_decorator(
+    ratelimit(key="user", rate=_rate("post_delete"), method="DELETE"), name="delete"
+)
+class PostWriteView(forum_views.PostWriteView):
+    pass
+
+
+@method_decorator(
     ratelimit(key="user", rate=_rate("reaction_toggle"), method="POST"), name="post"
 )
 class ReactionToggleView(forum_views.ReactionToggleView):

--- a/backend/apps/forum_host/api.py
+++ b/backend/apps/forum_host/api.py
@@ -26,14 +26,16 @@ def _rate(name):
 @method_decorator(
     ratelimit(key="user", rate=_rate("topic_create"), method="POST"), name="post"
 )
-class TopicCreateView(forum_views.TopicCreateView):
+class TopicListView(forum_views.TopicListView):
+    # GET (list) is public + unthrottled; only the merged POST (create) is rated.
     pass
 
 
 @method_decorator(
     ratelimit(key="user", rate=_rate("reply_create"), method="POST"), name="post"
 )
-class ReplyCreateView(forum_views.ReplyCreateView):
+class PostListView(forum_views.PostListView):
+    # GET (list) is public + unthrottled; only the merged POST (reply) is rated.
     pass
 
 

--- a/backend/apps/forum_host/api_urls.py
+++ b/backend/apps/forum_host/api_urls.py
@@ -7,20 +7,18 @@ package endpoint cannot silently ship unmounted or unthrottled.
 """
 
 from django.urls import path
-from wagtail_forum.api.views import (
-    BoardListView,
-    PostListView,
-    TopicDetailView,
-    TopicListView,
-)
+
+# GET-only views are mounted straight from the package (no throttle); views with
+# a throttled write handler come from the host wrappers in .api.
+from wagtail_forum.api.views import BoardListView, TopicDetailView
 
 from .api import (
     MeProfileView,
+    PostListView,
     ReactionToggleView,
-    ReplyCreateView,
     SearchView,
     SyncView,
-    TopicCreateView,
+    TopicListView,
 )
 
 app_name = "wagtail_forum_api"
@@ -28,22 +26,8 @@ app_name = "wagtail_forum_api"
 urlpatterns = [
     path("boards/", BoardListView.as_view(), name="board-list"),
     path("boards/<slug:slug>/topics/", TopicListView.as_view(), name="topic-list"),
-    path(
-        "boards/<slug:slug>/topics/create/",
-        TopicCreateView.as_view(),
-        name="topic-create",
-    ),
     path("topics/<int:topic_id>/", TopicDetailView.as_view(), name="topic-detail"),
-    path(
-        "topics/<int:topic_id>/posts/",
-        PostListView.as_view(),
-        name="post-list",
-    ),
-    path(
-        "topics/<int:topic_id>/posts/create/",
-        ReplyCreateView.as_view(),
-        name="reply-create",
-    ),
+    path("topics/<int:topic_id>/posts/", PostListView.as_view(), name="post-list"),
     path(
         "posts/<int:post_id>/reactions/",
         ReactionToggleView.as_view(),

--- a/backend/apps/forum_host/api_urls.py
+++ b/backend/apps/forum_host/api_urls.py
@@ -15,6 +15,7 @@ from wagtail_forum.api.views import BoardListView, TopicDetailView
 from .api import (
     MeProfileView,
     PostListView,
+    PostWriteView,
     ReactionToggleView,
     SearchView,
     SyncView,
@@ -28,6 +29,7 @@ urlpatterns = [
     path("boards/<slug:slug>/topics/", TopicListView.as_view(), name="topic-list"),
     path("topics/<int:topic_id>/", TopicDetailView.as_view(), name="topic-detail"),
     path("topics/<int:topic_id>/posts/", PostListView.as_view(), name="post-list"),
+    path("posts/<int:post_id>/", PostWriteView.as_view(), name="post-detail"),
     path(
         "posts/<int:post_id>/reactions/",
         ReactionToggleView.as_view(),

--- a/backend/apps/forum_host/constants.py
+++ b/backend/apps/forum_host/constants.py
@@ -7,6 +7,8 @@
 DEFAULT_FORUM_RATELIMITS = {
     "topic_create": "10/h",
     "reply_create": "30/h",
+    "post_update": "30/h",
+    "post_delete": "20/h",
     "reaction_toggle": "60/m",
     "profile_update": "10/h",
     "search": "30/m",

--- a/backend/apps/forum_host/tests/test_ratelimits.py
+++ b/backend/apps/forum_host/tests/test_ratelimits.py
@@ -71,7 +71,7 @@ def test_topic_create_is_throttled_per_user():
 
     def create(slug):
         return client.post(
-            f"/api/v1/forum/boards/{board.slug}/topics/create/",
+            f"/api/v1/forum/boards/{board.slug}/topics/",
             {
                 "title": slug,
                 "slug": slug,
@@ -96,8 +96,8 @@ def test_wrapped_routes_use_the_throttled_views():
     from apps.forum_host import api_urls as host
 
     wrapped = {
-        "topic-create": throttled.TopicCreateView,
-        "reply-create": throttled.ReplyCreateView,
+        "topic-list": throttled.TopicListView,
+        "post-list": throttled.PostListView,
         "reaction-toggle": throttled.ReactionToggleView,
         "me-profile": throttled.MeProfileView,
         "search": throttled.SearchView,
@@ -125,7 +125,7 @@ def test_throttle_is_per_user_not_global():
     with freeze_time("2026-06-10 12:00:00"):
         client.force_authenticate(users[0])
         first = client.post(
-            f"/api/v1/forum/boards/{board.slug}/topics/create/",
+            f"/api/v1/forum/boards/{board.slug}/topics/",
             {
                 "title": "a",
                 "slug": "a",
@@ -134,7 +134,7 @@ def test_throttle_is_per_user_not_global():
             format="json",
         )
         blocked = client.post(
-            f"/api/v1/forum/boards/{board.slug}/topics/create/",
+            f"/api/v1/forum/boards/{board.slug}/topics/",
             {
                 "title": "b",
                 "slug": "b",
@@ -144,7 +144,7 @@ def test_throttle_is_per_user_not_global():
         )
         client.force_authenticate(users[1])  # a DIFFERENT user is not throttled
         other = client.post(
-            f"/api/v1/forum/boards/{board.slug}/topics/create/",
+            f"/api/v1/forum/boards/{board.slug}/topics/",
             {
                 "title": "c",
                 "slug": "c",

--- a/backend/apps/forum_host/tests/test_ratelimits.py
+++ b/backend/apps/forum_host/tests/test_ratelimits.py
@@ -98,6 +98,7 @@ def test_wrapped_routes_use_the_throttled_views():
     wrapped = {
         "topic-list": throttled.TopicListView,
         "post-list": throttled.PostListView,
+        "post-detail": throttled.PostWriteView,
         "reaction-toggle": throttled.ReactionToggleView,
         "me-profile": throttled.MeProfileView,
         "search": throttled.SearchView,
@@ -156,3 +157,53 @@ def test_throttle_is_per_user_not_global():
     assert first.status_code == 201
     assert blocked.status_code == 429
     assert other.status_code == 201
+
+
+@override_settings(FORUM_RATELIMITS={"post_update": "1/h"})
+@pytest.mark.django_db
+def test_post_update_is_throttled_per_user():
+    """The new PATCH handler is throttled by the host wrapper (post_update).
+    DELETE uses the identical @method_decorator mechanism on the same class."""
+    from wagtail_forum.blocks import ForumBodyBlock
+    from wagtail_forum.models import Post, Topic
+    from wagtail_forum.workflow import submit_for_moderation
+
+    ensure_default_workflow()
+    board = _board()
+    author = User.objects.create_user(username="ed", password="x")
+    p = ForumProfile.for_user(author)
+    p.trust_level = TrustLevel.MEMBER  # >= autopublish, so create+edit go live
+    p.save()
+
+    topic = Topic(board=board, title="t", slug="t", author=author, live=False)
+    topic.save()
+    op = Post(
+        topic=topic,
+        author=author,
+        is_opening_post=True,
+        body=ForumBodyBlock().to_python([{"type": "paragraph", "value": "<p>op</p>"}]),
+        live=False,
+    )
+    op.save()
+    submit_for_moderation(op, author)
+    reply = Post(
+        topic=topic,
+        author=author,
+        body=ForumBodyBlock().to_python([{"type": "paragraph", "value": "<p>r</p>"}]),
+        live=False,
+    )
+    reply.save()
+    submit_for_moderation(reply, author)
+
+    client = APIClient()
+    client.force_authenticate(author)
+    payload = {"body": [{"type": "paragraph", "value": "<p>e</p>"}]}
+    with freeze_time("2026-06-10 12:00:00"):
+        first = client.patch(f"/api/v1/forum/posts/{reply.id}/", payload, format="json")
+        blocked = client.patch(
+            f"/api/v1/forum/posts/{reply.id}/", payload, format="json"
+        )
+
+    assert first.status_code == 200
+    assert blocked.status_code == 429
+    assert "Retry-After" in blocked

--- a/backend/packages/wagtail_forum/wagtail_forum/api/serializers.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/api/serializers.py
@@ -231,6 +231,13 @@ class ReplyCreateSerializer(serializers.Serializer):
         return validate_forum_body(value)
 
 
+class PostEditSerializer(serializers.Serializer):
+    body = serializers.JSONField()
+
+    def validate_body(self, value):
+        return validate_forum_body(value)
+
+
 class ReactionSerializer(serializers.Serializer):
     type = serializers.ChoiceField(choices=Reaction.REACTION_CHOICES)
 

--- a/backend/packages/wagtail_forum/wagtail_forum/api/urls.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/api/urls.py
@@ -4,6 +4,7 @@ from .views import (
     BoardListView,
     MeProfileView,
     PostListView,
+    PostWriteView,
     ReactionToggleView,
     SearchView,
     SyncView,
@@ -18,6 +19,7 @@ urlpatterns = [
     path("boards/<slug:slug>/topics/", TopicListView.as_view(), name="topic-list"),
     path("topics/<int:topic_id>/", TopicDetailView.as_view(), name="topic-detail"),
     path("topics/<int:topic_id>/posts/", PostListView.as_view(), name="post-list"),
+    path("posts/<int:post_id>/", PostWriteView.as_view(), name="post-detail"),
     path(
         "posts/<int:post_id>/reactions/",
         ReactionToggleView.as_view(),

--- a/backend/packages/wagtail_forum/wagtail_forum/api/urls.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/api/urls.py
@@ -5,10 +5,8 @@ from .views import (
     MeProfileView,
     PostListView,
     ReactionToggleView,
-    ReplyCreateView,
     SearchView,
     SyncView,
-    TopicCreateView,
     TopicDetailView,
     TopicListView,
 )
@@ -18,22 +16,8 @@ app_name = "wagtail_forum_api"
 urlpatterns = [
     path("boards/", BoardListView.as_view(), name="board-list"),
     path("boards/<slug:slug>/topics/", TopicListView.as_view(), name="topic-list"),
-    path(
-        "boards/<slug:slug>/topics/create/",
-        TopicCreateView.as_view(),
-        name="topic-create",
-    ),
     path("topics/<int:topic_id>/", TopicDetailView.as_view(), name="topic-detail"),
-    path(
-        "topics/<int:topic_id>/posts/",
-        PostListView.as_view(),
-        name="post-list",
-    ),
-    path(
-        "topics/<int:topic_id>/posts/create/",
-        ReplyCreateView.as_view(),
-        name="reply-create",
-    ),
+    path("topics/<int:topic_id>/posts/", PostListView.as_view(), name="post-list"),
     path(
         "posts/<int:post_id>/reactions/",
         ReactionToggleView.as_view(),

--- a/backend/packages/wagtail_forum/wagtail_forum/api/views.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/api/views.py
@@ -117,6 +117,12 @@ class TopicListView(generics.ListAPIView):
     pagination_class = TopicCursorPagination
     versioning_class = None
 
+    def get_permissions(self):
+        # POST (create) needs auth; GET (list) stays public like the read path.
+        if self.request.method == "POST":
+            return [IsAuthenticated()]
+        return super().get_permissions()
+
     def get_queryset(self):
         board = _get_board(self.kwargs["slug"])
         return (
@@ -124,53 +130,6 @@ class TopicListView(generics.ListAPIView):
             .select_related("author", "last_post_author")
             .order_by("-last_post_at", "-id")
         )
-
-
-@extend_schema(
-    responses={200: TopicDetailSerializer, 404: dict},
-    description=(
-        "Retrieve a topic's detail. Returns 404 for a non-live topic or a "
-        "topic on a hidden/non-live board (no existence leak)."
-    ),
-)
-class TopicDetailView(generics.RetrieveAPIView):
-    serializer_class = TopicDetailSerializer
-    versioning_class = None
-    lookup_url_kwarg = "topic_id"
-
-    def get_queryset(self):
-        if getattr(self, "swagger_fake_view", False):
-            return Topic.objects.none()
-        return Topic.objects.filter(
-            live=True, board__in=_visible_boards()
-        ).select_related("board", "author", "last_post_author")
-
-
-@extend_schema(
-    responses={200: PostSerializer(many=True)},
-    description=(
-        "List a topic's live posts, oldest first (cursor-paginated). Returns "
-        "404 if the topic is non-live or on a hidden/non-live board."
-    ),
-)
-class PostListView(generics.ListAPIView):
-    serializer_class = PostSerializer
-    pagination_class = PostCursorPagination
-    versioning_class = None
-
-    def get_queryset(self):
-        if getattr(self, "swagger_fake_view", False):
-            return Post.objects.none()
-        topic = get_object_or_404(
-            Topic.objects.filter(live=True, board__in=_visible_boards()),
-            id=self.kwargs["topic_id"],
-        )
-        return topic.posts.filter(live=True).select_related("author")
-
-
-class TopicCreateView(APIView):
-    permission_classes = [IsAuthenticated]
-    versioning_class = None
 
     @extend_schema(
         request=TopicCreateSerializer,
@@ -259,9 +218,52 @@ class TopicCreateView(APIView):
         raise Conflict("Could not allocate a unique slug for this topic.")
 
 
-class ReplyCreateView(APIView):
-    permission_classes = [IsAuthenticated]
+@extend_schema(
+    responses={200: TopicDetailSerializer, 404: dict},
+    description=(
+        "Retrieve a topic's detail. Returns 404 for a non-live topic or a "
+        "topic on a hidden/non-live board (no existence leak)."
+    ),
+)
+class TopicDetailView(generics.RetrieveAPIView):
+    serializer_class = TopicDetailSerializer
     versioning_class = None
+    lookup_url_kwarg = "topic_id"
+
+    def get_queryset(self):
+        if getattr(self, "swagger_fake_view", False):
+            return Topic.objects.none()
+        return Topic.objects.filter(
+            live=True, board__in=_visible_boards()
+        ).select_related("board", "author", "last_post_author")
+
+
+@extend_schema(
+    responses={200: PostSerializer(many=True)},
+    description=(
+        "List a topic's live posts, oldest first (cursor-paginated). Returns "
+        "404 if the topic is non-live or on a hidden/non-live board."
+    ),
+)
+class PostListView(generics.ListAPIView):
+    serializer_class = PostSerializer
+    pagination_class = PostCursorPagination
+    versioning_class = None
+
+    def get_permissions(self):
+        # POST (reply) needs auth; GET (list) stays public like the read path.
+        if self.request.method == "POST":
+            return [IsAuthenticated()]
+        return super().get_permissions()
+
+    def get_queryset(self):
+        if getattr(self, "swagger_fake_view", False):
+            return Post.objects.none()
+        topic = get_object_or_404(
+            Topic.objects.filter(live=True, board__in=_visible_boards()),
+            id=self.kwargs["topic_id"],
+        )
+        return topic.posts.filter(live=True).select_related("author")
 
     @extend_schema(
         request=ReplyCreateSerializer,

--- a/backend/packages/wagtail_forum/wagtail_forum/api/views.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/api/views.py
@@ -7,7 +7,7 @@ from django.utils import timezone
 from django.utils.dateparse import parse_datetime
 from rest_framework import generics
 from rest_framework import status as http_status
-from rest_framework.exceptions import NotFound, ValidationError
+from rest_framework.exceptions import NotFound, PermissionDenied, ValidationError
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -26,13 +26,14 @@ except ImportError:  # pragma: no cover
 
 from ..blocks import ForumBodyBlock
 from ..models import ForumBoard, Post, Reaction, Topic
-from ..workflow import submit_for_moderation
+from ..workflow import submit_edit_for_moderation, submit_for_moderation
 from .exceptions import Conflict, UnprocessableEntity
 from .idempotency import fingerprint, idempotency_cache_key, remember, replay, reserve
 from .pagination import PostCursorPagination, TopicCursorPagination
 from .serializers import (
     BoardSerializer,
     MeProfileSerializer,
+    PostEditSerializer,
     PostSerializer,
     ReactionSerializer,
     ReplyCreateSerializer,
@@ -322,6 +323,83 @@ class PostListView(generics.ListAPIView):
         result = {"id": post.id, "status": moderation_status}
         remember(cache_key, result, http_status.HTTP_201_CREATED, payload_fp)
         return Response(result, status=http_status.HTTP_201_CREATED)
+
+
+class PostWriteView(APIView):
+    """Edit (PATCH) or soft-delete (DELETE) a single post. Author or moderator."""
+
+    permission_classes = [IsAuthenticated]
+    versioning_class = None
+
+    def _get_editable(self, request, post_id):
+        # Hide non-live posts / posts on non-live topics / hidden boards (404),
+        # never 403 — no existence leak (mirrors ReplyCreateView, audit M6/M7).
+        post = get_object_or_404(
+            Post.objects.select_related("topic", "author"), id=post_id
+        )
+        if (
+            not post.live
+            or not post.topic.live
+            or not _visible_boards().filter(pk=post.topic.board_id).exists()
+        ):
+            raise NotFound()
+        # Trust the author OR a moderator (the change_post perm). can_edit/
+        # can_delete in PostSerializer compute the same predicate for the client.
+        if not (
+            request.user == post.author
+            or request.user.has_perm("wagtail_forum.change_post")
+        ):
+            raise PermissionDenied()
+        return post
+
+    @extend_schema(
+        request=PostEditSerializer,
+        responses={200: PostSerializer, 400: dict, 403: dict, 404: dict, 409: dict},
+        description=(
+            "Edit a post (author or moderator). Re-screened by author trust: a "
+            "trusted edit publishes immediately; an untrusted edit awaits "
+            "moderation while the last-approved body keeps serving. Response is "
+            "the post plus moderation_status (published|pending). 409 if the "
+            "topic is closed/locked."
+        ),
+    )
+    def patch(self, request, post_id):
+        post = self._get_editable(request, post_id)
+        if post.topic.is_closed or post.topic.locked:
+            raise Conflict("Topic is closed to edits.")
+        serializer = PostEditSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        post.body = ForumBodyBlock().to_python(serializer.validated_data["body"])
+        try:
+            moderation_status = submit_edit_for_moderation(post, request.user)
+        except Exception:
+            logger.exception(
+                "[ERROR] submit_edit_for_moderation failed for post %s", post.pk
+            )
+            moderation_status = "pending"
+        post.refresh_from_db()
+        data = PostSerializer(post, context={"request": request}).data
+        data["moderation_status"] = moderation_status
+        return Response(data)
+
+    @extend_schema(
+        responses={204: None, 403: dict, 404: dict, 409: dict},
+        description=(
+            "Soft-delete a post (author or moderator) by unpublishing it; the "
+            "topic's reply_count recounts via the unpublish signal. Deleting an "
+            "opening post returns 409 (delete the topic instead)."
+        ),
+    )
+    def delete(self, request, post_id):
+        post = self._get_editable(request, post_id)
+        if post.is_opening_post:
+            raise Conflict("Cannot delete the opening post; delete the topic.")
+        # unpublish() fires Wagtail's `unpublished` signal -> the forum's counter
+        # receivers recount reply_count/last_post_at/board/profile. Do NOT recount
+        # by hand (that double-processes). user=None: forum authors are not
+        # Wagtail editors, matching submit_for_moderation's publish(user=None).
+        post.unpublish(user=None)
+        return Response(status=http_status.HTTP_204_NO_CONTENT)
 
 
 class ReactionToggleView(APIView):

--- a/backend/packages/wagtail_forum/wagtail_forum/tests/api/test_post_edit_delete.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/tests/api/test_post_edit_delete.py
@@ -1,0 +1,199 @@
+"""PostWriteView: edit (PATCH) + soft-delete (DELETE). Spec 2 Q1/Q2/Q3."""
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Permission
+from rest_framework.test import APIClient
+from wagtail.models import Page
+from wagtail_forum.blocks import ForumBodyBlock
+from wagtail_forum.models import (
+    ForumBoard,
+    ForumIndex,
+    ForumProfile,
+    Post,
+    Topic,
+    TrustLevel,
+)
+from wagtail_forum.workflow import ensure_default_workflow, submit_for_moderation
+
+User = get_user_model()
+pytestmark = [pytest.mark.django_db, pytest.mark.urls("wagtail_forum.tests.api.urls")]
+
+
+def _board():
+    root = Page.objects.get(id=1)
+    index = root.add_child(instance=ForumIndex(title="Forum", slug="forum"))
+    return index.add_child(instance=ForumBoard(title="General", slug="general"))
+
+
+def _member(username):
+    u = User.objects.create_user(username=username, password="x")
+    p = ForumProfile.for_user(u)
+    p.trust_level = TrustLevel.MEMBER  # >= autopublish, so create+edit go live
+    p.save()
+    return u
+
+
+def _moderator(username):
+    u = User.objects.create_user(username=username, password="x")
+    ForumProfile.for_user(u)
+    perm = Permission.objects.get(
+        content_type__app_label="wagtail_forum", codename="change_post"
+    )
+    u.user_permissions.add(perm)
+    return User.objects.get(pk=u.pk)  # re-fetch to clear the permission cache
+
+
+def _body(html):
+    return ForumBodyBlock().to_python([{"type": "paragraph", "value": html}])
+
+
+def _topic_with_reply(board, author, reply_html="<p>a reply</p>"):
+    ensure_default_workflow()
+    topic = Topic(board=board, title="t", slug="t", author=author, live=False)
+    topic.save()
+    opening = Post(
+        topic=topic,
+        author=author,
+        is_opening_post=True,
+        body=_body("<p>op</p>"),
+        live=False,
+    )
+    opening.save()
+    submit_for_moderation(opening, author)
+    reply = Post(topic=topic, author=author, body=_body(reply_html), live=False)
+    reply.save()
+    submit_for_moderation(reply, author)
+    topic.refresh_from_db()
+    return topic, opening, reply
+
+
+def test_author_edit_publishes_new_body():
+    board = _board()
+    author = _member("ada")
+    _topic, _opening, reply = _topic_with_reply(board, author)
+    client = APIClient()
+    client.force_authenticate(author)
+    resp = client.patch(
+        f"/forum/posts/{reply.id}/",
+        {"body": [{"type": "paragraph", "value": "<p>edited</p>"}]},
+        format="json",
+    )
+    assert resp.status_code == 200
+    assert resp.data["moderation_status"] == "published"
+    assert any("edited" in b["value"] for b in resp.data["body"])
+    assert resp.data["edited_at"] is not None
+
+
+def test_non_author_cannot_edit():
+    board = _board()
+    author = _member("ada")
+    intruder = _member("eve")
+    _topic, _opening, reply = _topic_with_reply(board, author)
+    client = APIClient()
+    client.force_authenticate(intruder)
+    resp = client.patch(
+        f"/forum/posts/{reply.id}/",
+        {"body": [{"type": "paragraph", "value": "<p>hax</p>"}]},
+        format="json",
+    )
+    assert resp.status_code == 403
+
+
+def test_moderator_can_edit_and_delete_others_post():
+    board = _board()
+    author = _member("ada")
+    _topic, _opening, reply = _topic_with_reply(board, author)
+    mod = _moderator("mod")
+    client = APIClient()
+    client.force_authenticate(mod)
+    edit = client.patch(
+        f"/forum/posts/{reply.id}/",
+        {"body": [{"type": "paragraph", "value": "<p>mod edit</p>"}]},
+        format="json",
+    )
+    assert edit.status_code == 200
+    delete = client.delete(f"/forum/posts/{reply.id}/")
+    assert delete.status_code == 204
+    assert Post.objects.get(id=reply.id).live is False
+
+
+def test_edit_on_closed_topic_conflicts():
+    board = _board()
+    author = _member("ada")
+    topic, _opening, reply = _topic_with_reply(board, author)
+    Topic.objects.filter(id=topic.id).update(is_closed=True)
+    client = APIClient()
+    client.force_authenticate(author)
+    resp = client.patch(
+        f"/forum/posts/{reply.id}/",
+        {"body": [{"type": "paragraph", "value": "<p>edited</p>"}]},
+        format="json",
+    )
+    assert resp.status_code == 409
+
+
+def test_edit_malformed_body_is_400_not_500():
+    board = _board()
+    author = _member("ada")
+    _topic, _opening, reply = _topic_with_reply(board, author)
+    client = APIClient()
+    client.force_authenticate(author)
+    resp = client.patch(
+        f"/forum/posts/{reply.id}/", {"body": "not-a-list"}, format="json"
+    )
+    assert resp.status_code == 400
+
+
+def test_author_delete_soft_deletes_and_recounts():
+    board = _board()
+    author = _member("ada")
+    topic, _opening, reply = _topic_with_reply(board, author)
+    assert topic.reply_count == 1
+    client = APIClient()
+    client.force_authenticate(author)
+    resp = client.delete(f"/forum/posts/{reply.id}/")
+    assert resp.status_code == 204
+    assert Post.objects.get(id=reply.id).live is False
+    topic.refresh_from_db()
+    assert topic.reply_count == 0  # signal-maintained recount, not manual
+
+
+def test_delete_opening_post_conflicts():
+    board = _board()
+    author = _member("ada")
+    _topic, opening, _reply = _topic_with_reply(board, author)
+    client = APIClient()
+    client.force_authenticate(author)
+    resp = client.delete(f"/forum/posts/{opening.id}/")
+    assert resp.status_code == 409
+    assert Post.objects.get(id=opening.id).live is True
+
+
+def test_edit_hidden_post_is_404():
+    board = _board()
+    author = _member("ada")
+    _topic, _opening, reply = _topic_with_reply(board, author)
+    Post.objects.filter(id=reply.id).update(live=False)  # now hidden
+    client = APIClient()
+    client.force_authenticate(author)
+    resp = client.patch(
+        f"/forum/posts/{reply.id}/",
+        {"body": [{"type": "paragraph", "value": "<p>x</p>"}]},
+        format="json",
+    )
+    assert resp.status_code == 404
+
+
+def test_delete_on_hidden_board_is_404():
+    # The board-visibility guard in _get_editable is a security check (no writes
+    # on a restricted/non-live board) — exercise that branch specifically.
+    board = _board()
+    author = _member("ada")
+    _topic, _opening, reply = _topic_with_reply(board, author)
+    ForumBoard.objects.filter(id=board.id).update(live=False)  # board now hidden
+    client = APIClient()
+    client.force_authenticate(author)
+    resp = client.delete(f"/forum/posts/{reply.id}/")
+    assert resp.status_code == 404
+    assert Post.objects.get(id=reply.id).live is True  # not deleted

--- a/backend/packages/wagtail_forum/wagtail_forum/tests/api/test_replies_reactions.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/tests/api/test_replies_reactions.py
@@ -44,7 +44,7 @@ def test_reply_blocked_on_closed_topic():
     client = APIClient()
     client.force_authenticate(user)
     resp = client.post(
-        f"/forum/topics/{topic.id}/posts/create/",
+        f"/forum/topics/{topic.id}/posts/",
         {"body": [{"type": "paragraph", "value": "<p>hi</p>"}]},
         format="json",
     )
@@ -65,7 +65,7 @@ def test_reply_to_non_live_topic_returns_404():
     client = APIClient()
     client.force_authenticate(user)
     resp = client.post(
-        f"/forum/topics/{draft.id}/posts/create/",
+        f"/forum/topics/{draft.id}/posts/",
         {"body": [{"type": "paragraph", "value": "<p>hi</p>"}]},
         format="json",
     )
@@ -83,7 +83,7 @@ def test_reply_dangerous_body_is_sanitized():
     client = APIClient()
     client.force_authenticate(user)
     resp = client.post(
-        f"/forum/topics/{topic.id}/posts/create/",
+        f"/forum/topics/{topic.id}/posts/",
         {
             "body": [
                 {
@@ -166,7 +166,7 @@ def test_reaction_on_non_live_topic_post_returns_404():
 def _reply(client, topic, key=None):
     headers = {"HTTP_IDEMPOTENCY_KEY": key} if key else {}
     return client.post(
-        f"/forum/topics/{topic.id}/posts/create/",
+        f"/forum/topics/{topic.id}/posts/",
         {"body": [{"type": "paragraph", "value": "<p>hi</p>"}]},
         format="json",
         **headers,
@@ -200,7 +200,7 @@ def test_idempotency_key_reuse_with_different_payload_is_422():
 
     assert _reply(client, topic, key="k1").status_code == 201
     r2 = client.post(
-        f"/forum/topics/{topic.id}/posts/create/",
+        f"/forum/topics/{topic.id}/posts/",
         {"body": [{"type": "paragraph", "value": "<p>DIFFERENT</p>"}]},
         format="json",
         HTTP_IDEMPOTENCY_KEY="k1",
@@ -287,7 +287,7 @@ def test_reply_blocked_on_locked_topic():
     client = APIClient()
     client.force_authenticate(user)
     resp = client.post(
-        f"/forum/topics/{topic.id}/posts/create/",
+        f"/forum/topics/{topic.id}/posts/",
         {"body": [{"type": "paragraph", "value": "<p>hi</p>"}]},
         format="json",
     )

--- a/backend/packages/wagtail_forum/wagtail_forum/tests/api/test_topic_create.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/tests/api/test_topic_create.py
@@ -58,10 +58,10 @@ def test_trusted_user_creates_published_topic_idempotently():
     headers = {"HTTP_IDEMPOTENCY_KEY": "abc-123"}
 
     r1 = client.post(
-        f"/forum/boards/{board.slug}/topics/create/", payload, format="json", **headers
+        f"/forum/boards/{board.slug}/topics/", payload, format="json", **headers
     )
     r2 = client.post(
-        f"/forum/boards/{board.slug}/topics/create/", payload, format="json", **headers
+        f"/forum/boards/{board.slug}/topics/", payload, format="json", **headers
     )
 
     assert r1.status_code == 201
@@ -86,7 +86,7 @@ def test_api_topic_create_publishes_topic_and_updates_board_counters():
     client = APIClient()
     client.force_authenticate(user)
     r = client.post(
-        f"/forum/boards/{board.slug}/topics/create/",
+        f"/forum/boards/{board.slug}/topics/",
         {
             "title": "Hello",
             "slug": "hello",
@@ -115,7 +115,7 @@ def test_spam_in_topic_title_is_screened():
     client = APIClient()
     client.force_authenticate(user)
     r = client.post(
-        f"/forum/boards/{board.slug}/topics/create/",
+        f"/forum/boards/{board.slug}/topics/",
         {
             "title": "Best casino deals",
             "slug": "casino-deals",
@@ -148,13 +148,13 @@ def test_duplicate_slug_is_auto_suffixed():
     }
 
     r1 = client.post(
-        f"/forum/boards/{board.slug}/topics/create/",
+        f"/forum/boards/{board.slug}/topics/",
         payload,
         format="json",
         HTTP_IDEMPOTENCY_KEY="k1",
     )
     r2 = client.post(
-        f"/forum/boards/{board.slug}/topics/create/",
+        f"/forum/boards/{board.slug}/topics/",
         payload,
         format="json",
         HTTP_IDEMPOTENCY_KEY="k2",
@@ -186,9 +186,7 @@ def test_spam_backend_exception_leaves_pending_not_500():
         "body": [{"type": "paragraph", "value": "<p>hello there friend</p>"}],
     }
 
-    resp = client.post(
-        f"/forum/boards/{board.slug}/topics/create/", payload, format="json"
-    )
+    resp = client.post(f"/forum/boards/{board.slug}/topics/", payload, format="json")
 
     assert resp.status_code == 201
     assert resp.data["status"] == "pending"
@@ -217,13 +215,13 @@ def test_spam_backend_crash_replays_pending_on_retry():
     }
 
     r1 = client.post(
-        f"/forum/boards/{board.slug}/topics/create/",
+        f"/forum/boards/{board.slug}/topics/",
         payload,
         format="json",
         HTTP_IDEMPOTENCY_KEY="key1",
     )
     r2 = client.post(
-        f"/forum/boards/{board.slug}/topics/create/",
+        f"/forum/boards/{board.slug}/topics/",
         payload,
         format="json",
         HTTP_IDEMPOTENCY_KEY="key1",
@@ -260,9 +258,7 @@ def test_dangerous_body_is_sanitized_on_write():
             }
         ],
     }
-    resp = client.post(
-        f"/forum/boards/{board.slug}/topics/create/", payload, format="json"
-    )
+    resp = client.post(f"/forum/boards/{board.slug}/topics/", payload, format="json")
     assert resp.status_code == 201
     source = (
         Post.objects.get(topic__slug="t", is_opening_post=True).body[0].value.source
@@ -292,9 +288,7 @@ def test_safe_link_is_preserved():
             }
         ],
     }
-    resp = client.post(
-        f"/forum/boards/{board.slug}/topics/create/", payload, format="json"
-    )
+    resp = client.post(f"/forum/boards/{board.slug}/topics/", payload, format="json")
     assert resp.status_code == 201
     source = (
         Post.objects.get(topic__slug="t2", is_opening_post=True).body[0].value.source
@@ -316,9 +310,7 @@ def test_oversized_body_is_rejected():
         "slug": "t",
         "body": [{"type": "paragraph", "value": "<p>x</p>"}] * (MAX_BODY_BLOCKS + 1),
     }
-    resp = client.post(
-        f"/forum/boards/{board.slug}/topics/create/", payload, format="json"
-    )
+    resp = client.post(f"/forum/boards/{board.slug}/topics/", payload, format="json")
     assert resp.status_code == 400
     # Flat field error — body maps to a list of strings, not the double-nested
     # {"body": {"body": [...]}} shape (M14). The project envelope nests field
@@ -336,11 +328,11 @@ def test_unauthenticated_writes_are_rejected():
     client = APIClient()  # no credentials
 
     create = client.post(
-        f"/forum/boards/{board.slug}/topics/create/",
+        f"/forum/boards/{board.slug}/topics/",
         {"title": "x", "slug": "x", "body": []},
         format="json",
     )
-    reply = client.post("/forum/topics/1/posts/create/", {"body": []}, format="json")
+    reply = client.post("/forum/topics/1/posts/", {"body": []}, format="json")
     react = client.post("/forum/posts/1/reactions/", {"type": "like"}, format="json")
 
     assert create.status_code == 401
@@ -367,12 +359,8 @@ def test_slug_suffix_never_exceeds_max_length():
         "body": [{"type": "paragraph", "value": "<p>hi</p>"}],
     }
 
-    r1 = client.post(
-        f"/forum/boards/{board.slug}/topics/create/", payload, format="json"
-    )
-    r2 = client.post(
-        f"/forum/boards/{board.slug}/topics/create/", payload, format="json"
-    )
+    r1 = client.post(f"/forum/boards/{board.slug}/topics/", payload, format="json")
+    r2 = client.post(f"/forum/boards/{board.slug}/topics/", payload, format="json")
 
     assert r1.status_code == r2.status_code == 201
     assert len(r2.data["slug"]) <= 255

--- a/backend/packages/wagtail_forum/wagtail_forum/tests/api/test_visibility.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/tests/api/test_visibility.py
@@ -81,7 +81,7 @@ def test_unpublished_board_takedown_is_effective():
     client.force_authenticate(user)
 
     reply = client.post(
-        f"/forum/topics/{topic.id}/posts/create/",
+        f"/forum/topics/{topic.id}/posts/",
         {"body": [{"type": "paragraph", "value": "<p>hi</p>"}]},
         format="json",
     )

--- a/backend/packages/wagtail_forum/wagtail_forum/tests/workflow/test_edit_moderation.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/tests/workflow/test_edit_moderation.py
@@ -1,0 +1,94 @@
+"""submit_edit_for_moderation: re-screen an edit without unpublishing live
+content (Spec 2 Q2). Mirrors the PR-2a spike, now against the real helper."""
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.test import override_settings
+from wagtail.models import Page
+from wagtail_forum.blocks import ForumBodyBlock
+from wagtail_forum.models import (
+    ForumBoard,
+    ForumIndex,
+    ForumProfile,
+    Post,
+    Topic,
+    TrustLevel,
+)
+from wagtail_forum.workflow import (
+    ensure_default_workflow,
+    submit_edit_for_moderation,
+    submit_for_moderation,
+)
+
+User = get_user_model()
+pytestmark = pytest.mark.django_db
+
+
+def _board():
+    root = Page.objects.get(id=1)
+    index = root.add_child(instance=ForumIndex(title="Forum", slug="forum"))
+    return index.add_child(instance=ForumBoard(title="General", slug="general"))
+
+
+def _author(username, trust):
+    u = User.objects.create_user(username=username, password="x")
+    p = ForumProfile.for_user(u)
+    p.trust_level = trust
+    p.save()
+    return u
+
+
+def _body(html):
+    return ForumBodyBlock().to_python([{"type": "paragraph", "value": html}])
+
+
+def _live_post(board, author, html="<p>original</p>", slug="t"):
+    topic = Topic(board=board, title="t", slug=slug, author=author, live=False)
+    topic.save()
+    post = Post(
+        topic=topic, author=author, is_opening_post=True, body=_body(html), live=False
+    )
+    post.save()
+    submit_for_moderation(post, author)
+    post.refresh_from_db()
+    return post
+
+
+def test_trusted_edit_publishes_immediately():
+    ensure_default_workflow()
+    author = _author("trusted", TrustLevel.MEMBER)
+    post = _live_post(_board(), author)
+    post.body = _body("<p>edited by trusted</p>")
+    status = submit_edit_for_moderation(post, author)
+    fresh = Post.objects.get(pk=post.pk)
+    assert status == "published"
+    assert fresh.live and "edited by trusted" in fresh.body[0].value.source
+    assert fresh.edited is True
+
+
+def test_untrusted_flagged_edit_keeps_old_body_live():
+    ensure_default_workflow()
+    author = _author("newbie", TrustLevel.NEW)
+    post = _live_post(_board(), author, "<p>original clean</p>")
+    post.body = _body("<p>spamzzz buy now</p>")
+    with override_settings(WAGTAILFORUM_SPAM_BANNED_WORDS=["spamzzz"]):
+        status = submit_edit_for_moderation(post, author)
+    fresh = Post.objects.get(pk=post.pk)
+    assert status == "pending"
+    assert fresh.live, "post stays live during a pending edit"
+    assert "original clean" in fresh.body[0].value.source, "OLD body keeps serving"
+    assert "spamzzz" not in fresh.body[0].value.source
+    assert fresh.edited is False
+    assert fresh.has_unpublished_changes is True
+
+
+def test_untrusted_clean_edit_auto_publishes():
+    ensure_default_workflow()
+    author = _author("newbie2", TrustLevel.NEW)
+    post = _live_post(_board(), author, "<p>original2</p>")
+    post.body = _body("<p>clean edit here</p>")
+    status = submit_edit_for_moderation(post, author)
+    fresh = Post.objects.get(pk=post.pk)
+    assert status == "published"
+    assert fresh.live and "clean edit here" in fresh.body[0].value.source
+    assert fresh.edited is True

--- a/backend/packages/wagtail_forum/wagtail_forum/workflow.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/workflow.py
@@ -81,3 +81,41 @@ def submit_for_moderation(obj, user):
     status = "published" if obj.live else "pending"
     notify(moderation_decided, sender=type(obj), obj=obj, status=status)
     return status
+
+
+def submit_edit_for_moderation(obj, user):
+    """Re-screen an EDITED post WITHOUT unpublishing live content (Spec 2 Q2).
+
+    The caller has already set obj.body to the new, validated StreamField value.
+    Unlike submit_for_moderation (create-shaped: force-drafts live=False then
+    publishes), an edit must never take approved content dark:
+
+    - Trusted author (trust >= TRUST_AUTOPUBLISH_LEVEL): publish the new revision
+      immediately.
+    - Untrusted author: save a new revision and start the moderation workflow on
+      it. Clean content auto-approves -> publishes; flagged content is rejected
+      and the revision stays pending while the live row keeps its last-approved
+      body. live is NEVER forced False; obj.save() is NEVER called with the new
+      body (that would publish it unscreened).
+
+    `edited` is set in memory and captured in the revision, so publish() writes
+    it back atomically with the new body — it flips to True iff the edit goes
+    live. Trust derives from obj.author (the content's owner), never the caller.
+
+    Returns 'published' (the edit is now live) or 'pending' (awaiting moderation).
+    """
+    obj.edited = True  # captured in the revision; published atomically with body
+    profile = ForumProfile.for_user(obj.author)
+    revision = obj.save_revision(user=user)
+    if profile.trust_level >= get_setting("TRUST_AUTOPUBLISH_LEVEL"):
+        revision.publish(user=None)
+    else:
+        workflow = obj.get_workflow()
+        if workflow is not None:
+            # Clean -> auto-approve -> publish; flagged -> rejected, stays pending.
+            workflow.start(obj, None)
+        # Fail closed: no workflow -> the edit stays a pending revision.
+    obj.refresh_from_db()
+    # has_unpublished_changes is True after save_revision and cleared by publish();
+    # it is the single signal of whether the edit reached the live row.
+    return "pending" if obj.has_unpublished_changes else "published"

--- a/docs/superpowers/plans/2026-06-23-forum-spec2-pr2a-backend-write.md
+++ b/docs/superpowers/plans/2026-06-23-forum-spec2-pr2a-backend-write.md
@@ -1,0 +1,998 @@
+# Forum Spec 2 — PR-2a: Backend Write Path Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land the forum write API — REST-rationalized create routes, post edit (PATCH) and post delete (DELETE), and an edit-moderation helper that re-screens edits without ever unpublishing live content — entirely within the backend, with the host route-parity and rate-limit tests green. No web client changes (that is PR-2b).
+
+**Architecture:** Three changes inside the reusable `wagtail_forum` package plus their host throttle wrappers. (1) Collapse the two `…/create/` POST routes into REST `POST` on the existing collection paths by merging each create view into its sibling list view (one view class per path, GET=list + POST=create); the host throttles only the `post` handler via `@method_decorator(..., name="post")`, exactly as today's wrappers throttle an inherited handler. (2) Add `submit_edit_for_moderation(post, user)` to `workflow.py` — it captures `edited=True` in a new revision and routes by **author** trust, but never forces `live=False`, so an untrusted author's flagged edit waits as a pending revision while the last-approved body keeps serving. (3) Add `PostWriteView` at `posts/<id>/` with `patch` (edit) + `delete` (soft-delete = `unpublish()`), each host-throttled on its own method. Denormalized counters (`reply_count`, `last_post_at`, board/profile counts) are maintained by the existing `published`/`unpublished` signal receivers — the views call `publish()`/`unpublish()` and never recount by hand.
+
+**Tech Stack:** Django 6 / DRF, drf-spectacular, Wagtail 6 (DraftState/Revision/Workflow mixins), pytest + `pytest-django`, real Postgres (CI) / SQLite (backend-checks). nh3 sanitizer (unchanged).
+
+## Global Constraints
+
+- **No plant imports in the package core** — `wagtail_forum` is zero-plant-coupling; a reusability test runs against a minimal settings module. Add nothing that imports from `apps/`. (The edit helper lives in the package `workflow.py`; throttling lives only in the host `apps/forum_host/`.)
+- **`versioning_class = None` on every forum view** — omitting it is a silent 404 under the host's `NamespaceVersioning`. The new `PostWriteView` must set it; the merged list/create views already have it.
+- **Route-parity is a hard gate** — after every route add/rename, `apps/forum_host/tests/test_ratelimits.py::test_host_api_routes_match_package` (the `{(pattern, name)}` set) **and** `::test_wrapped_routes_use_the_throttled_views` (the route-name → throttled-class dict) must both be green. Update package `urls.py` and host `api_urls.py` in lockstep.
+- **Trust derives from `post.author`, never the caller** — same security stance as `submit_for_moderation` (a privileged caller must not launder an untrusted author's content through their own trust).
+- **Never `post.save()` the new body on the untrusted edit path** — only `save_revision()`. Any `.save()` writing `body` to the live row publishes the edit unscreened. The helper captures `edited` in the revision so no separate `.save()` is ever needed. (Validated by the spike, 2026-06-23.)
+- **Optional schema import** — reuse the existing `extend_schema` try/except shim at `views.py:16-24`; do not add a hard `drf_spectacular` import.
+- **No DB mocks** — real Postgres + real Wagtail revision/workflow machinery (CLAUDE.md testing rules).
+- **Test invocation** — package API tests set `pytestmark = pytest.mark.urls("wagtail_forum.tests.api.urls")` and hit `APIClient().get("/forum/…")`; host tests run against the real project urlconf at `/api/v1/forum/…`. Run from `backend/` with the venv: `cd /Users/williamtower/projects/plant_id_community/backend && source venv/bin/activate`.
+
+---
+
+## Epic roadmap (context — NOT part of this PR)
+
+Todo 231 (forum Spec 2) closes across these PRs; PR-1 has landed (merged as PR #394).
+
+- **PR-1 (done):** AC1 read-view `@extend_schema` + AC3 compound sync cursor. Backend-only, no route changes.
+- **PR-2a (this plan):** backend write path — route rationalization + `PostWriteView` (PATCH/DELETE) + `submit_edit_for_moderation`. No web changes; images still rejected by `validate_forum_body`.
+- **PR-2b (web):** migrate `forumService.ts` write fns (`createThread`/`createPost`/`updatePost`/`deletePost`) onto the new REST routes with `body:[…]` payloads; adapt `toggleReaction` to the `{reaction_counts, reacted}` shape; **delete** `fetchReactions` (`ReactionToggleView` has no `GET`); drive edit/delete affordances off `can_edit`/`can_delete`; composer emits `[{type:'paragraph', value:'<p>…</p>'}]`; re-enable compose/edit/delete/react UI; rewrite tests, delete machina-shape tests. `createThread` must send the board **slug** + a client-slugified topic **slug** (`TopicCreateSerializer` requires a `SlugField`; the backend auto-suffixes dupes). After PR-2b lands, AC2 flips (web off machina forum paths).
+- **PR-3 (images):** `PostImageUploadView` + relax `validate_forum_body` to accept in-collection `image` blocks (IDOR-safe) + web `StreamFieldRenderer` `image` case. Todo 231 archives only after PR-3.
+
+AC4 (route-parity green with the final URL surface) is satisfied continuously — every PR keeps the parity test green.
+
+### Spike result that grounds this plan (2026-06-23)
+
+A throwaway pytest exercised the proposed edit helper on real Postgres + Wagtail. All four assertions passed:
+
+1. **Trusted edit** → new body live immediately, `edited=True`.
+2. **Untrusted flagged edit** → OLD body keeps serving, flagged body never goes live, `edited` stays `False`, `has_unpublished_changes is True` (a pending revision exists).
+3. **Untrusted clean edit** → `SpamCheckTask` auto-approves → publishes → new body, `edited=True`.
+4. **HTML round-trip** → `bold/italic/external-link/inline-code/ul-li` survive `validate_forum_body` (nh3) → `to_python` → `serialize_forum_body` (`expand_db_html`).
+
+The helper code below is exactly what the spike validated.
+
+---
+
+## File Structure
+
+| File | Responsibility | PR-2a change |
+|------|----------------|--------------|
+| `backend/packages/wagtail_forum/wagtail_forum/workflow.py` | Moderation routing | **Add** `submit_edit_for_moderation(post, user)` |
+| `backend/packages/wagtail_forum/wagtail_forum/api/views.py` | DRF views | Merge `TopicCreateView`→`TopicListView.post`, `ReplyCreateView`→`PostListView.post`; **add** `PostWriteView` (patch/delete) |
+| `backend/packages/wagtail_forum/wagtail_forum/api/serializers.py` | Serializers | **Add** `PostEditSerializer` (body-only, `validate_forum_body`) |
+| `backend/packages/wagtail_forum/wagtail_forum/api/urls.py` | Package routes | Drop `…/create/` routes; **add** `posts/<id>/` (`post-detail`) |
+| `backend/apps/forum_host/api.py` | Throttle wrappers | Wrap merged `TopicListView`/`PostListView` (`post`) + new `PostWriteView` (`patch`/`delete`); drop `TopicCreateView`/`ReplyCreateView` wrappers |
+| `backend/apps/forum_host/api_urls.py` | Host mount | Mirror package routes; import merged list views + `PostWriteView` from `.api` |
+| `backend/apps/forum_host/constants.py` | Rate limits | **Add** `post_update`, `post_delete` |
+| `backend/packages/wagtail_forum/wagtail_forum/tests/api/test_post_edit_delete.py` | **New** — edit/delete API tests | Author/mod/closed/malformed/opening-post-409/recount/visibility |
+| `backend/packages/wagtail_forum/wagtail_forum/tests/workflow/test_edit_moderation.py` | **New** — helper unit tests | The four spike assertions, against the real helper |
+| `test_topic_create.py`, `test_replies_reactions.py`, `test_visibility.py` | Existing create tests | Mechanical `…/create/` → `…/` URL swap |
+| `apps/forum_host/tests/test_ratelimits.py` | Host throttle/parity tests | `…/create/` → `…/`; update wrapped-class dict |
+
+---
+
+## Task 1: `submit_edit_for_moderation` helper + unit tests
+
+**Files:**
+
+- Modify: `backend/packages/wagtail_forum/wagtail_forum/workflow.py`
+- Test: `backend/packages/wagtail_forum/wagtail_forum/tests/workflow/test_edit_moderation.py` (new; create the `tests/workflow/` package with an empty `__init__.py`)
+
+**Interfaces:**
+
+- Consumes: `ForumProfile.for_user`, `get_setting("TRUST_AUTOPUBLISH_LEVEL")`, Wagtail `save_revision`/`revision.publish`/`get_workflow`/`workflow.start` (all already used by `submit_for_moderation`).
+- Produces: `submit_edit_for_moderation(post, user) -> "published" | "pending"`. Caller sets `post.body` to the new (validated) StreamField value **before** calling; the helper sets `edited`, snapshots a revision, and publishes-or-queues. After it returns, `post` is `refresh_from_db()`-fresh.
+
+- [ ] **Step 1: Create the test package + write the failing tests**
+
+Create `backend/packages/wagtail_forum/wagtail_forum/tests/workflow/__init__.py` (empty) and `backend/packages/wagtail_forum/wagtail_forum/tests/workflow/test_edit_moderation.py`:
+
+```python
+"""submit_edit_for_moderation: re-screen an edit without unpublishing live
+content (Spec 2 Q2). Mirrors the PR-2a spike, now against the real helper."""
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.test import override_settings
+from wagtail.models import Page
+from wagtail_forum.blocks import ForumBodyBlock
+from wagtail_forum.models import (
+    ForumBoard,
+    ForumIndex,
+    ForumProfile,
+    Post,
+    Topic,
+    TrustLevel,
+)
+from wagtail_forum.workflow import (
+    ensure_default_workflow,
+    submit_edit_for_moderation,
+    submit_for_moderation,
+)
+
+User = get_user_model()
+pytestmark = pytest.mark.django_db
+
+
+def _board():
+    root = Page.objects.get(id=1)
+    index = root.add_child(instance=ForumIndex(title="Forum", slug="forum"))
+    return index.add_child(instance=ForumBoard(title="General", slug="general"))
+
+
+def _author(username, trust):
+    u = User.objects.create_user(username=username, password="x")
+    p = ForumProfile.for_user(u)
+    p.trust_level = trust
+    p.save()
+    return u
+
+
+def _body(html):
+    return ForumBodyBlock().to_python([{"type": "paragraph", "value": html}])
+
+
+def _live_post(board, author, html="<p>original</p>", slug="t"):
+    topic = Topic(board=board, title="t", slug=slug, author=author, live=False)
+    topic.save()
+    post = Post(
+        topic=topic, author=author, is_opening_post=True, body=_body(html), live=False
+    )
+    post.save()
+    submit_for_moderation(post, author)
+    post.refresh_from_db()
+    return post
+
+
+def test_trusted_edit_publishes_immediately():
+    ensure_default_workflow()
+    author = _author("trusted", TrustLevel.MEMBER)
+    post = _live_post(_board(), author)
+    post.body = _body("<p>edited by trusted</p>")
+    status = submit_edit_for_moderation(post, author)
+    fresh = Post.objects.get(pk=post.pk)
+    assert status == "published"
+    assert fresh.live and "edited by trusted" in fresh.body[0].value.source
+    assert fresh.edited is True
+
+
+def test_untrusted_flagged_edit_keeps_old_body_live():
+    ensure_default_workflow()
+    author = _author("newbie", TrustLevel.NEW)
+    post = _live_post(_board(), author, "<p>original clean</p>")
+    post.body = _body("<p>spamzzz buy now</p>")
+    with override_settings(WAGTAILFORUM_SPAM_BANNED_WORDS=["spamzzz"]):
+        status = submit_edit_for_moderation(post, author)
+    fresh = Post.objects.get(pk=post.pk)
+    assert status == "pending"
+    assert fresh.live, "post stays live during a pending edit"
+    assert "original clean" in fresh.body[0].value.source, "OLD body keeps serving"
+    assert "spamzzz" not in fresh.body[0].value.source
+    assert fresh.edited is False
+    assert fresh.has_unpublished_changes is True
+
+
+def test_untrusted_clean_edit_auto_publishes():
+    ensure_default_workflow()
+    author = _author("newbie2", TrustLevel.NEW)
+    post = _live_post(_board(), author, "<p>original2</p>")
+    post.body = _body("<p>clean edit here</p>")
+    status = submit_edit_for_moderation(post, author)
+    fresh = Post.objects.get(pk=post.pk)
+    assert status == "published"
+    assert fresh.live and "clean edit here" in fresh.body[0].value.source
+    assert fresh.edited is True
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd /Users/williamtower/projects/plant_id_community/backend && source venv/bin/activate && python -m pytest packages/wagtail_forum/wagtail_forum/tests/workflow/test_edit_moderation.py -v`
+Expected: FAIL — `ImportError: cannot import name 'submit_edit_for_moderation'`.
+
+- [ ] **Step 3: Implement the helper**
+
+In `backend/packages/wagtail_forum/wagtail_forum/workflow.py`, append after `submit_for_moderation`:
+
+```python
+def submit_edit_for_moderation(obj, user):
+    """Re-screen an EDITED post WITHOUT unpublishing live content (Spec 2 Q2).
+
+    The caller has already set obj.body to the new, validated StreamField value.
+    Unlike submit_for_moderation (create-shaped: force-drafts live=False then
+    publishes), an edit must never take approved content dark:
+
+    - Trusted author (trust >= TRUST_AUTOPUBLISH_LEVEL): publish the new revision
+      immediately.
+    - Untrusted author: save a new revision and start the moderation workflow on
+      it. Clean content auto-approves -> publishes; flagged content is rejected
+      and the revision stays pending while the live row keeps its last-approved
+      body. live is NEVER forced False; obj.save() is NEVER called with the new
+      body (that would publish it unscreened).
+
+    `edited` is set in memory and captured in the revision, so publish() writes
+    it back atomically with the new body — it flips to True iff the edit goes
+    live. Trust derives from obj.author (the content's owner), never the caller.
+
+    Returns 'published' (the edit is now live) or 'pending' (awaiting moderation).
+    """
+    obj.edited = True  # captured in the revision; published atomically with body
+    profile = ForumProfile.for_user(obj.author)
+    revision = obj.save_revision(user=user)
+    if profile.trust_level >= get_setting("TRUST_AUTOPUBLISH_LEVEL"):
+        revision.publish(user=None)
+    else:
+        workflow = obj.get_workflow()
+        if workflow is not None:
+            # Clean -> auto-approve -> publish; flagged -> rejected, stays pending.
+            workflow.start(obj, None)
+        # Fail closed: no workflow -> the edit stays a pending revision.
+    obj.refresh_from_db()
+    # has_unpublished_changes is True after save_revision and cleared by publish();
+    # it is the single signal of whether the edit reached the live row.
+    return "pending" if obj.has_unpublished_changes else "published"
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd /Users/williamtower/projects/plant_id_community/backend && source venv/bin/activate && python -m pytest packages/wagtail_forum/wagtail_forum/tests/workflow/test_edit_moderation.py -v`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/packages/wagtail_forum/wagtail_forum/workflow.py \
+        backend/packages/wagtail_forum/wagtail_forum/tests/workflow/
+git commit -m "231(PR-2a): add submit_edit_for_moderation (re-screen edits, never unpublish live)"
+```
+
+---
+
+## Task 2: Route rationalization — merge create routes into REST POST
+
+**Files:**
+
+- Modify: `backend/packages/wagtail_forum/wagtail_forum/api/views.py` (merge `TopicCreateView`→`TopicListView`, `ReplyCreateView`→`PostListView`)
+- Modify: `backend/packages/wagtail_forum/wagtail_forum/api/urls.py`
+- Modify: `backend/apps/forum_host/api.py`, `backend/apps/forum_host/api_urls.py`
+- Modify: `backend/packages/wagtail_forum/wagtail_forum/tests/api/test_topic_create.py`, `test_replies_reactions.py`, `test_visibility.py`
+- Modify: `backend/apps/forum_host/tests/test_ratelimits.py`
+
+**Interfaces:**
+
+- Produces: `POST /boards/<slug>/topics/` (create topic) and `POST /topics/<id>/posts/` (reply) replace the `…/create/` paths. GET on both paths is unchanged (list). Route names stay `topic-list` / `post-list`; names `topic-create` / `reply-create` are removed.
+
+- [ ] **Step 1: Update the package create tests to the new URLs (these become the failing tests)**
+
+These are mechanical, deterministic URL swaps. Run from the repo root:
+
+```bash
+cd /Users/williamtower/projects/plant_id_community
+sed -i '' 's#/topics/create/#/topics/#g; s#/posts/create/#/posts/#g' \
+  backend/packages/wagtail_forum/wagtail_forum/tests/api/test_topic_create.py \
+  backend/packages/wagtail_forum/wagtail_forum/tests/api/test_replies_reactions.py \
+  backend/packages/wagtail_forum/wagtail_forum/tests/api/test_visibility.py
+```
+
+Verify nothing else changed (the `idempotency_cache_key(..., "topic-create")` namespace strings in `views.py` are untouched — they have no leading slash and were not in the sed scope):
+
+```bash
+grep -rn "create/" backend/packages/wagtail_forum/wagtail_forum/tests/api/ ; echo "exit: $?"
+```
+
+Expected: no matches in the three files (exit 1 from grep = none found is success here).
+
+- [ ] **Step 2: Run the affected suites to verify they now fail**
+
+Run: `cd /Users/williamtower/projects/plant_id_community/backend && source venv/bin/activate && python -m pytest packages/wagtail_forum/wagtail_forum/tests/api/test_topic_create.py packages/wagtail_forum/wagtail_forum/tests/api/test_replies_reactions.py -q`
+Expected: FAIL — POSTs to `/forum/boards/<slug>/topics/` and `/forum/topics/<id>/posts/` 405 (the merged `post` handler does not exist yet; GET-only views reject POST).
+
+- [ ] **Step 3: Merge the create logic into the list views**
+
+In `backend/packages/wagtail_forum/wagtail_forum/api/views.py`:
+
+(a) Replace the `TopicListView` class (currently L115-126) with a GET-list + POST-create view. Move `TopicCreateView`'s `post` and `_create_topic` onto it verbatim, and add `get_permissions` so only POST requires auth:
+
+```python
+class TopicListView(generics.ListAPIView):
+    serializer_class = TopicListSerializer
+    pagination_class = TopicCursorPagination
+    versioning_class = None
+
+    def get_permissions(self):
+        # POST (create) needs auth; GET (list) stays public like the read path.
+        if self.request.method == "POST":
+            return [IsAuthenticated()]
+        return super().get_permissions()
+
+    def get_queryset(self):
+        board = _get_board(self.kwargs["slug"])
+        return (
+            Topic.objects.filter(board=board, live=True)
+            .select_related("author", "last_post_author")
+            .order_by("-last_post_at", "-id")
+        )
+
+    @extend_schema(
+        request=TopicCreateSerializer,
+        responses={201: dict, 409: dict, 422: dict},
+        description=(
+            "Create a topic (with its opening post) and route it through "
+            "moderation. Supports an Idempotency-Key header: a retry with the "
+            "same key replays the original response (original status code); "
+            "reuse with a different payload returns 422. A taken slug is "
+            "auto-suffixed (-2, -3, …) — read the final slug from the response."
+        ),
+    )
+    def post(self, request, slug):
+        cache_key = idempotency_cache_key(request, "topic-create")
+        payload_fp = (
+            fingerprint({"slug": slug, "body": request.data}) if cache_key else None
+        )
+        replayed = _replay_or_none(cache_key, payload_fp)
+        if replayed is not None:
+            return replayed
+
+        serializer = TopicCreateSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        board = _get_board(slug)
+
+        reserve(cache_key)
+        topic, opening = self._create_topic(request, board, serializer.validated_data)
+
+        try:
+            status = submit_for_moderation(opening, request.user)
+        except Exception:
+            logger.exception(
+                "[ERROR] submit_for_moderation failed for post %s; left as draft",
+                opening.pk,
+            )
+            status = "pending"
+
+        result = {"id": topic.id, "slug": topic.slug, "status": status}
+        remember(cache_key, result, http_status.HTTP_201_CREATED, payload_fp)
+        return Response(result, status=http_status.HTTP_201_CREATED)
+
+    @staticmethod
+    def _create_topic(request, board, validated):
+        """Create the draft topic + opening post atomically (born live=False).
+
+        A taken slug is auto-suffixed instead of 409ing: the unique constraint
+        also covers DRAFT topics, so a conflict response would leak a hidden
+        draft's existence (audit L4). Each attempt runs in its own transaction
+        so an IntegrityError can't poison an outer atomic block.
+        """
+        base_slug = validated["slug"]
+        for attempt in range(MAX_SLUG_ATTEMPTS):
+            if attempt == 0:
+                slug_try = base_slug
+            else:
+                suffix = f"-{attempt + 1}"
+                slug_try = f"{base_slug[:255 - len(suffix)]}{suffix}"
+            try:
+                with transaction.atomic():
+                    topic = Topic(
+                        board=board,
+                        title=validated["title"],
+                        slug=slug_try,
+                        author=request.user,
+                        live=False,
+                    )
+                    topic.save()
+                    opening = Post(
+                        topic=topic,
+                        author=request.user,
+                        is_opening_post=True,
+                        body=ForumBodyBlock().to_python(validated["body"]),
+                        live=False,
+                    )
+                    opening.save()
+                return topic, opening
+            except IntegrityError:
+                continue
+        raise Conflict("Could not allocate a unique slug for this topic.")
+```
+
+(b) Delete the now-redundant standalone `TopicCreateView` class (currently L171-259).
+
+(c) Add a `post` to `PostListView` (the AC1-annotated read view, currently L149-168). Keep the existing class-level `@extend_schema` (it documents the GET 200) and add a method-level `@extend_schema` on `post` (drf-spectacular applies the method-level one to POST). Add `get_permissions`, and move `ReplyCreateView.post`'s body onto it:
+
+```python
+@extend_schema(
+    responses={200: PostSerializer(many=True)},
+    description=(
+        "List a topic's live posts, oldest first (cursor-paginated). Returns "
+        "404 if the topic is non-live or on a hidden/non-live board."
+    ),
+)
+class PostListView(generics.ListAPIView):
+    serializer_class = PostSerializer
+    pagination_class = PostCursorPagination
+    versioning_class = None
+
+    def get_permissions(self):
+        if self.request.method == "POST":
+            return [IsAuthenticated()]
+        return super().get_permissions()
+
+    def get_queryset(self):
+        if getattr(self, "swagger_fake_view", False):
+            return Post.objects.none()
+        topic = get_object_or_404(
+            Topic.objects.filter(live=True, board__in=_visible_boards()),
+            id=self.kwargs["topic_id"],
+        )
+        return topic.posts.filter(live=True).select_related("author")
+
+    @extend_schema(
+        request=ReplyCreateSerializer,
+        responses={201: dict, 404: dict, 409: dict, 422: dict},
+        description=(
+            "Reply to a topic; the reply routes through moderation. Supports "
+            "an Idempotency-Key header (a mobile retry must not create a "
+            "duplicate reply)."
+        ),
+    )
+    def post(self, request, topic_id):
+        cache_key = idempotency_cache_key(request, "reply-create")
+        payload_fp = (
+            fingerprint({"topic": topic_id, "body": request.data})
+            if cache_key
+            else None
+        )
+        replayed = _replay_or_none(cache_key, payload_fp)
+        if replayed is not None:
+            return replayed
+
+        topic = get_object_or_404(
+            Topic.objects.filter(live=True, board__in=_visible_boards()),
+            id=topic_id,
+        )
+        if topic.is_closed or topic.locked:
+            raise Conflict("Topic is closed to replies.")
+        serializer = ReplyCreateSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        reserve(cache_key)
+        post = Post(
+            topic=topic,
+            author=request.user,
+            is_opening_post=False,
+            body=ForumBodyBlock().to_python(serializer.validated_data["body"]),
+            live=False,
+        )
+        post.save()
+
+        try:
+            moderation_status = submit_for_moderation(post, request.user)
+        except Exception:
+            logger.exception(
+                "[ERROR] submit_for_moderation failed for reply %s; left as draft",
+                post.pk,
+            )
+            moderation_status = "pending"
+
+        result = {"id": post.id, "status": moderation_status}
+        remember(cache_key, result, http_status.HTTP_201_CREATED, payload_fp)
+        return Response(result, status=http_status.HTTP_201_CREATED)
+```
+
+(d) Delete the now-redundant standalone `ReplyCreateView` class (currently L262-322).
+
+- [ ] **Step 4: Update the package URLconf**
+
+In `backend/packages/wagtail_forum/wagtail_forum/api/urls.py`, drop `TopicCreateView`/`ReplyCreateView` from the import and remove the two `…/create/` `path()` entries (the `topic-list` / `post-list` routes already exist and now serve POST too). Resulting `urlpatterns`:
+
+```python
+from django.urls import path
+
+from .views import (
+    BoardListView,
+    MeProfileView,
+    PostListView,
+    ReactionToggleView,
+    SearchView,
+    SyncView,
+    TopicDetailView,
+    TopicListView,
+)
+
+app_name = "wagtail_forum_api"
+
+urlpatterns = [
+    path("boards/", BoardListView.as_view(), name="board-list"),
+    path("boards/<slug:slug>/topics/", TopicListView.as_view(), name="topic-list"),
+    path("topics/<int:topic_id>/", TopicDetailView.as_view(), name="topic-detail"),
+    path("topics/<int:topic_id>/posts/", PostListView.as_view(), name="post-list"),
+    path(
+        "posts/<int:post_id>/reactions/",
+        ReactionToggleView.as_view(),
+        name="reaction-toggle",
+    ),
+    path("me/profile/", MeProfileView.as_view(), name="me-profile"),
+    path("search/", SearchView.as_view(), name="search"),
+    path("sync/", SyncView.as_view(), name="sync"),
+]
+```
+
+- [ ] **Step 5: Update the host throttle wrappers + mount**
+
+In `backend/apps/forum_host/api.py`, replace the `TopicCreateView`/`ReplyCreateView` wrappers with wrappers around the merged list views (throttle only `post`):
+
+```python
+@method_decorator(
+    ratelimit(key="user", rate=_rate("topic_create"), method="POST"), name="post"
+)
+class TopicListView(forum_views.TopicListView):
+    pass
+
+
+@method_decorator(
+    ratelimit(key="user", rate=_rate("reply_create"), method="POST"), name="post"
+)
+class PostListView(forum_views.PostListView):
+    pass
+```
+
+Leave `ReactionToggleView`, `MeProfileView`, `SearchView`, `SyncView` wrappers unchanged. In `backend/apps/forum_host/api_urls.py`, import the GET-only views (`BoardListView`, `TopicDetailView`) from the package and the throttled `TopicListView`/`PostListView` (+ the rest) from `.api`; mirror the package routes exactly:
+
+```python
+from django.urls import path
+from wagtail_forum.api.views import BoardListView, TopicDetailView
+
+from .api import (
+    MeProfileView,
+    PostListView,
+    ReactionToggleView,
+    SearchView,
+    SyncView,
+    TopicListView,
+)
+
+app_name = "wagtail_forum_api"
+
+urlpatterns = [
+    path("boards/", BoardListView.as_view(), name="board-list"),
+    path("boards/<slug:slug>/topics/", TopicListView.as_view(), name="topic-list"),
+    path("topics/<int:topic_id>/", TopicDetailView.as_view(), name="topic-detail"),
+    path("topics/<int:topic_id>/posts/", PostListView.as_view(), name="post-list"),
+    path(
+        "posts/<int:post_id>/reactions/",
+        ReactionToggleView.as_view(),
+        name="reaction-toggle",
+    ),
+    path("me/profile/", MeProfileView.as_view(), name="me-profile"),
+    path("search/", SearchView.as_view(), name="search"),
+    path("sync/", SyncView.as_view(), name="sync"),
+]
+```
+
+- [ ] **Step 6: Update the host rate-limit/parity tests**
+
+In `backend/apps/forum_host/tests/test_ratelimits.py`:
+
+- Swap the four `…/boards/{board.slug}/topics/create/` POST URLs to `…/boards/{board.slug}/topics/` (in `test_topic_create_is_throttled_per_user` and `test_throttle_is_per_user_not_global`).
+- In `test_wrapped_routes_use_the_throttled_views`, replace the `wrapped` dict with the new route-name → throttled-class map:
+
+```python
+    wrapped = {
+        "topic-list": throttled.TopicListView,
+        "post-list": throttled.PostListView,
+        "reaction-toggle": throttled.ReactionToggleView,
+        "me-profile": throttled.MeProfileView,
+        "search": throttled.SearchView,
+        "sync": throttled.SyncView,
+    }
+```
+
+(`board-list` and `topic-detail` stay GET-only/unthrottled package views — correctly absent.)
+
+- [ ] **Step 7: Run the merged-route suites + host parity/throttle tests**
+
+Run: `cd /Users/williamtower/projects/plant_id_community/backend && source venv/bin/activate && python -m pytest packages/wagtail_forum/wagtail_forum/tests/api/test_topic_create.py packages/wagtail_forum/wagtail_forum/tests/api/test_replies_reactions.py packages/wagtail_forum/wagtail_forum/tests/api/test_topics_list.py packages/wagtail_forum/wagtail_forum/tests/api/test_post_list.py packages/wagtail_forum/wagtail_forum/tests/api/test_visibility.py apps/forum_host/tests/test_ratelimits.py -q`
+Expected: PASS (create via REST POST works; GET list still works; parity + throttle green).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add backend/packages/wagtail_forum/wagtail_forum/api/views.py \
+        backend/packages/wagtail_forum/wagtail_forum/api/urls.py \
+        backend/apps/forum_host/api.py backend/apps/forum_host/api_urls.py \
+        backend/packages/wagtail_forum/wagtail_forum/tests/api/test_topic_create.py \
+        backend/packages/wagtail_forum/wagtail_forum/tests/api/test_replies_reactions.py \
+        backend/packages/wagtail_forum/wagtail_forum/tests/api/test_visibility.py \
+        backend/apps/forum_host/tests/test_ratelimits.py
+git commit -m "231(PR-2a): rationalize create routes to REST POST on collection paths"
+```
+
+---
+
+## Task 3: `PostWriteView` — edit (PATCH) + delete (DELETE)
+
+**Files:**
+
+- Modify: `backend/packages/wagtail_forum/wagtail_forum/api/views.py` (add `PostWriteView`, import `PermissionDenied` + `submit_edit_for_moderation` + `PostEditSerializer`)
+- Modify: `backend/packages/wagtail_forum/wagtail_forum/api/serializers.py` (add `PostEditSerializer`)
+- Modify: `backend/packages/wagtail_forum/wagtail_forum/api/urls.py` (add `posts/<id>/`)
+- Modify: `backend/apps/forum_host/api.py`, `api_urls.py`, `constants.py`
+- Modify: `backend/apps/forum_host/tests/test_ratelimits.py` (add `post-detail` to wrapped dict)
+- Test: `backend/packages/wagtail_forum/wagtail_forum/tests/api/test_post_edit_delete.py` (new)
+
+**Interfaces:**
+
+- Consumes: `submit_edit_for_moderation` (Task 1); `PostSerializer` (read shape, already imported).
+- Produces: `PATCH /posts/<id>/` → `200` `PostSerializer` body **plus** a top-level `moderation_status: published|pending`; `DELETE /posts/<id>/` → `204`. Both: `404` hidden/missing, `403` non-author-non-mod, `409` closed/locked (PATCH) or opening-post (DELETE), `400` malformed body (PATCH). Route name `post-detail`; host rates `post_update` (PATCH) + `post_delete` (DELETE).
+
+- [ ] **Step 1: Write the failing API tests**
+
+Create `backend/packages/wagtail_forum/wagtail_forum/tests/api/test_post_edit_delete.py`:
+
+```python
+"""PostWriteView: edit (PATCH) + soft-delete (DELETE). Spec 2 Q1/Q2/Q3."""
+
+import pytest
+from django.contrib.auth import get_user_model
+from rest_framework.test import APIClient
+from wagtail.models import Page
+from wagtail_forum.blocks import ForumBodyBlock
+from wagtail_forum.models import (
+    ForumBoard,
+    ForumIndex,
+    ForumProfile,
+    Post,
+    Topic,
+    TrustLevel,
+)
+from wagtail_forum.workflow import ensure_default_workflow, submit_for_moderation
+
+User = get_user_model()
+pytestmark = [pytest.mark.django_db, pytest.mark.urls("wagtail_forum.tests.api.urls")]
+
+
+def _board():
+    root = Page.objects.get(id=1)
+    index = root.add_child(instance=ForumIndex(title="Forum", slug="forum"))
+    return index.add_child(instance=ForumBoard(title="General", slug="general"))
+
+
+def _member(username):
+    u = User.objects.create_user(username=username, password="x")
+    p = ForumProfile.for_user(u)
+    p.trust_level = TrustLevel.MEMBER  # >= autopublish, so create+edit go live
+    p.save()
+    return u
+
+
+def _body(html):
+    return ForumBodyBlock().to_python([{"type": "paragraph", "value": html}])
+
+
+def _topic_with_reply(board, author, reply_html="<p>a reply</p>"):
+    ensure_default_workflow()
+    topic = Topic(board=board, title="t", slug="t", author=author, live=False)
+    topic.save()
+    opening = Post(
+        topic=topic, author=author, is_opening_post=True, body=_body("<p>op</p>"),
+        live=False,
+    )
+    opening.save()
+    submit_for_moderation(opening, author)
+    reply = Post(topic=topic, author=author, body=_body(reply_html), live=False)
+    reply.save()
+    submit_for_moderation(reply, author)
+    topic.refresh_from_db()
+    return topic, opening, reply
+
+
+def test_author_edit_publishes_new_body():
+    board = _board()
+    author = _member("ada")
+    _topic, _opening, reply = _topic_with_reply(board, author)
+    client = APIClient()
+    client.force_authenticate(author)
+    resp = client.patch(
+        f"/forum/posts/{reply.id}/",
+        {"body": [{"type": "paragraph", "value": "<p>edited</p>"}]},
+        format="json",
+    )
+    assert resp.status_code == 200
+    assert resp.data["moderation_status"] == "published"
+    assert any("edited" in b["value"] for b in resp.data["body"])
+    assert resp.data["edited_at"] is not None
+
+
+def test_non_author_cannot_edit():
+    board = _board()
+    author = _member("ada")
+    intruder = _member("eve")
+    _topic, _opening, reply = _topic_with_reply(board, author)
+    client = APIClient()
+    client.force_authenticate(intruder)
+    resp = client.patch(
+        f"/forum/posts/{reply.id}/",
+        {"body": [{"type": "paragraph", "value": "<p>hax</p>"}]},
+        format="json",
+    )
+    assert resp.status_code == 403
+
+
+def test_edit_on_closed_topic_conflicts():
+    board = _board()
+    author = _member("ada")
+    topic, _opening, reply = _topic_with_reply(board, author)
+    Topic.objects.filter(id=topic.id).update(is_closed=True)
+    client = APIClient()
+    client.force_authenticate(author)
+    resp = client.patch(
+        f"/forum/posts/{reply.id}/",
+        {"body": [{"type": "paragraph", "value": "<p>edited</p>"}]},
+        format="json",
+    )
+    assert resp.status_code == 409
+
+
+def test_edit_malformed_body_is_400_not_500():
+    board = _board()
+    author = _member("ada")
+    _topic, _opening, reply = _topic_with_reply(board, author)
+    client = APIClient()
+    client.force_authenticate(author)
+    resp = client.patch(
+        f"/forum/posts/{reply.id}/", {"body": "not-a-list"}, format="json"
+    )
+    assert resp.status_code == 400
+
+
+def test_author_delete_soft_deletes_and_recounts():
+    board = _board()
+    author = _member("ada")
+    topic, _opening, reply = _topic_with_reply(board, author)
+    assert topic.reply_count == 1
+    client = APIClient()
+    client.force_authenticate(author)
+    resp = client.delete(f"/forum/posts/{reply.id}/")
+    assert resp.status_code == 204
+    assert Post.objects.get(id=reply.id).live is False
+    topic.refresh_from_db()
+    assert topic.reply_count == 0  # signal-maintained recount, not manual
+
+
+def test_delete_opening_post_conflicts():
+    board = _board()
+    author = _member("ada")
+    _topic, opening, _reply = _topic_with_reply(board, author)
+    client = APIClient()
+    client.force_authenticate(author)
+    resp = client.delete(f"/forum/posts/{opening.id}/")
+    assert resp.status_code == 409
+    assert Post.objects.get(id=opening.id).live is True
+
+
+def test_edit_hidden_post_is_404():
+    board = _board()
+    author = _member("ada")
+    _topic, _opening, reply = _topic_with_reply(board, author)
+    Post.objects.filter(id=reply.id).update(live=False)  # now hidden
+    client = APIClient()
+    client.force_authenticate(author)
+    resp = client.patch(
+        f"/forum/posts/{reply.id}/",
+        {"body": [{"type": "paragraph", "value": "<p>x</p>"}]},
+        format="json",
+    )
+    assert resp.status_code == 404
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd /Users/williamtower/projects/plant_id_community/backend && source venv/bin/activate && python -m pytest packages/wagtail_forum/wagtail_forum/tests/api/test_post_edit_delete.py -q`
+Expected: FAIL — `404` for every PATCH/DELETE (`posts/<id>/` route does not exist yet).
+
+- [ ] **Step 3: Add `PostEditSerializer`**
+
+In `backend/packages/wagtail_forum/wagtail_forum/api/serializers.py`, after `ReplyCreateSerializer`:
+
+```python
+class PostEditSerializer(serializers.Serializer):
+    body = serializers.JSONField()
+
+    def validate_body(self, value):
+        return validate_forum_body(value)
+```
+
+- [ ] **Step 4: Add `PostWriteView` and its imports**
+
+In `backend/packages/wagtail_forum/wagtail_forum/api/views.py`:
+
+Add to the DRF exceptions import (currently `from rest_framework.exceptions import NotFound, ValidationError`):
+
+```python
+from rest_framework.exceptions import NotFound, PermissionDenied, ValidationError
+```
+
+Add to the workflow import (currently `from ..workflow import submit_for_moderation`):
+
+```python
+from ..workflow import submit_edit_for_moderation, submit_for_moderation
+```
+
+Add `PostEditSerializer` to the serializers import block.
+
+Add the view (place it after `PostListView`):
+
+```python
+class PostWriteView(APIView):
+    """Edit (PATCH) or soft-delete (DELETE) a single post. Author or moderator."""
+
+    permission_classes = [IsAuthenticated]
+    versioning_class = None
+
+    def _get_editable(self, request, post_id):
+        # Hide non-live posts / posts on non-live topics / hidden boards (404),
+        # never 403 — no existence leak (mirrors ReplyCreateView, audit M6/M7).
+        post = get_object_or_404(
+            Post.objects.select_related("topic", "author"), id=post_id
+        )
+        if (
+            not post.live
+            or not post.topic.live
+            or not _visible_boards().filter(pk=post.topic.board_id).exists()
+        ):
+            raise NotFound()
+        # Trust the author OR a moderator (the change_post perm). can_edit/
+        # can_delete in PostSerializer compute the same predicate for the client.
+        if not (
+            request.user == post.author
+            or request.user.has_perm("wagtail_forum.change_post")
+        ):
+            raise PermissionDenied()
+        return post
+
+    @extend_schema(
+        request=PostEditSerializer,
+        responses={200: PostSerializer, 400: dict, 403: dict, 404: dict, 409: dict},
+        description=(
+            "Edit a post (author or moderator). Re-screened by author trust: a "
+            "trusted edit publishes immediately; an untrusted edit awaits "
+            "moderation while the last-approved body keeps serving. Response is "
+            "the post plus moderation_status (published|pending). 409 if the "
+            "topic is closed/locked."
+        ),
+    )
+    def patch(self, request, post_id):
+        post = self._get_editable(request, post_id)
+        if post.topic.is_closed or post.topic.locked:
+            raise Conflict("Topic is closed to edits.")
+        serializer = PostEditSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        post.body = ForumBodyBlock().to_python(serializer.validated_data["body"])
+        try:
+            moderation_status = submit_edit_for_moderation(post, request.user)
+        except Exception:
+            logger.exception(
+                "[ERROR] submit_edit_for_moderation failed for post %s", post.pk
+            )
+            moderation_status = "pending"
+        post.refresh_from_db()
+        data = PostSerializer(post, context={"request": request}).data
+        data["moderation_status"] = moderation_status
+        return Response(data)
+
+    @extend_schema(
+        responses={204: None, 403: dict, 404: dict, 409: dict},
+        description=(
+            "Soft-delete a post (author or moderator) by unpublishing it; the "
+            "topic's reply_count recounts via the unpublish signal. Deleting an "
+            "opening post returns 409 (delete the topic instead)."
+        ),
+    )
+    def delete(self, request, post_id):
+        post = self._get_editable(request, post_id)
+        if post.is_opening_post:
+            raise Conflict("Cannot delete the opening post; delete the topic.")
+        # unpublish() fires Wagtail's `unpublished` signal -> the forum's counter
+        # receivers recount reply_count/last_post_at/board/profile. Do NOT recount
+        # by hand (that double-processes). user=None: forum authors are not
+        # Wagtail editors, matching submit_for_moderation's publish(user=None).
+        post.unpublish(user=None)
+        return Response(status=http_status.HTTP_204_NO_CONTENT)
+```
+
+> **Verify during Step 6:** `post.unpublish(user=None)` must fire the `unpublished` signal and drop `reply_count` (the `test_author_delete_soft_deletes_and_recounts` assertion). If a Wagtail version quirk requires a real user, switch to `user=request.user`; the test is the gate.
+
+- [ ] **Step 5: Add the route + host wrapper + rate limits**
+
+Package `urls.py` — add to the import and `urlpatterns` (place after the `post-list` route):
+
+```python
+    path("posts/<int:post_id>/", PostWriteView.as_view(), name="post-detail"),
+```
+
+(add `PostWriteView` to the `from .views import (...)` block).
+
+Host `constants.py` — add two keys to `DEFAULT_FORUM_RATELIMITS`:
+
+```python
+    "post_update": "30/h",
+    "post_delete": "20/h",
+```
+
+Host `api.py` — add the wrapper (two throttled methods on one class):
+
+```python
+@method_decorator(
+    ratelimit(key="user", rate=_rate("post_update"), method="PATCH"), name="patch"
+)
+@method_decorator(
+    ratelimit(key="user", rate=_rate("post_delete"), method="DELETE"), name="delete"
+)
+class PostWriteView(forum_views.PostWriteView):
+    pass
+```
+
+Host `api_urls.py` — import `PostWriteView` from `.api` and add the mirrored route:
+
+```python
+    path("posts/<int:post_id>/", PostWriteView.as_view(), name="post-detail"),
+```
+
+Host `tests/test_ratelimits.py` — add to the `wrapped` dict in `test_wrapped_routes_use_the_throttled_views`:
+
+```python
+        "post-detail": throttled.PostWriteView,
+```
+
+- [ ] **Step 6: Run the edit/delete suite + host parity**
+
+Run: `cd /Users/williamtower/projects/plant_id_community/backend && source venv/bin/activate && python -m pytest packages/wagtail_forum/wagtail_forum/tests/api/test_post_edit_delete.py apps/forum_host/tests/test_ratelimits.py -v`
+Expected: PASS (all edit/delete cases + route parity + wrapped-class pin).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/packages/wagtail_forum/wagtail_forum/api/views.py \
+        backend/packages/wagtail_forum/wagtail_forum/api/serializers.py \
+        backend/packages/wagtail_forum/wagtail_forum/api/urls.py \
+        backend/apps/forum_host/api.py backend/apps/forum_host/api_urls.py \
+        backend/apps/forum_host/constants.py \
+        backend/apps/forum_host/tests/test_ratelimits.py \
+        backend/packages/wagtail_forum/wagtail_forum/tests/api/test_post_edit_delete.py
+git commit -m "231(PR-2a): add PostWriteView (PATCH edit re-moderates, DELETE soft-deletes)"
+```
+
+---
+
+## Task 4: Full-suite gate + schema + work-log
+
+**Files:** `todos/231-in_progress-p1-forum-spec2-read-api-web-client.md` (work log only).
+
+- [ ] **Step 1: Run the whole forum package + host suite**
+
+Run: `cd /Users/williamtower/projects/plant_id_community/backend && source venv/bin/activate && python -m pytest packages/wagtail_forum/ apps/forum_host/ -q`
+Expected: all pass (PR-1 baseline 116 + Task 1's 3 + Task 3's 7 new ≈ 126; no regressions).
+
+- [ ] **Step 2: Confirm the OpenAPI schema still generates (CI backend-checks gate)**
+
+Run: `cd /Users/williamtower/projects/plant_id_community/backend && source venv/bin/activate && python manage.py spectacular --file /tmp/schema.yml 2>&1 | tail -8`
+Expected: exits 0. No **new error** mentioning `TopicListView`, `PostListView`, or `PostWriteView` (pre-existing warnings from todo 238 are acceptable). Confirm `/forum/posts/{post_id}/` appears with `patch` + `delete` operations:
+
+```bash
+grep -A2 "/forum/posts/{post_id}/:" /tmp/schema.yml | head -5
+```
+
+- [ ] **Step 3: Confirm the package zero-coupling test still passes**
+
+Run: `cd /Users/williamtower/projects/plant_id_community/backend && source venv/bin/activate && python -m pytest packages/wagtail_forum/wagtail_forum/tests/test_smoke.py -q`
+Expected: PASS (no `apps.*` import added to the package core).
+
+- [ ] **Step 4: Update the todo 231 work log**
+
+Append a `### 2026-06-23 - PR-2a (backend write path) landed` entry to `todos/231-in_progress-p1-forum-spec2-read-api-web-client.md`: route rationalization done, `PostWriteView` (PATCH/DELETE) + `submit_edit_for_moderation` landed, Q1/Q2/Q3 enforced, parity/rate-limit/schema green. Note PR-2b (web) + PR-3 (images) remain; the todo stays `in_progress` (archives only after PR-3). Do **not** flip AC2/AC4 yet.
+
+- [ ] **Step 5: Commit the work-log update**
+
+```bash
+git add todos/231-in_progress-p1-forum-spec2-read-api-web-client.md
+git commit -m "231: log PR-2a backend write path"
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:** route rationalization (Phase 2 "Route rationalization") → Task 2; `PostUpdateView`/`PostDeleteView` (Phase 2 table) → Task 3; resolved Q1 (opening-post delete → 409) → `test_delete_opening_post_conflicts`; Q2 (edit re-moderation, never unpublish; dedicated edit helper) → Task 1 + `submit_edit_for_moderation`; Q3 (delete = unpublish, no new field, recount) → Task 3 delete + `test_author_delete_soft_deletes_and_recounts`. Images (Phase 3) and all web/composer work (Phase 1/2 client) are explicitly out of PR-2a (Epic roadmap). The TipTap→StreamField round-trip de-risk was completed as a spike (result recorded above); the composer itself is PR-2b.
+- **Placeholder scan:** none — every code step shows full code; every run step shows the command + expected result. The one runtime uncertainty (`unpublish(user=None)` firing the recount) is gated by an explicit test, with the fallback named.
+- **Type consistency:** `submit_edit_for_moderation(post, user) -> str` defined in Task 1 is imported and called in Task 3; `PostEditSerializer` defined in Task 3 Step 3 is imported in Step 4; `post-detail` route name added in Task 3 Step 5 is asserted in the same step's `wrapped` dict update; the merged `post` handlers (Task 2) are what the host `name="post"` decorators target (Task 2 Step 5).
+- **Parity invariant:** Task 2 and Task 3 each end with `test_ratelimits.py` green; package `urls.py` and host `api_urls.py` are edited together in both tasks.
+- **No migration:** Q3 adds no field; `edited` already exists. Confirmed — nothing in this PR runs `makemigrations`.

--- a/todos/231-in_progress-p1-forum-spec2-read-api-web-client.md
+++ b/todos/231-in_progress-p1-forum-spec2-read-api-web-client.md
@@ -167,3 +167,49 @@ before its first use) — re-added after the usage existed.
 
 **Still open (do NOT close):** AC2 (web off machina) + AC4 final URL surface need
 PR-2 (write path) and PR-3 (images). Todo archives only after PR-3.
+
+### 2026-06-23 - PR-2a (backend write path) landed — todo still OPEN
+
+Branch `feat/forum-spec2-pr2a-backend-write`; plan
+`docs/superpowers/plans/2026-06-23-forum-spec2-pr2a-backend-write.md`. PR-2 was
+split into PR-2a (backend, this) + PR-2b (web client) so the risky edit helper +
+route rationalization get isolated review and match the one-at-a-time merge
+cadence. **No migration** (Q3 adds no field; `edited` already exists).
+
+**De-risk spike first (throwaway):** confirmed on real Postgres + Wagtail that
+`save_revision()` + `workflow.start()` on a LIVE, untrusted post keeps the
+last-approved body serving while the new revision waits, and that `edited`
+captured in the revision publishes atomically — i.e. the create-path's force
+`live=False` must NOT be reused for edits. Also confirmed the TipTap→StreamField
+HTML round-trip (`bold/italic/external-link/code/ul`) survives nh3 → `to_python`
+→ `expand_db_html`. Spike deleted; assertions reborn as real tests.
+
+**Done in PR-2a (TDD, four commits):**
+
+- **Edit helper** — `submit_edit_for_moderation(post, user)` in `workflow.py`:
+  sets `edited=True` in memory, `save_revision()`, then publishes (trusted) or
+  starts the workflow (untrusted) — NEVER forces `live=False`, NEVER `post.save()`
+  the new body. Returns `published|pending` off `has_unpublished_changes`. Trust
+  derives from `post.author`. 3 unit tests.
+- **Route rationalization (spec Phase 2)** — `…/topics/create/` →
+  `POST …/topics/`, `…/posts/create/` → `POST …/posts/` by merging each create
+  view into its sibling list view (GET=list + POST=create on one class);
+  `get_permissions` makes only POST require auth. Host throttles only `name="post"`
+  (GET stays public/unthrottled). Route names `topic-create`/`reply-create`
+  removed; parity + rate-limit tests updated in lockstep.
+- **`PostWriteView`** at `posts/<id>/` — `PATCH` (edit, re-moderates via the helper;
+  409 closed/locked, 403 non-author/non-mod, 404 hidden, 400 malformed; response =
+  `PostSerializer` + `moderation_status`) and `DELETE` (soft-delete = `unpublish()`,
+  which fires the existing `unpublished` signal → `reply_count` recounts; **no
+  manual recount**; Q1 opening-post DELETE → 409). New `post-detail` route + host
+  wrapper (`post_update`/`post_delete` rates). 9 API tests incl. moderator path,
+  hidden-board 404, and a PATCH throttle-enforcement test.
+
+Verification: full forum package + host suite **131 passed**; `manage.py
+spectacular` exits 0 with `/forum/posts/{post_id}/` exposing patch+delete and no
+new forum-view error; zero-coupling `test_reusability`/`test_smoke` green. Gotcha
+hit + fixed again: autoflake stripped `PermissionDenied` +
+`submit_edit_for_moderation` (added before first use) — re-added after the
+`PostWriteView` usage existed.
+
+**Still open (do NOT close):** AC2 (web off machina) needs PR-2b; images need PR-3.


### PR DESCRIPTION
## Scope — PR-2a of a split (backend only)

**This is the first of two write-path PRs.** It lands the forum **backend** write
API; the **React web forum still 404s on writes until PR-2b** migrates the client
off the machina dialect. No user-visible change yet — renaming the (already-broken)
create routes can't worsen the deployed web forum.

- **PR-2a (this):** backend write path — route rationalization + `PostWriteView`
  (PATCH/DELETE) + `submit_edit_for_moderation`.
- **PR-2b (next):** migrate `forumService.ts` write fns, adapt reactions, re-enable
  the compose/edit/delete UI.
- **PR-3:** inline images.

Closes part of todo **231** (forum Spec 2). Todo stays open until PR-3.
Plan: `docs/superpowers/plans/2026-06-23-forum-spec2-pr2a-backend-write.md`.

## What changed

- **`submit_edit_for_moderation(post, user)`** (`workflow.py`) — re-screens an edit
  by **author** trust without ever unpublishing live content: sets `edited=True` in
  memory, `save_revision()`, then publishes (trusted) or starts the workflow
  (untrusted). It **never** forces `live=False` and **never** `post.save()`s the new
  body, so a flagged untrusted edit waits as a pending revision while the
  last-approved body keeps serving. Returns `published|pending`. *(De-risked first
  with a throwaway spike on real Postgres + Wagtail — see the plan; spike deleted,
  assertions reborn as real tests.)*
- **Route rationalization (spec Phase 2)** — `…/topics/create/` → `POST …/topics/`
  and `…/posts/create/` → `POST …/posts/`, by merging each create view into its
  sibling list view (GET=list + POST=create on one class). Host throttles only the
  `post` handler; GET stays public/unthrottled. Route names `topic-create`/
  `reply-create` removed; **route-parity + rate-limit tests updated in lockstep**.
- **`PostWriteView`** at `posts/<id>/`:
  - `PATCH` — author/moderator edit; 409 closed/locked, 403 non-author/non-mod, 404
    hidden, 400 malformed; response = `PostSerializer` + `moderation_status`.
  - `DELETE` — soft-delete = `unpublish()`, which fires the existing `unpublished`
    signal → `reply_count` recounts (**no manual recount**); opening-post DELETE →
    **409** (resolved Q1).
  - New host wrapper with `post_update`/`post_delete` rates.

Resolved spec questions enforced: **Q1** opening-post delete → 409; **Q2** edit
re-moderation never unpublishes live content; **Q3** delete = unpublish, **no new
field, no migration**.

## Verification

- Full forum package + host suite: **131 passed** (adds the edit helper, edit/delete
  API, moderator path, hidden-board 404, and a PATCH throttle-enforcement test).
- `manage.py spectacular` exits 0; `/forum/posts/{post_id}/` exposes patch+delete;
  no new forum-view schema error.
- Route-parity (`test_host_api_routes_match_package`) + callback-pin
  (`test_wrapped_routes_use_the_throttled_views`) green; package zero-coupling
  (`test_reusability`/`test_smoke`) green. `manage.py check`: no issues.

## Notes for the reviewer/merger

- **Owner-merge** (matching PR-1's cadence) — not auto-armed.
- No migration. No web changes. No plant imports added to the package core.

🤖 Generated with [Claude Code](https://claude.com/claude-code)