### PR TITLE
231(PR-2b): forum web write client — compose/reply/edit/delete/react onto wagtail_forum

### DIFF
--- a/docs/superpowers/plans/2026-06-23-forum-spec2-pr2b-web-write.md
+++ b/docs/superpowers/plans/2026-06-23-forum-spec2-pr2b-web-write.md
@@ -1,0 +1,471 @@
+# Forum Spec 2 — PR-2b (Web Write Client) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Migrate the React web forum **write** client off the retired machina dialect onto the new `wagtail_forum` REST routes (landed in PR-2a, PR #395) and re-enable the compose/reply/edit/delete/react UI.
+
+**Architecture:** The read client already speaks the new API (Phase 1). This PR rewrites the *write* functions in `forumService.ts` to the PR-2a contract, adjusts the TS types, adds a `NewThreadPage` compose route, and wires reply/edit/delete/react into `ThreadDetailPage` + `PostCard`. The post body is StreamField JSON (`[{type:'paragraph', value:'<p>…</p>'}]`); the composer reuses the existing `TipTapEditor` (HTML out → wrapped as one paragraph block). nh3 on the backend is the trust boundary.
+
+**Tech Stack:** React 19 + TypeScript, React Router v6 (`react-router-dom`), TipTap, Vitest + Testing Library, Tailwind 4.
+
+## Global Constraints
+
+- **Web only.** Branch `feat/forum-spec2-pr2b-web-write` off `main` (disjoint from PR-2a's backend-only diff). PR is **owner-merge** — do NOT auto-arm merge.
+- **Body contract:** every write sends `body: [{ type: 'paragraph', value: '<html>' }]`. A single paragraph `RichTextBlock` holds all rich text. nh3 server allowlist = `p,br,strong,b,em,i,u,ul,ol,li,a,code` — heading/quote/strike/codeblock degrade to plain text, so the composer toolbar is trimmed to the surviving marks.
+- **Reaction contract:** request field is `type` (NOT `reaction_type`); response is `{ reaction_counts: {…}, reacted: bool }` (no `action`, no `user_reactions`).
+- **Create responses are thin:** topic create → `{ id, slug, status }`; reply create → `{ id, status }`. `status` ∈ `published|pending`.
+- **Pending ⇒ not live.** A `pending` new topic is `live=False`; `fetchThread(id)` 404s it. **Never navigate into a pending topic** — show an "awaiting moderation" confirmation instead. A `pending` reply must not be appended (the list only returns live posts).
+- **Edit re-moderates by author trust** (backend). PATCH returns the full post (currently-live body) + `moderation_status`. Replace state with the returned post; if `pending`, also surface "edit awaiting moderation".
+- **Capability flags:** drive edit/delete visibility off backend `post.can_edit` / `post.can_delete`. The client-side author check is dead (the mapper sets `post.author.id = ''`).
+- **Auth:** cookie-JWT; `authenticatedFetch` already adds `X-CSRFToken` + `credentials:'include'`. No `Authorization` header.
+- **Images are OUT OF SCOPE (PR-3).** Leave `uploadPostImage`/`deletePostImage`/`fetchPostImages`/`reorderPostImage`s and their tests untouched. They are not wired into any compose UI built here.
+- **Gates (web CI):** `npm run type-check`, `npm run lint`, `npm run test` (vitest `--run`) must all pass. Run from `web/`.
+- **TS conventions:** all source `.ts`/`.tsx`; import Router symbols from `react-router-dom`; avoid `any` (use `unknown`); debounce timers via `useRef`.
+
+## File Structure
+
+| File | Change | Responsibility |
+|---|---|---|
+| `web/src/services/forumService.ts` | modify | Rewrite `createThread`, `createPost`, `updatePost`, `deletePost`, `toggleReaction`; delete `fetchReactions`; add `toBodyBlocks` helper. |
+| `web/src/types/forum.ts` | modify | Update `ReactionToggleResult`, `UpdatePostInput`; add `CreateTopicInput`/`CreateReplyInput`/`EditPostResult`/`CreateTopicResult`/`CreateReplyResult`. |
+| `web/src/services/forumService.test.ts` | modify | Rewrite write-fn tests to the new contract; delete the `fetchReactions` test + import. |
+| `web/src/pages/forum/NewThreadPage.tsx` | create | Compose a new topic; on success branch on `status`. |
+| `web/src/pages/forum/NewThreadPage.test.tsx` | create | Render, submit, published→navigate, pending→notice. |
+| `web/src/App.tsx` | modify | Add `/forum/new-thread` route (static; outranks `/:categorySlug`). |
+| `web/src/pages/forum/ThreadDetailPage.tsx` | modify | Reply composer + edit/delete/react wiring; remove read-only notice; hide composer when locked/closed. |
+| `web/src/pages/forum/ThreadDetailPage.test.tsx` | modify | Cover reply/edit/delete/react flows. |
+| `web/src/components/forum/PostCard.tsx` | modify | Gate edit/delete on `post.can_edit`/`post.can_delete`; drop dead `useAuth` author check. |
+| `web/src/components/forum/PostCard.test.tsx` | modify | Assert capability-flag-driven visibility. |
+| `web/src/components/forum/TipTapEditor.tsx` | modify | Trim toolbar to nh3-surviving marks (bold/italic/link/ul/ol/inline-code). |
+| `web/src/components/forum/TipTapEditor.test.tsx` | modify | Drop assertions for removed toolbar buttons. |
+| `todos/231-in_progress-p1-forum-spec2-read-api-web-client.md` | modify | Work-log: PR-2b landed; todo still open (PR-3 images). |
+
+**Interfaces produced (shared across tasks):**
+
+```ts
+// types/forum.ts
+export interface CreateTopicInput { boardSlug: string; title: string; content: string; }
+export interface CreateReplyInput { thread: number; content: string; }
+export interface UpdatePostInput { content: string; }                 // was { content_raw, content_format }
+export interface CreateTopicResult { id: string; slug: string; status: 'published' | 'pending'; }
+export interface CreateReplyResult { id: string; status: 'published' | 'pending'; }
+export interface EditPostResult { post: Post; status: 'published' | 'pending'; }
+export interface ReactionToggleResult { reaction_counts: Record<string, number>; reacted: boolean; }
+```
+
+```ts
+// forumService.ts — body helper (single source of the block shape)
+function toBodyBlocks(html: string): Array<{ type: 'paragraph'; value: string }> {
+  return [{ type: 'paragraph', value: html }];
+}
+```
+
+---
+
+### Task 1: Service — reaction contract (`type` request, `{reaction_counts, reacted}` response)
+
+**Files:**
+
+- Modify: `web/src/services/forumService.ts` (`toggleReaction`, delete `fetchReactions` + `BackendReactionResponse`/`toCounts`)
+- Modify: `web/src/types/forum.ts` (`ReactionToggleResult`)
+- Test: `web/src/services/forumService.test.ts`
+
+**Interfaces:**
+
+- Produces: `toggleReaction(postId, reactionType) → Promise<ReactionToggleResult>` where the body sent is `{ type }` and the result is `{ reaction_counts, reacted }`.
+
+- [ ] **Step 1: Update the test** — replace the `toggleReaction` test and DELETE the `fetchReactions` test + its import.
+
+```ts
+// remove `fetchReactions` from the import block at top of file
+it('toggleReaction posts {type} and returns {reaction_counts, reacted}', async () => {
+  fetchMock.mockResolvedValueOnce(okJson({ reaction_counts: { like: 3 }, reacted: true }));
+  const r = await toggleReaction('50', 'like');
+  expect(r).toEqual({ reaction_counts: { like: 3 }, reacted: true });
+  const [url, opts] = fetchMock.mock.calls[0];
+  expect(url).toContain('/posts/50/reactions/');
+  expect(opts.method).toBe('POST');
+  expect(JSON.parse(opts.body)).toEqual({ type: 'like' });
+});
+```
+
+- [ ] **Step 2: Run it — fails** (`cd web && npm run test -- forumService` → toggleReaction assertion fails; `fetchReactions` no longer exported).
+
+- [ ] **Step 3: Implement** — replace the Reactions section of `forumService.ts`:
+
+```ts
+/** Toggle a reaction on a post; returns updated counts + this user's resulting state. */
+export async function toggleReaction(
+  postId: string,
+  reactionType: string
+): Promise<ReactionToggleResult> {
+  return authenticatedFetch<ReactionToggleResult>(`${FORUM_BASE}/posts/${postId}/reactions/`, {
+    method: 'POST',
+    body: JSON.stringify({ type: reactionType }),
+  });
+}
+```
+
+Delete `fetchReactions`, `BackendReactionResponse`, and `toCounts`. Update `types/forum.ts`:
+
+```ts
+export interface ReactionToggleResult {
+  reaction_counts: Record<string, number>;
+  reacted: boolean;
+}
+```
+
+- [ ] **Step 4: Run it — passes.**
+
+- [ ] **Step 5: Commit** — `feat(231,pr2b): web reactions onto {type}/{reaction_counts,reacted} contract`
+
+---
+
+### Task 2: Service — create topic (`POST /boards/{slug}/topics/`)
+
+**Files:**
+
+- Modify: `web/src/services/forumService.ts` (`createThread`, add `toBodyBlocks`)
+- Modify: `web/src/types/forum.ts` (`CreateTopicInput`, `CreateTopicResult`)
+- Test: `web/src/services/forumService.test.ts`
+
+**Interfaces:**
+
+- Consumes: `slugifyTitle` from `../utils/forumUrls`.
+- Produces: `createThread({ boardSlug, title, content }) → Promise<CreateTopicResult>`.
+
+- [ ] **Step 1: Test** — replace the machina `createThread` test:
+
+```ts
+it('createThread posts to /boards/{slug}/topics/ with {title, slug, body[]}', async () => {
+  fetchMock.mockResolvedValueOnce(okJson({ id: 12, slug: 'succulent-help', status: 'published' }));
+  const r = await createThread({ boardSlug: 'plant-care', title: 'Succulent help!', content: '<p>hi</p>' });
+  expect(r).toEqual({ id: '12', slug: 'succulent-help', status: 'published' });
+  const [url, opts] = fetchMock.mock.calls[0];
+  expect(url).toContain('/boards/plant-care/topics/');
+  expect(opts.method).toBe('POST');
+  expect(JSON.parse(opts.body)).toEqual({
+    title: 'Succulent help!',
+    slug: 'succulent-help',
+    body: [{ type: 'paragraph', value: '<p>hi</p>' }],
+  });
+});
+```
+
+- [ ] **Step 2: Run it — fails.**
+
+- [ ] **Step 3: Implement** — add `toBodyBlocks` near the top of `forumService.ts` and import `slugifyTitle`:
+
+```ts
+import { slugifyTitle } from '../utils/forumUrls';
+
+function toBodyBlocks(html: string): Array<{ type: 'paragraph'; value: string }> {
+  return [{ type: 'paragraph', value: html }];
+}
+
+export async function createThread(data: CreateTopicInput): Promise<CreateTopicResult> {
+  const { boardSlug, title, content } = data;
+  const res = await authenticatedFetch<{ id: number; slug: string; status: 'published' | 'pending' }>(
+    `${FORUM_BASE}/boards/${boardSlug}/topics/`,
+    {
+      method: 'POST',
+      body: JSON.stringify({ title, slug: slugifyTitle(title), body: toBodyBlocks(content) }),
+    }
+  );
+  return { id: String(res.id), slug: res.slug, status: res.status };
+}
+```
+
+Add to `types/forum.ts`: `CreateTopicInput`, `CreateTopicResult` (see shared block). Remove the now-unused `mapTopicDetailToThread` import from `forumService.ts` **only if** no other function uses it (`fetchThread` still does — keep it).
+
+- [ ] **Step 4: Run it — passes.**
+
+- [ ] **Step 5: Commit** — `feat(231,pr2b): web createThread onto POST /boards/{slug}/topics/`
+
+---
+
+### Task 3: Service — create reply (`POST /topics/{id}/posts/`)
+
+**Files:**
+
+- Modify: `web/src/services/forumService.ts` (`createPost`)
+- Modify: `web/src/types/forum.ts` (`CreateReplyInput`, `CreateReplyResult`)
+- Test: `web/src/services/forumService.test.ts`
+
+**Interfaces:**
+
+- Produces: `createPost({ thread, content }) → Promise<CreateReplyResult>`.
+
+- [ ] **Step 1: Test** — replace the machina `createPost` tests (the `/posts/create/` test and the missing-`{data}` test):
+
+```ts
+it('createPost posts to /topics/{id}/posts/ with {body[]}', async () => {
+  fetchMock.mockResolvedValueOnce(okJson({ id: 51, status: 'pending' }));
+  const r = await createPost({ thread: 12, content: '<p>hi</p>' });
+  expect(r).toEqual({ id: '51', status: 'pending' });
+  const [url, opts] = fetchMock.mock.calls[0];
+  expect(url).toContain('/topics/12/posts/');
+  expect(opts.method).toBe('POST');
+  expect(JSON.parse(opts.body)).toEqual({ body: [{ type: 'paragraph', value: '<p>hi</p>' }] });
+});
+```
+
+Update the two "Error propagation" tests at the bottom that call `createPost({ thread: 12, content_raw: 'x' })` → `createPost({ thread: 12, content: 'x' })`.
+
+- [ ] **Step 2: Run it — fails.**
+
+- [ ] **Step 3: Implement:**
+
+```ts
+export async function createPost(data: CreateReplyInput): Promise<CreateReplyResult> {
+  const { thread, content } = data;
+  const res = await authenticatedFetch<{ id: number; status: 'published' | 'pending' }>(
+    `${FORUM_BASE}/topics/${thread}/posts/`,
+    { method: 'POST', body: JSON.stringify({ body: toBodyBlocks(content) }) }
+  );
+  return { id: String(res.id), status: res.status };
+}
+```
+
+Add `CreateReplyInput`, `CreateReplyResult` to `types/forum.ts`. Remove the old `CreatePostInput` if unused (search first).
+
+- [ ] **Step 4: Run it — passes.**
+
+- [ ] **Step 5: Commit** — `feat(231,pr2b): web createPost onto POST /topics/{id}/posts/`
+
+---
+
+### Task 4: Service — edit (`PATCH /posts/{id}/`) + delete (`DELETE /posts/{id}/`)
+
+**Files:**
+
+- Modify: `web/src/services/forumService.ts` (`updatePost`, `deletePost`)
+- Modify: `web/src/types/forum.ts` (`UpdatePostInput`, `EditPostResult`)
+- Test: `web/src/services/forumService.test.ts`
+
+**Interfaces:**
+
+- Consumes: `mapPostToPost` (already imported).
+- Produces: `updatePost(postId, { content }) → Promise<EditPostResult>`; `deletePost(postId) → Promise<void>`.
+
+- [ ] **Step 1: Test** — replace the `updatePost` + `deletePost` tests:
+
+```ts
+it('updatePost PATCHes /posts/{id}/ with {body[]} and returns {post, status}', async () => {
+  fetchMock.mockResolvedValueOnce(
+    okJson({ ...backendPost, id: 50, topic_id: 77, moderation_status: 'published' })
+  );
+  const r = await updatePost('50', { content: '<p>edited</p>' });
+  expect(r.status).toBe('published');
+  expect(r.post.id).toBe('50');
+  expect(r.post.thread).toBe('77');
+  const [url, opts] = fetchMock.mock.calls[0];
+  expect(url).toContain('/posts/50/');
+  expect(opts.method).toBe('PATCH');
+  expect(JSON.parse(opts.body)).toEqual({ body: [{ type: 'paragraph', value: '<p>edited</p>' }] });
+});
+
+it('deletePost DELETEs /posts/{id}/ (no /delete/ suffix)', async () => {
+  fetchMock.mockResolvedValueOnce({ ok: true, status: 204, json: async () => undefined });
+  await deletePost('50');
+  const [url, opts] = fetchMock.mock.calls[0];
+  expect(url).toMatch(/\/posts\/50\/$/);
+  expect(opts.method).toBe('DELETE');
+});
+```
+
+- [ ] **Step 2: Run it — fails.**
+
+- [ ] **Step 3: Implement:**
+
+```ts
+export async function updatePost(postId: string, data: UpdatePostInput): Promise<EditPostResult> {
+  const res = await authenticatedFetch<BackendPost & { moderation_status: 'published' | 'pending' }>(
+    `${FORUM_BASE}/posts/${postId}/`,
+    { method: 'PATCH', body: JSON.stringify({ body: toBodyBlocks(data.content) }) }
+  );
+  return { post: mapPostToPost(res, String(res.topic_id)), status: res.moderation_status };
+}
+
+export async function deletePost(postId: string): Promise<void> {
+  await authenticatedFetch<void>(`${FORUM_BASE}/posts/${postId}/`, { method: 'DELETE' });
+}
+```
+
+Update `types/forum.ts`: `UpdatePostInput = { content: string }`; add `EditPostResult`.
+
+- [ ] **Step 4: Run it — passes.** Then run the **whole** service suite: `npm run test -- forumService` (all green; image tests untouched).
+
+- [ ] **Step 5: Commit** — `feat(231,pr2b): web edit/delete onto PATCH+DELETE /posts/{id}/`
+
+---
+
+### Task 5: NewThread compose page + route
+
+**Files:**
+
+- Create: `web/src/pages/forum/NewThreadPage.tsx`
+- Create: `web/src/pages/forum/NewThreadPage.test.tsx`
+- Modify: `web/src/App.tsx`
+
+**Interfaces:**
+
+- Consumes: `createThread`, `fetchCategory` (service); `parseLeadingId`, `slugifyTitle`, `threadPath`, `categoryPath` (forumUrls); `TipTapEditor`.
+
+**Behavior:**
+
+- Read `?category=<idOrIdSlug>` from the query string. `parseLeadingId` → numeric board id → `fetchCategory(id)` → `{ id, slug, name }`.
+- Form: title `<input>` + `TipTapEditor` (onChange → html state). Submit disabled while title empty OR content empty (`<p></p>`/whitespace).
+- Submit → `createThread({ boardSlug: category.slug, title, content: html })`.
+  - `status === 'published'` → `navigate(threadPath(category, { id: res.id, slug: res.slug }))`.
+  - `status === 'pending'` → set a success notice ("Your topic was submitted and is awaiting moderation.") and `navigate(categoryPath(category))` (do NOT navigate into the pending — it 404s).
+- Errors → surface `err.message`.
+
+- [ ] **Step 1: Write the failing test** (`NewThreadPage.test.tsx`):
+
+```tsx
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { vi } from 'vitest';
+import NewThreadPage from './NewThreadPage';
+import * as svc from '../../services/forumService';
+
+const navigate = vi.fn();
+vi.mock('react-router-dom', async (orig) => ({
+  ...(await orig<typeof import('react-router-dom')>()),
+  useNavigate: () => navigate,
+  useSearchParams: () => [new URLSearchParams('category=3-plant-care'), vi.fn()],
+}));
+// TipTap is heavy + jsdom-hostile — stub it to a textarea that emits HTML.
+vi.mock('../../components/forum/TipTapEditor', () => ({
+  default: ({ onChange }: { onChange?: (h: string) => void }) => (
+    <textarea aria-label="body" onChange={(e) => onChange?.(`<p>${e.target.value}</p>`)} />
+  ),
+}));
+
+beforeEach(() => {
+  navigate.mockClear();
+  vi.spyOn(svc, 'fetchCategory').mockResolvedValue({
+    id: '3', name: 'Plant Care', slug: 'plant-care', created_at: '',
+  });
+});
+
+it('published topic → navigates into the new thread', async () => {
+  vi.spyOn(svc, 'createThread').mockResolvedValue({ id: '12', slug: 'my-topic', status: 'published' });
+  render(<MemoryRouter><NewThreadPage /></MemoryRouter>);
+  await screen.findByText('Plant Care');
+  await userEvent.type(screen.getByLabelText(/title/i), 'My Topic');
+  await userEvent.type(screen.getByLabelText('body'), 'hello');
+  await userEvent.click(screen.getByRole('button', { name: /post|create|submit/i }));
+  await waitFor(() =>
+    expect(navigate).toHaveBeenCalledWith('/forum/3-plant-care/12-my-topic')
+  );
+});
+
+it('pending topic → shows moderation notice, does NOT navigate into it', async () => {
+  vi.spyOn(svc, 'createThread').mockResolvedValue({ id: '12', slug: 'my-topic', status: 'pending' });
+  render(<MemoryRouter><NewThreadPage /></MemoryRouter>);
+  await screen.findByText('Plant Care');
+  await userEvent.type(screen.getByLabelText(/title/i), 'My Topic');
+  await userEvent.type(screen.getByLabelText('body'), 'hello');
+  await userEvent.click(screen.getByRole('button', { name: /post|create|submit/i }));
+  await waitFor(() => expect(navigate).toHaveBeenCalledWith('/forum/3-plant-care'));
+  expect(svc.createThread).toHaveBeenCalledWith({
+    boardSlug: 'plant-care', title: 'My Topic', content: '<p>hello</p>',
+  });
+});
+```
+
+- [ ] **Step 2: Run it — fails** (no `NewThreadPage`).
+
+- [ ] **Step 3: Implement `NewThreadPage.tsx`** — resolve category in `useEffect`, controlled title + editor html, submit handler branching on `status`. Use `LoadingSpinner`, `Button`, `logger`, match the surface styling of `ThreadListPage`. Guard empty body (`stripHtml(html).trim() === ''`). The submit button label includes "Post" (matches the test regex).
+
+- [ ] **Step 4: Add the route** in `App.tsx` (lazy import + `<Route path="/forum/new-thread" element={<NewThreadPage />} />`). Place it among the forum routes; React Router v6 ranks the static segment above `/:categorySlug`, but add it **before** the param route anyway for clarity. Also remove the duplicate `/forum/search` route line while here.
+
+- [ ] **Step 5: Run it — passes.** `npm run test -- NewThreadPage`.
+
+- [ ] **Step 6: Commit** — `feat(231,pr2b): NewThread compose page + /forum/new-thread route`
+
+---
+
+### Task 6: ThreadDetailPage write wiring + PostCard capability flags
+
+**Files:**
+
+- Modify: `web/src/components/forum/PostCard.tsx` + `PostCard.test.tsx`
+- Modify: `web/src/pages/forum/ThreadDetailPage.tsx` + `ThreadDetailPage.test.tsx`
+- Modify: `web/src/components/forum/TipTapEditor.tsx` + `TipTapEditor.test.tsx`
+
+**Interfaces:**
+
+- Consumes: `createPost`, `updatePost`, `deletePost`, `toggleReaction` (service).
+
+**6a — PostCard: drive edit/delete off capability flags.**
+
+- [ ] **Step 1: Update `PostCard.test.tsx`** — assert Edit/Delete render when `post.can_edit`/`post.can_delete` true AND the handler is passed; absent when the flag is false. Remove any `useAuth`-mock-driven author assertions.
+- [ ] **Step 2: Run — fails.**
+- [ ] **Step 3: Implement** — in `PostCard.tsx` drop `useAuth`/`isAuthor`/`isModerator`/`canEdit`; gate per-button:
+  - Edit button: `{post.can_edit && onEdit && (<button …>)}`
+  - Delete button: `{post.can_delete && onDelete && (<button …>)}`
+  - Wrap row in `{(post.can_edit || post.can_delete) && (onEdit || onDelete) && (…)}`.
+  - Remove the now-unused `useAuth` import **in the same edit** (edit-time import strip).
+- [ ] **Step 4: Run — passes.**
+
+**6b — TipTapEditor: trim toolbar to nh3-surviving marks.**
+
+- [ ] **Step 5: Update `TipTapEditor.test.tsx`** — drop assertions for H2/H3/strike/blockquote/code-block buttons (if any).
+- [ ] **Step 6: Implement** — remove the H2, H3, strikethrough, blockquote, and code-block `ToolbarButton`s (keep bold, italic, bullet list, ordered list, inline code, link/unlink). Optionally disable `heading`/`strike`/`blockquote`/`codeBlock` in `StarterKit.configure` so keyboard shortcuts can't reintroduce them. Keep the component otherwise intact.
+- [ ] **Step 7: Run TipTapEditor tests — pass.**
+
+**6c — ThreadDetailPage: reply + edit + delete + react.**
+
+- [ ] **Step 8: Update `ThreadDetailPage.test.tsx`** — add cases: a reply submit calls `createPost` then refetches; a published reply appears; clicking a post's Delete calls `deletePost` and removes it; clicking a reaction calls `toggleReaction` and updates the count; the reply composer is hidden when `thread.is_locked`. Mock `TipTapEditor` to a textarea as in Task 5. Mock the service module.
+- [ ] **Step 9: Run — fails.**
+- [ ] **Step 10: Implement** — in `ThreadDetailPage.tsx`:
+  - Remove the read-only "Replies are coming soon" notice.
+  - **Reply composer** (hidden if `thread.is_locked`): `TipTapEditor` + Post button → `createPost({ thread: topicId, content: html })`. On `published` → re-run `fetchPosts({ thread: topicId })` and reset to first page (or append the refetched first page); on `pending` → toast "awaiting moderation", clear editor, do not append.
+  - **`handleReact(postId, type)`** → `toggleReaction(postId, type)` → map result `reaction_counts` onto that post in `posts` state.
+  - **`handleDelete(post)`** → `window.confirm` → `deletePost(post.id)` → filter it out of `posts`, decrement `totalPosts`.
+  - **`handleEdit(post)`** → set an `editingPostId`; render an inline `TipTapEditor` seeded with `bodyToHtml(post.body)` (first paragraph block value); Save → `updatePost(post.id, { content })` → replace that post with `result.post`; if `result.status === 'pending'` toast "edit awaiting moderation". `bodyToHtml = (blocks) => blocks?.find(b => b.type === 'paragraph')?.value ?? ''`.
+  - Pass `onEdit={handleEdit}` `onDelete={handleDelete}` `onReact={handleReact}` to each `PostCard`.
+- [ ] **Step 11: Run — passes.**
+
+- [ ] **Step 12: Commit** — `feat(231,pr2b): wire reply/edit/delete/react into ThreadDetailPage + capability-flag PostCard`
+
+---
+
+### Task 7: Gate, machina sweep, work-log
+
+**Files:**
+
+- Modify: `todos/231-in_progress-p1-forum-spec2-read-api-web-client.md`
+
+- [ ] **Step 1: Machina sweep** — confirm no machina **write** paths remain in the migrated functions:
+
+```bash
+cd web && grep -nE "topics/create/|posts/create/|posts/[^/]+/delete/|reaction_type|categories/[0-9]" src/services/forumService.ts
+```
+
+Expected: only the **image** functions may still match `…/delete/` (PR-3); the topic/reply/edit/reaction lines must be gone. If a non-image match remains, fix it.
+
+- [ ] **Step 2: Full web gate:**
+
+```bash
+cd web && npm run type-check && npm run lint && npm run test -- --run
+```
+
+Expected: type-check 0 errors; lint clean; vitest all green.
+
+- [ ] **Step 3: Work-log** — append a `### 2026-06-23 - PR-2b (web write client) landed — todo still OPEN` entry to todo 231: list the migrated write fns + contracts, the new compose page, the capability-flag wiring, the verification output, and "Still open: PR-3 (images) — `image` block render + `POST /topics/{id}/images/` + `validate_forum_body` relax; todo 231 archives after PR-3."
+
+- [ ] **Step 4: Commit** — `docs(231,pr2b): work-log web write client; PR-3 images remain`
+
+---
+
+## Self-Review
+
+- **Spec coverage:** Phase 2 client (create topic/reply, edit, delete, react, route rationalization consumed) ✓. Phase 3 images explicitly deferred ✓. Error surfacing via `authenticatedFetch` (unchanged) ✓. `can_edit`/`can_delete` consumed ✓. Cursor "Load More" already present (Phase 1) — untouched ✓.
+- **Type consistency:** `CreateTopicInput`/`CreateReplyInput`/`UpdatePostInput`/`*Result` defined in Task 1's shared block, consumed by Tasks 2–6 ✓. `toBodyBlocks` defined once (Task 2) ✓.
+- **Pending correctness:** new-topic pending → board nav, not thread nav (Task 5) ✓; pending reply not appended (Task 6) ✓.
+- **No placeholders:** service-layer code is complete; UI tasks specify exact handlers + the `bodyToHtml`/`toBodyBlocks` shapes ✓.

--- a/todos/231-in_progress-p1-forum-spec2-read-api-web-client.md
+++ b/todos/231-in_progress-p1-forum-spec2-read-api-web-client.md
@@ -167,3 +167,40 @@ before its first use) — re-added after the usage existed.
 
 **Still open (do NOT close):** AC2 (web off machina) + AC4 final URL surface need
 PR-2 (write path) and PR-3 (images). Todo archives only after PR-3.
+
+### 2026-06-23 - PR-2b (web write client) landed — todo still OPEN
+
+Branch `feat/forum-spec2-pr2b-web-write` off `main` (web-only; disjoint from the
+backend PR-2a). Plan: `docs/superpowers/plans/2026-06-23-forum-spec2-pr2b-web-write.md`.
+PR-2a (backend write path, PR #395) is its prerequisite for live integration but
+the web suite mocks `fetch`, so PR-2b is fully verifiable without it.
+
+**Done (TDD; commits = plan + reactions + service-writes + NewThread + wiring + this log):**
+
+- **Service** (`forumService.ts`) migrated onto the PR-2a routes:
+  `createThread` → `POST /boards/{slug}/topics/` (client slugifies the title;
+  returns `{id, slug, status}`); `createPost` → `POST /topics/{id}/posts/`
+  (`{id, status}`); `updatePost` → `PATCH /posts/{id}/` (full post +
+  `moderation_status`); `deletePost` → `DELETE /posts/{id}/`; `toggleReaction`
+  → `{type}` request / `{reaction_counts, reacted}` response. Bodies wrapped as a
+  single `paragraph` StreamField block via `toBodyBlocks`. `fetchReactions`
+  deleted (no GET on the toggle endpoint).
+- **Compose UI**: new `NewThreadPage` + `/forum/new-thread` route (a published
+  topic navigates into the thread; a *pending* one is `live=False` and would 404,
+  so we notify + return to the board). `ThreadDetailPage` gained the reply
+  composer (hidden when locked), inline edit, delete-with-confirm, and reaction
+  toggles; the read-only notice is gone. `PostCard` now gates edit/delete on the
+  backend `can_edit`/`can_delete` (the client-side author check was dead — the
+  mapper sets `author.id=''`).
+
+Verification: full web suite **559 passed** (37 files); `tsc --noEmit` clean;
+ESLint 0 errors. Machina write-path sweep of `forumService.ts` is empty
+(`topics/create/`, `posts/create/`, `posts/{id}/delete/`, `reaction_type` all
+gone); the only legacy paths left are the **image** fns (PR-3).
+
+**Deferred to PR-3 (do NOT close the todo):** inline image upload/render —
+`POST /topics/{id}/images/`, `validate_forum_body` relax, the web
+`StreamFieldRenderer` `image` case, and migrating the forum image client fns.
+Also a UX nicety: the composer toolbar still offers heading/quote/strike/
+code-block marks that the server's nh3 allowlist flattens to text (graceful, no
+data loss) — trim later. Todo archives after PR-3.

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -17,6 +17,7 @@ const BlogPreview = lazy(() => import('./pages/BlogPreview'));
 const CategoryListPage = lazy(() => import('./pages/forum/CategoryListPage'));
 const ThreadListPage = lazy(() => import('./pages/forum/ThreadListPage'));
 const ThreadDetailPage = lazy(() => import('./pages/forum/ThreadDetailPage'));
+const NewThreadPage = lazy(() => import('./pages/forum/NewThreadPage'));
 const SearchPage = lazy(() => import('./pages/forum/SearchPage'));
 const ProfilePage = lazy(() => import('./pages/ProfilePage'));
 const SettingsPage = lazy(() => import('./pages/SettingsPage'));
@@ -52,7 +53,7 @@ function App() {
           <Route path="/blog/preview/:content_type/:token" element={<BlogPreview />} />
           <Route path="/forum/search" element={<SearchPage />} />
           <Route path="/forum" element={<CategoryListPage />} />
-          <Route path="/forum/search" element={<SearchPage />} />
+          <Route path="/forum/new-thread" element={<NewThreadPage />} />
           <Route path="/forum/:categorySlug" element={<ThreadListPage />} />
           <Route path="/forum/:categorySlug/:threadSlug" element={<ThreadDetailPage />} />
         </Route>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -53,7 +53,6 @@ function App() {
           <Route path="/blog/preview/:content_type/:token" element={<BlogPreview />} />
           <Route path="/forum/search" element={<SearchPage />} />
           <Route path="/forum" element={<CategoryListPage />} />
-          <Route path="/forum/new-thread" element={<NewThreadPage />} />
           <Route path="/forum/:categorySlug" element={<ThreadListPage />} />
           <Route path="/forum/:categorySlug/:threadSlug" element={<ThreadDetailPage />} />
         </Route>
@@ -61,6 +60,8 @@ function App() {
         {/* Protected routes - requires authentication */}
         <Route element={<ProtectedLayout />}>
           <Route element={<RootLayout />}>
+            {/* Composing a thread requires auth (the API rejects anon writes). */}
+            <Route path="/forum/new-thread" element={<NewThreadPage />} />
             <Route path="/diagnose" element={<DiseaseDiagnosePage />} />
             <Route path="/profile" element={<ProfilePage />} />
             <Route path="/settings" element={<SettingsPage />} />

--- a/web/src/components/forum/PostCard.test.tsx
+++ b/web/src/components/forum/PostCard.test.tsx
@@ -3,16 +3,7 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { BrowserRouter } from 'react-router-dom';
 import PostCard from './PostCard';
-import { useAuth } from '../../contexts/AuthContext';
 import { createMockPost } from '../../tests/forumUtils';
-
-// Mock the AuthContext
-vi.mock('../../contexts/AuthContext', () => ({
-  useAuth: vi.fn(() => ({
-    user: null,
-    isAuthenticated: false,
-  })),
-}));
 
 /**
  * Helper to render PostCard with Router context.
@@ -272,21 +263,8 @@ describe('PostCard', () => {
     expect(screen.getByText('p')).toBeInTheDocument();
   });
 
-  it('edit and delete buttons are in the DOM for the post owner when handlers are provided', () => {
-    vi.mocked(useAuth).mockReturnValueOnce({
-      user: { id: 1, email: 'owner@example.com', is_staff: false, is_moderator: false },
-      isAuthenticated: true,
-      isLoading: false,
-      error: null,
-      login: vi.fn(),
-      logout: vi.fn(),
-      signup: vi.fn(),
-      clearError: vi.fn(),
-    });
-
-    const post = createMockPost({
-      author: { id: 1, username: 'owner', email: '', display_name: 'Owner', trust_level: 'member' },
-    });
+  it('shows edit/delete buttons when can_edit/can_delete are true and handlers are provided', () => {
+    const post = createMockPost({ can_edit: true, can_delete: true });
 
     renderPostCard(post);
 
@@ -295,21 +273,17 @@ describe('PostCard', () => {
     expect(screen.getByTitle('Delete post')).toBeInTheDocument();
   });
 
-  it('hides edit and delete buttons for the post owner when no handlers are provided', () => {
-    vi.mocked(useAuth).mockReturnValueOnce({
-      user: { id: 1, email: 'owner@example.com', is_staff: false, is_moderator: false },
-      isAuthenticated: true,
-      isLoading: false,
-      error: null,
-      login: vi.fn(),
-      logout: vi.fn(),
-      signup: vi.fn(),
-      clearError: vi.fn(),
-    });
+  it('hides edit/delete buttons when the capability flags are false', () => {
+    const post = createMockPost({ can_edit: false, can_delete: false });
 
-    const post = createMockPost({
-      author: { id: 1, username: 'owner', email: '', display_name: 'Owner', trust_level: 'member' },
-    });
+    renderPostCard(post);
+
+    expect(screen.queryByTitle('Edit post')).not.toBeInTheDocument();
+    expect(screen.queryByTitle('Delete post')).not.toBeInTheDocument();
+  });
+
+  it('hides edit/delete buttons when no handlers are provided even if capable', () => {
+    const post = createMockPost({ can_edit: true, can_delete: true });
 
     render(
       <BrowserRouter>
@@ -319,5 +293,23 @@ describe('PostCard', () => {
 
     expect(screen.queryByTitle('Edit post')).not.toBeInTheDocument();
     expect(screen.queryByTitle('Delete post')).not.toBeInTheDocument();
+  });
+
+  it('calls onEdit/onDelete with the post when the buttons are clicked', async () => {
+    const onEdit = vi.fn();
+    const onDelete = vi.fn();
+    const post = createMockPost({ id: 'post-7', can_edit: true, can_delete: true });
+
+    render(
+      <BrowserRouter>
+        <PostCard post={post} onEdit={onEdit} onDelete={onDelete} />
+      </BrowserRouter>
+    );
+
+    await userEvent.click(screen.getByTitle('Edit post'));
+    await userEvent.click(screen.getByTitle('Delete post'));
+
+    expect(onEdit).toHaveBeenCalledWith(post);
+    expect(onDelete).toHaveBeenCalledWith(post);
   });
 });

--- a/web/src/components/forum/PostCard.tsx
+++ b/web/src/components/forum/PostCard.tsx
@@ -1,6 +1,5 @@
 import { memo, useMemo } from 'react';
 import { formatDistanceToNow } from 'date-fns';
-import { useAuth } from '../../contexts/AuthContext';
 import StreamFieldRenderer from '../StreamFieldRenderer';
 import type { Post } from '@/types';
 
@@ -32,11 +31,10 @@ function getReactionEmoji(type: string): string {
  * Includes author info, content, reactions, and edit/delete options.
  */
 function PostCard({ post, onEdit, onDelete, onReact }: PostCardProps) {
-  const { user } = useAuth();
-
-  const isAuthor = user && String(user.id) === String(post.author.id);
-  const isModerator = user && (user.is_staff || user.is_moderator);
-  const canEdit = isAuthor || isModerator;
+  // Edit/delete visibility is driven by the backend capability flags
+  // (PostSerializer.can_edit/can_delete) — the only authority on author-or-mod.
+  const showEdit = !!post.can_edit && !!onEdit;
+  const showDelete = !!post.can_delete && !!onDelete;
 
   // Memoize formatted date
   const formattedDate = useMemo(() => {
@@ -100,22 +98,22 @@ function PostCard({ post, onEdit, onDelete, onReact }: PostCardProps) {
           </div>
         </div>
 
-        {/* Actions (edit/delete) — shown only when handlers are provided (Phase 2 write UI).
-            Always visible on mobile, fade in on desktop hover. */}
-        {canEdit && (onEdit || onDelete) && (
+        {/* Actions (edit/delete) — gated on the backend capability flags AND the
+            presence of a handler. Always visible on mobile, fade in on desktop hover. */}
+        {(showEdit || showDelete) && (
           <div className="flex gap-2 md:opacity-0 md:group-hover:opacity-100 transition-opacity">
-            {onEdit && (
+            {showEdit && (
               <button
-                onClick={() => onEdit(post)}
+                onClick={() => onEdit!(post)}
                 className="min-h-11 px-3 py-1 text-sm text-sky hover:bg-sky/10 rounded inline-flex items-center"
                 title="Edit post"
               >
                 ✏️ Edit
               </button>
             )}
-            {onDelete && (
+            {showDelete && (
               <button
-                onClick={() => onDelete(post)}
+                onClick={() => onDelete!(post)}
                 className="min-h-11 px-3 py-1 text-sm text-error hover:bg-error/10 rounded inline-flex items-center"
                 title="Delete post"
               >

--- a/web/src/pages/forum/NewThreadPage.test.tsx
+++ b/web/src/pages/forum/NewThreadPage.test.tsx
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import * as ReactRouter from 'react-router-dom';
+import NewThreadPage from './NewThreadPage';
+import * as forumService from '../../services/forumService';
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return { ...actual, useNavigate: vi.fn(), useSearchParams: vi.fn() };
+});
+
+vi.mock('../../services/forumService');
+
+// TipTap is heavy + jsdom-hostile — stub it to a textarea that emits paragraph HTML.
+vi.mock('../../components/forum/TipTapEditor', () => ({
+  default: ({ onChange }: { onChange?: (html: string) => void }) => (
+    <textarea aria-label="body" onChange={(e) => onChange?.(`<p>${e.target.value}</p>`)} />
+  ),
+}));
+
+let mockNavigate: ReturnType<typeof vi.fn>;
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <NewThreadPage />
+    </MemoryRouter>
+  );
+}
+
+describe('NewThreadPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockNavigate = vi.fn();
+    vi.mocked(ReactRouter.useNavigate).mockReturnValue(
+      mockNavigate as unknown as ReturnType<typeof ReactRouter.useNavigate>
+    );
+    vi.mocked(ReactRouter.useSearchParams).mockReturnValue([
+      new URLSearchParams('category=3-plant-care'),
+      vi.fn(),
+    ]);
+    vi.spyOn(forumService, 'fetchCategory').mockResolvedValue({
+      id: '3',
+      name: 'Plant Care',
+      slug: 'plant-care',
+      created_at: '',
+    });
+  });
+
+  it('published topic → navigates into the new thread', async () => {
+    vi.spyOn(forumService, 'createThread').mockResolvedValue({
+      id: '12',
+      slug: 'my-topic',
+      status: 'published',
+    });
+    renderPage();
+    await screen.findByText('Plant Care');
+    await userEvent.type(screen.getByLabelText(/title/i), 'My Topic');
+    await userEvent.type(screen.getByLabelText('body'), 'hello');
+    await userEvent.click(screen.getByRole('button', { name: /post|create|submit/i }));
+    await waitFor(() =>
+      expect(mockNavigate).toHaveBeenCalledWith('/forum/3-plant-care/12-my-topic')
+    );
+  });
+
+  it('pending topic → moderation notice, navigates to the board (not into the pending topic)', async () => {
+    vi.spyOn(window, 'alert').mockImplementation(() => {});
+    vi.spyOn(forumService, 'createThread').mockResolvedValue({
+      id: '12',
+      slug: 'my-topic',
+      status: 'pending',
+    });
+    renderPage();
+    await screen.findByText('Plant Care');
+    await userEvent.type(screen.getByLabelText(/title/i), 'My Topic');
+    await userEvent.type(screen.getByLabelText('body'), 'hello');
+    await userEvent.click(screen.getByRole('button', { name: /post|create|submit/i }));
+    await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith('/forum/3-plant-care'));
+    expect(forumService.createThread).toHaveBeenCalledWith({
+      boardSlug: 'plant-care',
+      title: 'My Topic',
+      content: '<p>hello</p>',
+    });
+  });
+
+  it('blocks submit until both title and body are filled', async () => {
+    renderPage();
+    await screen.findByText('Plant Care');
+    expect(screen.getByRole('button', { name: /post|create|submit/i })).toBeDisabled();
+    await userEvent.type(screen.getByLabelText(/title/i), 'My Topic');
+    expect(screen.getByRole('button', { name: /post|create|submit/i })).toBeDisabled();
+    await userEvent.type(screen.getByLabelText('body'), 'hello');
+    expect(screen.getByRole('button', { name: /post|create|submit/i })).toBeEnabled();
+  });
+});

--- a/web/src/pages/forum/NewThreadPage.tsx
+++ b/web/src/pages/forum/NewThreadPage.tsx
@@ -1,0 +1,185 @@
+import { useState, useEffect, useCallback, FormEvent } from 'react';
+import { useNavigate, useSearchParams, Link } from 'react-router-dom';
+import { createThread, fetchCategory } from '../../services/forumService';
+import { parseLeadingId, threadPath, categoryPath } from '../../utils/forumUrls';
+import TipTapEditor from '../../components/forum/TipTapEditor';
+import LoadingSpinner from '../../components/ui/LoadingSpinner';
+import Button from '../../components/ui/Button';
+import { logger } from '../../utils/logger';
+import type { Category } from '@/types';
+
+/** Strip tags + whitespace to detect an effectively-empty rich-text body. */
+function isBlankHtml(html: string): boolean {
+  return html.replace(/<[^>]*>/g, '').trim() === '';
+}
+
+/**
+ * NewThreadPage Component
+ *
+ * Compose a new topic on a board. Reached via `/forum/new-thread?category={id}-{slug}`.
+ * On success: a published topic navigates into the new thread; a pending topic
+ * (untrusted author) is live=False and would 404 if opened, so we surface a
+ * moderation notice and return to the board instead.
+ */
+export default function NewThreadPage() {
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const categoryParam = searchParams.get('category');
+
+  const [category, setCategory] = useState<Category | null>(null);
+  const [title, setTitle] = useState('');
+  const [body, setBody] = useState('');
+  const [loading, setLoading] = useState<boolean>(true);
+  const [submitting, setSubmitting] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const load = async () => {
+      const forumId = parseLeadingId(categoryParam ?? undefined);
+      if (forumId == null) {
+        setError('Invalid board. Open “New Thread” from a forum board.');
+        setLoading(false);
+        return;
+      }
+      try {
+        setLoading(true);
+        setError(null);
+        setCategory(await fetchCategory(forumId));
+      } catch (err) {
+        logger.error('Error loading board for new thread', {
+          component: 'NewThreadPage',
+          error: err,
+          context: { categoryParam },
+        });
+        setError(err instanceof Error ? err.message : 'Failed to load board');
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+  }, [categoryParam]);
+
+  const canSubmit = !!category && title.trim() !== '' && !isBlankHtml(body);
+
+  const handleSubmit = useCallback(
+    async (e: FormEvent<HTMLFormElement>) => {
+      e.preventDefault();
+      if (!category || !title.trim() || isBlankHtml(body)) return;
+      try {
+        setSubmitting(true);
+        setError(null);
+        const res = await createThread({
+          boardSlug: category.slug,
+          title: title.trim(),
+          content: body,
+        });
+        if (res.status === 'published') {
+          navigate(threadPath(category, { id: res.id, slug: res.slug, title: title.trim() }));
+        } else {
+          // A pending topic is live=False — opening it 404s. Confirm + return to board.
+          window.alert('Your topic was submitted and is awaiting moderation.');
+          navigate(categoryPath(category));
+        }
+      } catch (err) {
+        logger.error('Error creating thread', {
+          component: 'NewThreadPage',
+          error: err,
+          context: { board: category.slug },
+        });
+        setError(err instanceof Error ? err.message : 'Failed to create thread');
+      } finally {
+        setSubmitting(false);
+      }
+    },
+    [category, title, body, navigate]
+  );
+
+  if (loading) {
+    return (
+      <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <LoadingSpinner />
+      </div>
+    );
+  }
+
+  if (error && !category) {
+    return (
+      <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <div className="bg-error/10 border border-error/30 text-ink px-4 py-3 rounded">
+          <strong>Error:</strong> {error}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      {/* Breadcrumb */}
+      <nav className="mb-6 text-sm text-ink-2" aria-label="Breadcrumb">
+        <ol className="flex items-center gap-2">
+          <li>
+            <Link to="/forum" className="hover:text-primary">
+              Forums
+            </Link>
+          </li>
+          <li aria-hidden="true">›</li>
+          <li>
+            <Link to={category ? categoryPath(category) : '/forum'} className="hover:text-primary">
+              {category?.name}
+            </Link>
+          </li>
+          <li aria-hidden="true">›</li>
+          <li aria-current="page" className="font-medium text-ink">
+            New Thread
+          </li>
+        </ol>
+      </nav>
+
+      <h1 className="text-3xl font-bold text-ink mb-6">Start a New Thread</h1>
+
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label htmlFor="thread-title" className="block text-sm font-medium text-ink-2 mb-1">
+            Title
+          </label>
+          <input
+            id="thread-title"
+            type="text"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            placeholder="A clear, specific title"
+            maxLength={255}
+            className="w-full px-4 py-2 border border-line-2 rounded-lg focus:ring-2 focus:ring-primary focus:border-transparent bg-surface-2 text-ink"
+          />
+        </div>
+
+        <div>
+          <span className="block text-sm font-medium text-ink-2 mb-1">Message</span>
+          <TipTapEditor content={body} onChange={setBody} placeholder="Write your post..." />
+        </div>
+
+        {error && (
+          <div className="bg-error/10 border border-error/30 text-ink px-4 py-3 rounded">
+            {error}
+          </div>
+        )}
+
+        <div className="flex gap-2">
+          <Button
+            type="submit"
+            variant="primary"
+            disabled={!canSubmit || submitting}
+            loading={submitting}
+          >
+            Post Thread
+          </Button>
+          <Link to={category ? categoryPath(category) : '/forum'}>
+            <Button type="button" variant="outline">
+              Cancel
+            </Button>
+          </Link>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/web/src/pages/forum/ThreadDetailPage.test.tsx
+++ b/web/src/pages/forum/ThreadDetailPage.test.tsx
@@ -288,6 +288,8 @@ describe('ThreadDetailPage', () => {
       content: '<p>my reply</p>',
     });
     expect(fetchPostsSpy).toHaveBeenCalledTimes(2);
+    // The composer remounts (key bump) so it visibly clears after posting.
+    expect(screen.getByLabelText('Write a reply...')).toHaveValue('');
   });
 
   it('shows a moderation notice for a pending reply and does not refetch', async () => {

--- a/web/src/pages/forum/ThreadDetailPage.test.tsx
+++ b/web/src/pages/forum/ThreadDetailPage.test.tsx
@@ -6,6 +6,7 @@ import * as ReactRouter from 'react-router-dom';
 import ThreadDetailPage from './ThreadDetailPage';
 import { createMockThread, createMockPost } from '../../tests/forumUtils';
 import * as forumService from '../../services/forumService';
+import { useAuth } from '../../contexts/AuthContext';
 
 vi.mock('react-router-dom', async () => {
   const actual = await vi.importActual('react-router-dom');
@@ -19,6 +20,7 @@ vi.mock('react-router-dom', async () => {
 // The aria-label is the placeholder so the reply composer ("Write a reply...") and
 // the edit editor ("body", no placeholder) are individually addressable.
 vi.mock('../../services/forumService');
+vi.mock('../../contexts/AuthContext', () => ({ useAuth: vi.fn() }));
 vi.mock('../../components/forum/TipTapEditor', () => ({
   default: ({
     onChange,
@@ -45,6 +47,11 @@ function renderThreadDetailPage(categorySlug = 'plant-care', threadSlug = 'water
   );
 }
 
+const mockAuth = (isAuthenticated: boolean) =>
+  ({ user: isAuthenticated ? { id: 1 } : null, isAuthenticated }) as unknown as ReturnType<
+    typeof useAuth
+  >;
+
 describe('ThreadDetailPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -54,6 +61,8 @@ describe('ThreadDetailPage', () => {
       categorySlug: '3-plant-care',
       threadSlug: '12-watering-tips',
     });
+    // Default to authenticated so the write UI renders; the logged-out test overrides.
+    vi.mocked(useAuth).mockReturnValue(mockAuth(true));
   });
 
   it('shows error (not infinite spinner) when threadSlug has no leading id', async () => {
@@ -258,6 +267,21 @@ describe('ThreadDetailPage', () => {
       expect(screen.getByText(/new replies are disabled/i)).toBeInTheDocument();
     });
     expect(screen.queryByRole('button', { name: /Post Reply/i })).not.toBeInTheDocument();
+  });
+
+  it('hides the composer and reaction buttons for a logged-out user', async () => {
+    vi.mocked(useAuth).mockReturnValue(mockAuth(false));
+    vi.spyOn(forumService, 'fetchThread').mockResolvedValue(createMockThread());
+    vi.spyOn(forumService, 'fetchPosts').mockResolvedValue({
+      items: [createMockPost({ id: '5', reaction_counts: { like: 1 } })],
+      meta: { count: 0, next: null, previous: null },
+    });
+
+    renderThreadDetailPage();
+
+    await screen.findByText(/Log in/i);
+    expect(screen.queryByRole('button', { name: /Post Reply/i })).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('React like')).not.toBeInTheDocument();
   });
 
   it('submits a published reply and shows it after refetch', async () => {

--- a/web/src/pages/forum/ThreadDetailPage.test.tsx
+++ b/web/src/pages/forum/ThreadDetailPage.test.tsx
@@ -15,10 +15,23 @@ vi.mock('react-router-dom', async () => {
   };
 });
 
-// Mock the forumService and AuthContext (PostCard calls useAuth internally)
+// Mock the forumService; stub TipTapEditor to a textarea (jsdom-hostile rich editor).
+// The aria-label is the placeholder so the reply composer ("Write a reply...") and
+// the edit editor ("body", no placeholder) are individually addressable.
 vi.mock('../../services/forumService');
-vi.mock('../../contexts/AuthContext', () => ({
-  useAuth: vi.fn(() => ({ user: null, isAuthenticated: false })),
+vi.mock('../../components/forum/TipTapEditor', () => ({
+  default: ({
+    onChange,
+    placeholder,
+  }: {
+    onChange?: (html: string) => void;
+    placeholder?: string;
+  }) => (
+    <textarea
+      aria-label={placeholder || 'body'}
+      onChange={(e) => onChange?.(`<p>${e.target.value}</p>`)}
+    />
+  ),
 }));
 
 /**
@@ -221,42 +234,155 @@ describe('ThreadDetailPage', () => {
     expect(screen.getByText(errorMessage)).toBeInTheDocument();
   });
 
-  it('shows read-only notice instead of reply form', async () => {
-    const mockThread = createMockThread();
-
-    vi.spyOn(forumService, 'fetchThread').mockResolvedValue(mockThread);
-    vi.spyOn(forumService, 'fetchPosts').mockResolvedValue({
-      items: [],
-      meta: { count: 0 },
-    });
+  it('shows a reply composer (no read-only notice)', async () => {
+    vi.spyOn(forumService, 'fetchThread').mockResolvedValue(createMockThread());
+    vi.spyOn(forumService, 'fetchPosts').mockResolvedValue({ items: [], meta: { count: 0 } });
 
     renderThreadDetailPage();
 
     await waitFor(() => {
-      expect(screen.getByText(/read-only/i)).toBeInTheDocument();
+      expect(screen.getByRole('heading', { name: /Post a Reply/i })).toBeInTheDocument();
     });
-
-    expect(screen.getByText(/coming soon/i)).toBeInTheDocument();
+    expect(screen.getByLabelText('Write a reply...')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Post Reply/i })).toBeInTheDocument();
+    expect(screen.queryByText(/coming soon/i)).not.toBeInTheDocument();
   });
 
-  it('does not show reply form or Post Your Reply heading', async () => {
-    const mockThread = createMockThread();
+  it('hides the reply composer when the thread is locked', async () => {
+    vi.spyOn(forumService, 'fetchThread').mockResolvedValue(createMockThread({ is_locked: true }));
+    vi.spyOn(forumService, 'fetchPosts').mockResolvedValue({ items: [], meta: { count: 0 } });
 
-    vi.spyOn(forumService, 'fetchThread').mockResolvedValue(mockThread);
+    renderThreadDetailPage();
+
+    await waitFor(() => {
+      expect(screen.getByText(/new replies are disabled/i)).toBeInTheDocument();
+    });
+    expect(screen.queryByRole('button', { name: /Post Reply/i })).not.toBeInTheDocument();
+  });
+
+  it('submits a published reply and shows it after refetch', async () => {
+    vi.spyOn(forumService, 'fetchThread').mockResolvedValue(createMockThread({ post_count: 0 }));
+    const fetchPostsSpy = vi
+      .spyOn(forumService, 'fetchPosts')
+      .mockResolvedValueOnce({ items: [], meta: { count: 0, next: null, previous: null } })
+      .mockResolvedValueOnce({
+        items: [
+          createMockPost({
+            id: '99',
+            body: [{ id: 'b', type: 'paragraph', value: '<p>my reply</p>' }],
+          }),
+        ],
+        meta: { count: 0, next: null, previous: null },
+      });
+    vi.spyOn(forumService, 'createPost').mockResolvedValue({ id: '99', status: 'published' });
+
+    renderThreadDetailPage();
+
+    await screen.findByRole('button', { name: /Post Reply/i });
+    await userEvent.type(screen.getByLabelText('Write a reply...'), 'my reply');
+    await userEvent.click(screen.getByRole('button', { name: /Post Reply/i }));
+
+    await waitFor(() => expect(screen.getByText('my reply')).toBeInTheDocument());
+    expect(forumService.createPost).toHaveBeenCalledWith({
+      thread: 12,
+      content: '<p>my reply</p>',
+    });
+    expect(fetchPostsSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('shows a moderation notice for a pending reply and does not refetch', async () => {
+    vi.spyOn(forumService, 'fetchThread').mockResolvedValue(createMockThread());
+    const fetchPostsSpy = vi
+      .spyOn(forumService, 'fetchPosts')
+      .mockResolvedValue({ items: [], meta: { count: 0 } });
+    vi.spyOn(forumService, 'createPost').mockResolvedValue({ id: '99', status: 'pending' });
+
+    renderThreadDetailPage();
+
+    await screen.findByRole('button', { name: /Post Reply/i });
+    await userEvent.type(screen.getByLabelText('Write a reply...'), 'spammy');
+    await userEvent.click(screen.getByRole('button', { name: /Post Reply/i }));
+
+    await waitFor(() => expect(screen.getByText(/awaiting moderation/i)).toBeInTheDocument());
+    expect(fetchPostsSpy).toHaveBeenCalledTimes(1); // initial load only — no refetch
+  });
+
+  it('deletes a post after confirmation and removes it from the list', async () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+    vi.spyOn(forumService, 'fetchThread').mockResolvedValue(createMockThread({ post_count: 1 }));
     vi.spyOn(forumService, 'fetchPosts').mockResolvedValue({
-      items: [],
-      meta: { count: 0 },
+      items: [
+        createMockPost({
+          id: '5',
+          can_delete: true,
+          body: [{ id: 'b', type: 'paragraph', value: '<p>doomed</p>' }],
+        }),
+      ],
+      meta: { count: 0, next: null, previous: null },
+    });
+    const deleteSpy = vi.spyOn(forumService, 'deletePost').mockResolvedValue(undefined);
+
+    renderThreadDetailPage();
+
+    await screen.findByText('doomed');
+    await userEvent.click(screen.getByTitle('Delete post'));
+
+    await waitFor(() => expect(deleteSpy).toHaveBeenCalledWith('5'));
+    expect(screen.queryByText('doomed')).not.toBeInTheDocument();
+  });
+
+  it('toggling a reaction updates the displayed count', async () => {
+    vi.spyOn(forumService, 'fetchThread').mockResolvedValue(createMockThread());
+    vi.spyOn(forumService, 'fetchPosts').mockResolvedValue({
+      items: [createMockPost({ id: '5', reaction_counts: { like: 0 } })],
+      meta: { count: 0, next: null, previous: null },
+    });
+    vi.spyOn(forumService, 'toggleReaction').mockResolvedValue({
+      reaction_counts: { like: 1 },
+      reacted: true,
     });
 
     renderThreadDetailPage();
 
-    // Block until the loaded state is rendered (the read-only notice appears),
-    // then assert the write UI is absent.
-    await screen.findByText(/read-only/i);
+    await screen.findByLabelText('React like');
+    expect(screen.getByLabelText('React like')).toHaveTextContent('0');
+    await userEvent.click(screen.getByLabelText('React like'));
 
-    expect(screen.queryByText(/Post Your Reply/i)).not.toBeInTheDocument();
-    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: /Post Reply/i })).not.toBeInTheDocument();
+    await waitFor(() => expect(screen.getByLabelText('React like')).toHaveTextContent('1'));
+    expect(forumService.toggleReaction).toHaveBeenCalledWith('5', 'like');
+  });
+
+  it('edits a post and shows the new body', async () => {
+    vi.spyOn(forumService, 'fetchThread').mockResolvedValue(createMockThread());
+    vi.spyOn(forumService, 'fetchPosts').mockResolvedValue({
+      items: [
+        createMockPost({
+          id: '5',
+          can_edit: true,
+          body: [{ id: 'b', type: 'paragraph', value: '<p>old</p>' }],
+        }),
+      ],
+      meta: { count: 0, next: null, previous: null },
+    });
+    vi.spyOn(forumService, 'updatePost').mockResolvedValue({
+      post: createMockPost({
+        id: '5',
+        body: [{ id: 'b', type: 'paragraph', value: '<p>new body</p>' }],
+      }),
+      status: 'published',
+    });
+
+    renderThreadDetailPage();
+
+    await screen.findByText('old');
+    await userEvent.click(screen.getByTitle('Edit post'));
+    await userEvent.type(await screen.findByLabelText('body'), 'new body');
+    await userEvent.click(screen.getByRole('button', { name: /^Save$/i }));
+
+    await waitFor(() =>
+      expect(forumService.updatePost).toHaveBeenCalledWith('5', { content: '<p>new body</p>' })
+    );
+    await waitFor(() => expect(screen.getByText('new body')).toBeInTheDocument());
   });
 
   it('shows Load More button when meta.next is present', async () => {

--- a/web/src/pages/forum/ThreadDetailPage.test.tsx
+++ b/web/src/pages/forum/ThreadDetailPage.test.tsx
@@ -292,6 +292,42 @@ describe('ThreadDetailPage', () => {
     expect(screen.getByLabelText('Write a reply...')).toHaveValue('');
   });
 
+  it('a published reply on a multi-page thread loads through to the new reply', async () => {
+    // The new reply is the NEWEST post (oldest-first ordering) → last cursor page.
+    // Reloading must follow the cursor to the end, not stop at page 1.
+    const opening = createMockPost({
+      id: '1',
+      is_first_post: true,
+      body: [{ id: 'b0', type: 'paragraph', value: '<p>opening</p>' }],
+    });
+    const reply = createMockPost({
+      id: '99',
+      body: [{ id: 'b9', type: 'paragraph', value: '<p>my reply</p>' }],
+    });
+    vi.spyOn(forumService, 'fetchThread').mockResolvedValue(createMockThread({ post_count: 1 }));
+    vi.spyOn(forumService, 'fetchPosts')
+      .mockResolvedValueOnce({
+        items: [opening],
+        meta: { count: 0, next: 'cursor-2', previous: null },
+      }) // mount: page 1
+      .mockResolvedValueOnce({
+        items: [opening],
+        meta: { count: 0, next: 'cursor-2', previous: null },
+      }) // reload: page 1
+      .mockResolvedValueOnce({ items: [reply], meta: { count: 0, next: null, previous: null } }); // reload: page 2 (the reply)
+    vi.spyOn(forumService, 'createPost').mockResolvedValue({ id: '99', status: 'published' });
+
+    renderThreadDetailPage();
+
+    await screen.findByRole('button', { name: /Post Reply/i });
+    await userEvent.type(screen.getByLabelText('Write a reply...'), 'my reply');
+    await userEvent.click(screen.getByRole('button', { name: /Post Reply/i }));
+
+    await waitFor(() => expect(screen.getByText('my reply')).toBeInTheDocument());
+    // Load More is gone — the cursor was followed to the end.
+    expect(screen.queryByText(/Load More Posts/i)).not.toBeInTheDocument();
+  });
+
   it('shows a moderation notice for a pending reply and does not refetch', async () => {
     vi.spyOn(forumService, 'fetchThread').mockResolvedValue(createMockThread());
     const fetchPostsSpy = vi

--- a/web/src/pages/forum/ThreadDetailPage.tsx
+++ b/web/src/pages/forum/ThreadDetailPage.tsx
@@ -28,6 +28,24 @@ function bodyToHtml(body: Post['body']): string {
   return typeof value === 'string' ? value : '';
 }
 
+// Posts are ordered oldest-first, so a brand-new reply is the NEWEST post and lands
+// on the last cursor page. Reload every page through to the end after posting so the
+// author actually sees their reply (refetching only page 1 would show the oldest 20).
+const MAX_REFRESH_PAGES = 50; // safety bound for pathologically long threads
+async function collectAllPosts(threadId: number): Promise<{ items: Post[]; next: string | null }> {
+  const items: Post[] = [];
+  let cursor: string | undefined;
+  let next: string | null = null;
+  for (let i = 0; i < MAX_REFRESH_PAGES; i++) {
+    const page = await fetchPosts(cursor ? { thread: threadId, cursor } : { thread: threadId });
+    items.push(...page.items);
+    next = page.meta.next ?? null;
+    if (!next) break;
+    cursor = next;
+  }
+  return { items, next };
+}
+
 /**
  * ThreadDetailPage Component
  *
@@ -141,9 +159,9 @@ export default function ThreadDetailPage() {
         setReplyBody('');
         setComposerKey((k) => k + 1); // remount the editor so it visibly clears
         if (res.status === 'published') {
-          const refreshed = await fetchPosts({ thread: topicId });
+          const refreshed = await collectAllPosts(topicId);
           setPosts(refreshed.items);
-          setNextCursor(refreshed.meta.next ?? null);
+          setNextCursor(refreshed.next);
           setTotalPosts((n) => n + 1);
         } else {
           setNotice('Your reply was submitted and is awaiting moderation.');
@@ -372,7 +390,12 @@ export default function ThreadDetailPage() {
           >
             {loadingMore
               ? 'Loading...'
-              : `Load More Posts (${Math.max(0, totalPosts - posts.length)} remaining)`}
+              : // totalPosts is reply_count (excludes the opening post), so compare it
+                // against loaded REPLIES, not all loaded posts, or it under-counts by 1.
+                `Load More Posts (${Math.max(
+                  0,
+                  totalPosts - posts.filter((p) => !p.is_first_post).length
+                )} remaining)`}
           </Button>
         </div>
       )}

--- a/web/src/pages/forum/ThreadDetailPage.tsx
+++ b/web/src/pages/forum/ThreadDetailPage.tsx
@@ -54,6 +54,9 @@ export default function ThreadDetailPage() {
   // Write-path state
   const [replyBody, setReplyBody] = useState<string>('');
   const [replySubmitting, setReplySubmitting] = useState<boolean>(false);
+  // TipTap's `content` is init-only, so resetting replyBody won't clear the editor;
+  // bumping this key remounts a fresh (empty) composer after a successful reply.
+  const [composerKey, setComposerKey] = useState<number>(0);
   const [editingPostId, setEditingPostId] = useState<string | null>(null);
   const [editBody, setEditBody] = useState<string>('');
   const [editSubmitting, setEditSubmitting] = useState<boolean>(false);
@@ -136,6 +139,7 @@ export default function ThreadDetailPage() {
         setNotice(null);
         const res = await createPost({ thread: topicId, content: replyBody });
         setReplyBody('');
+        setComposerKey((k) => k + 1); // remount the editor so it visibly clears
         if (res.status === 'published') {
           const refreshed = await fetchPosts({ thread: topicId });
           setPosts(refreshed.items);
@@ -385,6 +389,7 @@ export default function ThreadDetailPage() {
         >
           <h2 className="text-lg font-semibold text-ink">Post a Reply</h2>
           <TipTapEditor
+            key={composerKey}
             content={replyBody}
             onChange={setReplyBody}
             placeholder="Write a reply..."

--- a/web/src/pages/forum/ThreadDetailPage.tsx
+++ b/web/src/pages/forum/ThreadDetailPage.tsx
@@ -1,22 +1,38 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, FormEvent } from 'react';
 import { useParams, Link } from 'react-router-dom';
-import { fetchThread, fetchPosts } from '../../services/forumService';
+import {
+  fetchThread,
+  fetchPosts,
+  createPost,
+  updatePost,
+  deletePost,
+  toggleReaction,
+} from '../../services/forumService';
 import { parseLeadingId } from '../../utils/forumUrls';
 import PostCard from '../../components/forum/PostCard';
+import TipTapEditor from '../../components/forum/TipTapEditor';
 import LoadingSpinner from '../../components/ui/LoadingSpinner';
 import Button from '../../components/ui/Button';
 import { logger } from '../../utils/logger';
 import type { Thread, Post } from '@/types';
 import type { PaginatedResponse } from '@/types/forum';
 
+/** Strip tags + whitespace to detect an effectively-empty rich-text body. */
+function isBlankHtml(html: string): boolean {
+  return html.replace(/<[^>]*>/g, '').trim() === '';
+}
+
+/** Extract the editable HTML from a post body (the single paragraph block). */
+function bodyToHtml(body: Post['body']): string {
+  const value = body?.find((b) => b.type === 'paragraph')?.value;
+  return typeof value === 'string' ? value : '';
+}
+
 /**
  * ThreadDetailPage Component
  *
- * Displays a thread with its posts (read-only for Phase 1).
+ * Displays a thread with its posts and the write UI (reply, edit, delete, react).
  * Route: /forum/:categorySlug/:threadSlug
- *
- * Phase 2: reply/react/delete write UI removed for read-only Phase 1 —
- * restore from git history (commit 36f0a54) + the Phase 2 plan.
  */
 export default function ThreadDetailPage() {
   const { categorySlug, threadSlug } = useParams<{ categorySlug: string; threadSlug: string }>();
@@ -34,6 +50,15 @@ export default function ThreadDetailPage() {
   // totalPosts is seeded from thread.post_count (meta.count is hardcoded 0 by the service)
   const [totalPosts, setTotalPosts] = useState<number>(0);
   const [loadingMore, setLoadingMore] = useState<boolean>(false);
+
+  // Write-path state
+  const [replyBody, setReplyBody] = useState<string>('');
+  const [replySubmitting, setReplySubmitting] = useState<boolean>(false);
+  const [editingPostId, setEditingPostId] = useState<string | null>(null);
+  const [editBody, setEditBody] = useState<string>('');
+  const [editSubmitting, setEditSubmitting] = useState<boolean>(false);
+  // A transient banner for write errors + moderation outcomes.
+  const [notice, setNotice] = useState<string | null>(null);
 
   // Load thread and initial posts
   useEffect(() => {
@@ -73,7 +98,7 @@ export default function ThreadDetailPage() {
     loadData();
   }, [topicId, threadSlug, categorySlug]);
 
-  // Load more posts (cursor pagination) — Phase 2
+  // Load more posts (cursor pagination)
   const handleLoadMore = useCallback(async () => {
     if (topicId == null || !nextCursor) return;
 
@@ -92,11 +117,116 @@ export default function ThreadDetailPage() {
         error: err,
         context: { threadId: thread?.id },
       });
-      alert(`Failed to load more posts: ${err instanceof Error ? err.message : 'Unknown error'}`);
+      setNotice(
+        `Failed to load more posts: ${err instanceof Error ? err.message : 'Unknown error'}`
+      );
     } finally {
       setLoadingMore(false);
     }
   }, [nextCursor, topicId, thread?.id]);
+
+  // Submit a reply. A published reply is refetched into the list; a pending reply
+  // (untrusted author) is unlisted, so we only confirm it was submitted.
+  const handleReply = useCallback(
+    async (e: FormEvent<HTMLFormElement>) => {
+      e.preventDefault();
+      if (topicId == null || isBlankHtml(replyBody)) return;
+      try {
+        setReplySubmitting(true);
+        setNotice(null);
+        const res = await createPost({ thread: topicId, content: replyBody });
+        setReplyBody('');
+        if (res.status === 'published') {
+          const refreshed = await fetchPosts({ thread: topicId });
+          setPosts(refreshed.items);
+          setNextCursor(refreshed.meta.next ?? null);
+          setTotalPosts((n) => n + 1);
+        } else {
+          setNotice('Your reply was submitted and is awaiting moderation.');
+        }
+      } catch (err) {
+        logger.error('Error posting reply', {
+          component: 'ThreadDetailPage',
+          error: err,
+          context: { threadId: topicId },
+        });
+        setNotice(err instanceof Error ? err.message : 'Failed to post reply');
+      } finally {
+        setReplySubmitting(false);
+      }
+    },
+    [topicId, replyBody]
+  );
+
+  const handleReact = useCallback(async (postId: string, reactionType: string) => {
+    try {
+      const result = await toggleReaction(postId, reactionType);
+      setPosts((prev) =>
+        prev.map((p) => (p.id === postId ? { ...p, reaction_counts: result.reaction_counts } : p))
+      );
+    } catch (err) {
+      logger.error('Error toggling reaction', {
+        component: 'ThreadDetailPage',
+        error: err,
+        context: { postId, reactionType },
+      });
+      setNotice(err instanceof Error ? err.message : 'Failed to react');
+    }
+  }, []);
+
+  const handleDelete = useCallback(async (post: Post) => {
+    if (!window.confirm('Delete this post? This cannot be undone.')) return;
+    try {
+      await deletePost(post.id);
+      setPosts((prev) => prev.filter((p) => p.id !== post.id));
+      setTotalPosts((n) => Math.max(0, n - 1));
+    } catch (err) {
+      logger.error('Error deleting post', {
+        component: 'ThreadDetailPage',
+        error: err,
+        context: { postId: post.id },
+      });
+      setNotice(err instanceof Error ? err.message : 'Failed to delete post');
+    }
+  }, []);
+
+  const handleEdit = useCallback((post: Post) => {
+    setEditingPostId(post.id);
+    setEditBody(bodyToHtml(post.body));
+  }, []);
+
+  const handleEditSubmit = useCallback(
+    async (e: FormEvent<HTMLFormElement>) => {
+      e.preventDefault();
+      if (editingPostId == null || isBlankHtml(editBody)) return;
+      try {
+        setEditSubmitting(true);
+        setNotice(null);
+        const res = await updatePost(editingPostId, { content: editBody });
+        setPosts((prev) => prev.map((p) => (p.id === editingPostId ? res.post : p)));
+        if (res.status === 'pending') {
+          setNotice('Your edit was submitted and is awaiting moderation.');
+        }
+        setEditingPostId(null);
+        setEditBody('');
+      } catch (err) {
+        logger.error('Error editing post', {
+          component: 'ThreadDetailPage',
+          error: err,
+          context: { postId: editingPostId },
+        });
+        setNotice(err instanceof Error ? err.message : 'Failed to save edit');
+      } finally {
+        setEditSubmitting(false);
+      }
+    },
+    [editingPostId, editBody]
+  );
+
+  const cancelEdit = useCallback(() => {
+    setEditingPostId(null);
+    setEditBody('');
+  }, []);
 
   if (loading) {
     return (
@@ -181,13 +311,49 @@ export default function ThreadDetailPage() {
         </div>
       </div>
 
+      {/* Write-path notice (errors + moderation outcomes) */}
+      {notice && (
+        <div className="mb-6 rounded-lg border border-line bg-surface-2 px-4 py-3 text-ink-2">
+          {notice}
+        </div>
+      )}
+
       {/* Posts List */}
       <div className="space-y-4 mb-8">
-        {posts.map((post) => (
-          <div key={post.id} id={`post-${post.id}`}>
-            <PostCard post={post} />
-          </div>
-        ))}
+        {posts.map((post) =>
+          editingPostId === post.id ? (
+            <form
+              key={post.id}
+              onSubmit={handleEditSubmit}
+              className="bg-surface-2 rounded-lg shadow-md p-6 space-y-3"
+            >
+              <span className="block text-sm font-medium text-ink-2">Edit post</span>
+              <TipTapEditor key={post.id} content={editBody} onChange={setEditBody} />
+              <div className="flex gap-2">
+                <Button
+                  type="submit"
+                  variant="primary"
+                  disabled={isBlankHtml(editBody) || editSubmitting}
+                  loading={editSubmitting}
+                >
+                  Save
+                </Button>
+                <Button type="button" variant="outline" onClick={cancelEdit}>
+                  Cancel
+                </Button>
+              </div>
+            </form>
+          ) : (
+            <div key={post.id} id={`post-${post.id}`}>
+              <PostCard
+                post={post}
+                onEdit={handleEdit}
+                onDelete={handleDelete}
+                onReact={handleReact}
+              />
+            </div>
+          )
+        )}
       </div>
 
       {/* Load More Button (cursor pagination) */}
@@ -207,10 +373,32 @@ export default function ThreadDetailPage() {
         </div>
       )}
 
-      {/* Read-only notice — Phase 2 will restore reply/react/delete write UI */}
-      <div className="mt-8 rounded-lg border border-line bg-surface-2 p-6 text-center">
-        <p className="text-ink-2">🔒 Replies are coming soon — the forum is read-only for now.</p>
-      </div>
+      {/* Reply composer — hidden when the thread is locked/closed */}
+      {thread.is_locked ? (
+        <div className="mt-8 rounded-lg border border-line bg-surface-2 p-6 text-center">
+          <p className="text-ink-2">🔒 This thread is locked — new replies are disabled.</p>
+        </div>
+      ) : (
+        <form
+          onSubmit={handleReply}
+          className="mt-8 bg-surface-2 rounded-lg shadow-md p-6 space-y-3"
+        >
+          <h2 className="text-lg font-semibold text-ink">Post a Reply</h2>
+          <TipTapEditor
+            content={replyBody}
+            onChange={setReplyBody}
+            placeholder="Write a reply..."
+          />
+          <Button
+            type="submit"
+            variant="primary"
+            disabled={isBlankHtml(replyBody) || replySubmitting}
+            loading={replySubmitting}
+          >
+            Post Reply
+          </Button>
+        </form>
+      )}
     </div>
   );
 }

--- a/web/src/pages/forum/ThreadDetailPage.tsx
+++ b/web/src/pages/forum/ThreadDetailPage.tsx
@@ -13,6 +13,7 @@ import PostCard from '../../components/forum/PostCard';
 import TipTapEditor from '../../components/forum/TipTapEditor';
 import LoadingSpinner from '../../components/ui/LoadingSpinner';
 import Button from '../../components/ui/Button';
+import { useAuth } from '../../contexts/AuthContext';
 import { logger } from '../../utils/logger';
 import type { Thread, Post } from '@/types';
 import type { PaginatedResponse } from '@/types/forum';
@@ -54,6 +55,7 @@ async function collectAllPosts(threadId: number): Promise<{ items: Post[]; next:
  */
 export default function ThreadDetailPage() {
   const { categorySlug, threadSlug } = useParams<{ categorySlug: string; threadSlug: string }>();
+  const { isAuthenticated } = useAuth();
 
   // The route param is a hybrid "id-slug"; lookups use the leading topic id.
   const topicId = parseLeadingId(threadSlug);
@@ -371,7 +373,7 @@ export default function ThreadDetailPage() {
                 post={post}
                 onEdit={handleEdit}
                 onDelete={handleDelete}
-                onReact={handleReact}
+                onReact={isAuthenticated ? handleReact : undefined}
               />
             </div>
           )
@@ -404,6 +406,15 @@ export default function ThreadDetailPage() {
       {thread.is_locked ? (
         <div className="mt-8 rounded-lg border border-line bg-surface-2 p-6 text-center">
           <p className="text-ink-2">🔒 This thread is locked — new replies are disabled.</p>
+        </div>
+      ) : !isAuthenticated ? (
+        <div className="mt-8 rounded-lg border border-line bg-surface-2 p-6 text-center">
+          <p className="text-ink-2">
+            <Link to="/login" className="text-primary hover:underline">
+              Log in
+            </Link>{' '}
+            to post a reply.
+          </p>
         </div>
       ) : (
         <form

--- a/web/src/services/forumService.test.ts
+++ b/web/src/services/forumService.test.ts
@@ -262,52 +262,58 @@ describe('forumService (wagtail_forum API contract)', () => {
 
   // --- Write functions (structurally intact, Phase 2) -----------------------
 
-  it('createThread posts to /categories/{id}/topics/create/ (Phase 2 placeholder)', async () => {
-    fetchMock.mockResolvedValueOnce(okJson({ topic: backendTopicDetail }));
-    const t = await createThread({
-      title: 'Succulent help',
-      category: 3,
-      first_post_content: 'hello',
-      first_post_format: 'html',
+  it('createThread posts to /boards/{slug}/topics/ with {title, slug, body[]}', async () => {
+    fetchMock.mockResolvedValueOnce(
+      okJson({ id: 12, slug: 'succulent-help', status: 'published' })
+    );
+    const r = await createThread({
+      boardSlug: 'plant-care',
+      title: 'Succulent help!',
+      content: '<p>hi</p>',
     });
-    expect(t.id).toBe('12');
+    expect(r).toEqual({ id: '12', slug: 'succulent-help', status: 'published' });
     const [url, opts] = fetchMock.mock.calls[0];
-    expect(url).toContain('/categories/3/topics/create/');
+    expect(url).toContain('/boards/plant-care/topics/');
     expect(opts.method).toBe('POST');
+    expect(JSON.parse(opts.body)).toEqual({
+      title: 'Succulent help!',
+      slug: 'succulent-help',
+      body: [{ type: 'paragraph', value: '<p>hi</p>' }],
+    });
   });
 
-  it('createPost posts to /posts/create/ and unwraps {data}', async () => {
-    fetchMock.mockResolvedValueOnce(okJson({ message: 'ok', data: backendPost }));
-    const p = await createPost({ thread: 12, content_raw: 'hi', content_format: 'html' });
-    expect(p.id).toBe('50');
+  it('createPost posts to /topics/{id}/posts/ with {body[]}', async () => {
+    fetchMock.mockResolvedValueOnce(okJson({ id: 51, status: 'pending' }));
+    const r = await createPost({ thread: 12, content: '<p>hi</p>' });
+    expect(r).toEqual({ id: '51', status: 'pending' });
     const [url, opts] = fetchMock.mock.calls[0];
-    expect(url).toContain('/posts/create/');
-    expect(JSON.parse(opts.body)).toMatchObject({ topic: 12, content: 'hi' });
+    expect(url).toContain('/topics/12/posts/');
+    expect(opts.method).toBe('POST');
+    expect(JSON.parse(opts.body)).toEqual({ body: [{ type: 'paragraph', value: '<p>hi</p>' }] });
   });
 
-  it('createPost throws a clear error when the response is missing {data}', async () => {
-    fetchMock.mockResolvedValueOnce(okJson({ message: 'ok', post: backendPost }));
-    await expect(
-      createPost({ thread: 12, content_raw: 'hi', content_format: 'html' })
-    ).rejects.toThrow(/missing "data"/);
-  });
-
-  it('updatePost maps topic_id to thread', async () => {
-    fetchMock.mockResolvedValueOnce(okJson({ data: { ...backendPost, topic_id: 77 } }));
-    const p = await updatePost('50', { content_raw: '<p>edited</p>', content_format: 'html' });
-    expect(p.thread).toBe('77');
+  it('updatePost PATCHes /posts/{id}/ with {body[]} and returns {post, status}', async () => {
+    fetchMock.mockResolvedValueOnce(
+      okJson({ ...backendPost, id: 50, topic_id: 77, moderation_status: 'published' })
+    );
+    const r = await updatePost('50', { content: '<p>edited</p>' });
+    expect(r.status).toBe('published');
+    expect(r.post.id).toBe('50');
+    expect(r.post.thread).toBe('77');
     const [url, opts] = fetchMock.mock.calls[0];
     expect(url).toContain('/posts/50/');
     expect(opts.method).toBe('PATCH');
+    expect(JSON.parse(opts.body)).toEqual({
+      body: [{ type: 'paragraph', value: '<p>edited</p>' }],
+    });
   });
 
-  it('deletePost hits the /delete/ suffix endpoint', async () => {
+  it('deletePost DELETEs /posts/{id}/ (no /delete/ suffix)', async () => {
     fetchMock.mockResolvedValueOnce({ ok: true, status: 204, json: async () => undefined });
     await deletePost('50');
-    expect(fetchMock).toHaveBeenCalledWith(
-      expect.stringContaining('/posts/50/delete/'),
-      expect.objectContaining({ method: 'DELETE' })
-    );
+    const [url, opts] = fetchMock.mock.calls[0];
+    expect(url).toMatch(/\/posts\/50\/$/);
+    expect(opts.method).toBe('DELETE');
   });
 
   it('toggleReaction posts {type} and returns {reaction_counts, reacted}', async () => {
@@ -354,9 +360,7 @@ describe('forumService (wagtail_forum API contract)', () => {
       status: 429,
       json: async () => ({ detail: 'Rate limit exceeded' }),
     });
-    await expect(createPost({ thread: 12, content_raw: 'x' })).rejects.toThrow(
-      'Rate limit exceeded'
-    );
+    await expect(createPost({ thread: 12, content: 'x' })).rejects.toThrow('Rate limit exceeded');
   });
 
   it('propagates backend errors with canonical message field', async () => {
@@ -365,6 +369,6 @@ describe('forumService (wagtail_forum API contract)', () => {
       status: 403,
       json: async () => ({ message: 'Permission denied' }),
     });
-    await expect(createPost({ thread: 12, content_raw: 'x' })).rejects.toThrow('Permission denied');
+    await expect(createPost({ thread: 12, content: 'x' })).rejects.toThrow('Permission denied');
   });
 });

--- a/web/src/services/forumService.test.ts
+++ b/web/src/services/forumService.test.ts
@@ -10,7 +10,6 @@ import {
   updatePost,
   deletePost,
   toggleReaction,
-  fetchReactions,
   uploadPostImage,
   deletePostImage,
   searchForum,
@@ -311,35 +310,14 @@ describe('forumService (wagtail_forum API contract)', () => {
     );
   });
 
-  it('toggleReaction posts reaction_type and normalizes counts', async () => {
-    fetchMock.mockResolvedValueOnce(
-      okJson({
-        action: 'added',
-        reaction_type: 'like',
-        reactions: { like: { count: 3, users: [] } },
-        user_reactions: ['like'],
-      })
-    );
+  it('toggleReaction posts {type} and returns {reaction_counts, reacted}', async () => {
+    fetchMock.mockResolvedValueOnce(okJson({ reaction_counts: { like: 3 }, reacted: true }));
     const r = await toggleReaction('50', 'like');
-    expect(r).toMatchObject({
-      action: 'added',
-      reaction_counts: { like: 3 },
-      user_reactions: ['like'],
-    });
+    expect(r).toEqual({ reaction_counts: { like: 3 }, reacted: true });
     const [url, opts] = fetchMock.mock.calls[0];
     expect(url).toContain('/posts/50/reactions/');
-    expect(JSON.parse(opts.body)).toEqual({ reaction_type: 'like' });
-  });
-
-  it('fetchReactions normalizes counts and user_reactions', async () => {
-    fetchMock.mockResolvedValueOnce(
-      okJson({
-        reactions: { like: { count: 3, users: [] } },
-        user_reactions: [],
-      })
-    );
-    const r = await fetchReactions('50');
-    expect(r.reaction_counts).toEqual({ like: 3 });
+    expect(opts.method).toBe('POST');
+    expect(JSON.parse(opts.body)).toEqual({ type: 'like' });
   });
 
   it('uploadPostImage sends FormData with the plural field name to images/upload/', async () => {

--- a/web/src/services/forumService.ts
+++ b/web/src/services/forumService.ts
@@ -220,44 +220,15 @@ export async function deletePost(postId: string): Promise<void> {
 // Reactions (toggle model)
 // ---------------------------------------------------------------------------
 
-interface BackendReactionResponse {
-  reactions?: Record<string, { count: number; users: unknown[] }>;
-  user_reactions?: string[];
-  action?: 'added' | 'removed';
-  reaction_type?: string;
-}
-
-function toCounts(r: BackendReactionResponse): Record<string, number> {
-  const counts: Record<string, number> = {};
-  for (const [type, info] of Object.entries(r.reactions || {})) counts[type] = info.count;
-  return counts;
-}
-
-/** Toggle a reaction on a post; returns updated counts + the user's active reactions. */
+/** Toggle a reaction on a post; returns updated counts + this user's resulting state. */
 export async function toggleReaction(
   postId: string,
   reactionType: string
 ): Promise<ReactionToggleResult> {
-  const res = await authenticatedFetch<BackendReactionResponse>(
-    `${FORUM_BASE}/posts/${postId}/reactions/`,
-    { method: 'POST', body: JSON.stringify({ reaction_type: reactionType }) }
-  );
-  return {
-    action: res.action || 'added',
-    reaction_type: res.reaction_type || reactionType,
-    reaction_counts: toCounts(res),
-    user_reactions: res.user_reactions || [],
-  };
-}
-
-/** Read reaction counts + the current user's active reactions for a post. */
-export async function fetchReactions(
-  postId: string
-): Promise<{ reaction_counts: Record<string, number>; user_reactions: string[] }> {
-  const res = await authenticatedFetch<BackendReactionResponse>(
-    `${FORUM_BASE}/posts/${postId}/reactions/`
-  );
-  return { reaction_counts: toCounts(res), user_reactions: res.user_reactions || [] };
+  return authenticatedFetch<ReactionToggleResult>(`${FORUM_BASE}/posts/${postId}/reactions/`, {
+    method: 'POST',
+    body: JSON.stringify({ type: reactionType }),
+  });
 }
 
 // ---------------------------------------------------------------------------

--- a/web/src/services/forumService.ts
+++ b/web/src/services/forumService.ts
@@ -1,10 +1,9 @@
 /**
- * Forum API Service — translation layer.
+ * Forum API Service — translation layer for the wagtail_forum REST API.
  *
- * READ functions target the wagtail_forum API contract (Tasks 1-4).
- * WRITE functions (createThread, createPost, updatePost, deletePost,
- * toggleReaction, image fns) are Phase 2/3 — left structurally intact
- * so they still compile, but their endpoints will 404 until Phase 2 lands.
+ * READ and WRITE functions (create topic/reply, edit, delete, react) target the
+ * wagtail_forum contract. The image functions remain on the legacy shape pending
+ * PR-3 (inline-image upload + render); they are not wired into any compose UI.
  *
  * Cookie-based JWT auth with CSRF on mutating requests.
  */
@@ -31,14 +30,25 @@ import type {
   Post,
   Attachment,
   PaginatedResponse,
+  CreateTopicInput,
+  CreateTopicResult,
+  CreateReplyInput,
+  CreateReplyResult,
   UpdatePostInput,
+  EditPostResult,
   SearchForumOptions,
   SearchForumResponse,
   ReactionToggleResult,
 } from '../types/forum';
+import { slugifyTitle } from '../utils/forumUrls';
 
 const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:8000';
 const FORUM_BASE = `${API_URL}/api/v1/forum`;
+
+/** Wrap composer HTML as the forum body StreamField (a single paragraph block). */
+function toBodyBlocks(html: string): Array<{ type: 'paragraph'; value: string }> {
+  return [{ type: 'paragraph', value: html }];
+}
 
 interface DrfPage<T> {
   results?: T[];
@@ -135,27 +145,17 @@ export async function fetchThread(topicId: number): Promise<Thread> {
   return mapTopicDetailToThread(data);
 }
 
-export async function createThread(data: {
-  title: string;
-  category: number;
-  first_post_content: string;
-  first_post_format?: string;
-}): Promise<Thread> {
-  // Phase 2 will migrate this to POST /boards/{slug}/topics/ with a body[] payload.
-  // Left structurally intact so it compiles; endpoint will 404 until Phase 2.
-  const { title, category, first_post_content, first_post_format = 'plain' } = data;
-  const res = await authenticatedFetch<{ topic: BackendTopicDetail }>(
-    `${FORUM_BASE}/categories/${category}/topics/create/`,
-    {
-      method: 'POST',
-      body: JSON.stringify({
-        subject: title,
-        content: first_post_content,
-        content_format: first_post_format,
-      }),
-    }
-  );
-  return mapTopicDetailToThread(res.topic);
+export async function createThread(data: CreateTopicInput): Promise<CreateTopicResult> {
+  const { boardSlug, title, content } = data;
+  const res = await authenticatedFetch<{
+    id: number;
+    slug: string;
+    status: 'published' | 'pending';
+  }>(`${FORUM_BASE}/boards/${boardSlug}/topics/`, {
+    method: 'POST',
+    body: JSON.stringify({ title, slug: slugifyTitle(title), body: toBodyBlocks(content) }),
+  });
+  return { id: String(res.id), slug: res.slug, status: res.status };
 }
 
 // ---------------------------------------------------------------------------
@@ -186,34 +186,27 @@ export async function fetchPosts(options: {
   };
 }
 
-export async function createPost(data: {
-  thread: number;
-  content_raw: string;
-  content_format?: string;
-}): Promise<Post> {
-  // Phase 2 will migrate to POST /topics/{id}/replies/ with a body[] payload.
-  const { thread, content_raw, content_format = 'plain' } = data;
-  const res = await authenticatedFetch<{ data: BackendPost }>(`${FORUM_BASE}/posts/create/`, {
-    method: 'POST',
-    body: JSON.stringify({ topic: thread, content: content_raw, content_format }),
-  });
-  if (!res?.data) {
-    throw new Error('createPost: response is missing "data" — unexpected response shape');
-  }
-  return mapPostToPost(res.data, String(thread));
+export async function createPost(data: CreateReplyInput): Promise<CreateReplyResult> {
+  const { thread, content } = data;
+  const res = await authenticatedFetch<{ id: number; status: 'published' | 'pending' }>(
+    `${FORUM_BASE}/topics/${thread}/posts/`,
+    { method: 'POST', body: JSON.stringify({ body: toBodyBlocks(content) }) }
+  );
+  return { id: String(res.id), status: res.status };
 }
 
-export async function updatePost(postId: string, data: UpdatePostInput): Promise<Post> {
-  const { content_raw, content_format } = data;
-  const res = await authenticatedFetch<{ data: BackendPost }>(`${FORUM_BASE}/posts/${postId}/`, {
+export async function updatePost(postId: string, data: UpdatePostInput): Promise<EditPostResult> {
+  const res = await authenticatedFetch<
+    BackendPost & { moderation_status: 'published' | 'pending' }
+  >(`${FORUM_BASE}/posts/${postId}/`, {
     method: 'PATCH',
-    body: JSON.stringify({ content: content_raw, content_format }),
+    body: JSON.stringify({ body: toBodyBlocks(data.content) }),
   });
-  return mapPostToPost(res.data, String(res.data.topic_id));
+  return { post: mapPostToPost(res, String(res.topic_id)), status: res.moderation_status };
 }
 
 export async function deletePost(postId: string): Promise<void> {
-  await authenticatedFetch<void>(`${FORUM_BASE}/posts/${postId}/delete/`, { method: 'DELETE' });
+  await authenticatedFetch<void>(`${FORUM_BASE}/posts/${postId}/`, { method: 'DELETE' });
 }
 
 // ---------------------------------------------------------------------------

--- a/web/src/types/forum.ts
+++ b/web/src/types/forum.ts
@@ -169,11 +169,42 @@ export interface CreatePostInput {
 }
 
 /**
- * Update post input
+ * Update post input — body is HTML; the service wraps it as a paragraph block.
  */
 export interface UpdatePostInput {
-  content_raw: string;
-  content_format: string;
+  content: string;
+}
+
+/** Create-topic input (POST /boards/{slug}/topics/). content is HTML. */
+export interface CreateTopicInput {
+  boardSlug: string;
+  title: string;
+  content: string;
+}
+
+/** Create-reply input (POST /topics/{id}/posts/). content is HTML. */
+export interface CreateReplyInput {
+  thread: number;
+  content: string;
+}
+
+/** Thin create-topic response — the topic may be pending moderation. */
+export interface CreateTopicResult {
+  id: string;
+  slug: string;
+  status: 'published' | 'pending';
+}
+
+/** Thin create-reply response — the reply may be pending moderation. */
+export interface CreateReplyResult {
+  id: string;
+  status: 'published' | 'pending';
+}
+
+/** Edit response — the (currently-live) post plus its moderation outcome. */
+export interface EditPostResult {
+  post: Post;
+  status: 'published' | 'pending';
 }
 
 /**

--- a/web/src/types/forum.ts
+++ b/web/src/types/forum.ts
@@ -222,10 +222,8 @@ export interface SearchForumResponse {
 
 /** Result of toggling a reaction on a post (backend toggle endpoint). */
 export interface ReactionToggleResult {
-  action: 'added' | 'removed';
-  reaction_type: string;
   /** Map of reaction_type -> count, e.g. { like: 5, love: 2 } */
   reaction_counts: Record<string, number>;
-  /** Reaction types the current user currently has active on this post */
-  user_reactions: string[];
+  /** Whether the current user now has this reaction active on the post. */
+  reacted: boolean;
 }


### PR DESCRIPTION
## What

PR-2b of the forum Spec 2 epic (todo 231): migrate the React web forum **write** client off the retired machina dialect onto the new `wagtail_forum` REST routes and re-enable the compose/reply/edit/delete/react UI. The read path landed earlier; this completes the interactive web forum.

**Web-only diff** (disjoint from the backend PR-2a). Branch off `main`.

## Prerequisite

The matching backend write path is **PR #395 (PR-2a)** — these routes go live when that merges. The web suite mocks `fetch`, so this PR is fully verifiable on its own; live end-to-end works once #395 is deployed.

## Changes

**Service (`forumService.ts`)** onto the PR-2a contract:
- `createThread` → `POST /boards/{slug}/topics/` — client slugifies the title; returns `{id, slug, status}`
- `createPost` → `POST /topics/{id}/posts/` — returns `{id, status}`
- `updatePost` → `PATCH /posts/{id}/` — returns the full post + `moderation_status`
- `deletePost` → `DELETE /posts/{id}/` (drops the machina `/delete/` suffix)
- `toggleReaction` → `{type}` request, `{reaction_counts, reacted}` response; `fetchReactions` removed
- bodies wrapped as a single `paragraph` StreamField block via `toBodyBlocks`

**Compose UI:**
- New `NewThreadPage` + `/forum/new-thread` route. A **published** topic navigates into the new thread; a **pending** (untrusted-author) topic is `live=False` and would 404, so it shows a moderation notice and returns to the board.
- `ThreadDetailPage` gains the reply composer (hidden when the thread is locked), inline edit, delete-with-confirm, and reaction toggles; the read-only notice is gone. A published reply refetches; a pending reply/edit shows an "awaiting moderation" notice.
- `PostCard` now gates edit/delete on the backend `can_edit`/`can_delete` (the old client-side author check was dead — the mapper sets `author.id=''`).

## Verification

- Full web suite **559 passed** (37 files); `tsc --noEmit` clean; ESLint 0 errors.
- Machina write-path sweep of `forumService.ts` is empty (`topics/create/`, `posts/create/`, `posts/{id}/delete/`, `reaction_type` all gone). The only legacy paths left are the **image** fns — see below.

## Out of scope (PR-3)

Inline images: `POST /topics/{id}/images/`, the `validate_forum_body` relax, the web `StreamFieldRenderer` `image` case, and migrating the forum image client fns. A small UX nicety also remains: the composer toolbar still offers heading/quote/strike/code-block marks that the server's nh3 allowlist flattens to plain text (graceful — no data loss). **Todo 231 stays open until PR-3.**

## Merge

Owner-merge — not auto-armed (matching PR-1 / PR-2a cadence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)