### PR TITLE
users: require verified email before auto-linking Google login to an account

### DIFF
--- a/.claude/agents/security-reviewer.md
+++ b/.claude/agents/security-reviewer.md
@@ -58,6 +58,9 @@ Review only the files passed to you. Do not read the full repo. You run in paral
 - [ ] CORS `ALLOWED_ORIGINS` must list port 5174 (React dev) — not 5173
 - [ ] Mutating requests from frontend must include `X-CSRFToken` header + `credentials: 'include'`
 - [ ] JWT tokens never stored in localStorage — backend uses HttpOnly cookies or flutter_secure_storage
+- [ ] OAuth/federated account match-or-create gates on a **provider-verified** email (Google `verified_email`/`email_verified`, GitHub `primary AND verified`, allauth `EmailAddress.verified`, Firebase `email_verified` or trusted provider) and fails closed when the signal is absent — matching an existing account by an unverified email is an account-takeover vector; auto-creating off one is a duplicate-account vector. See `authentication.md` → "Trust only provider-verified emails"
+- [ ] An allauth `pre_social_login` that finds an unverified-email collision must ABORT the pipeline (`raise ImmediateHttpResponse(...)`), never bare-`return` — under `SOCIALACCOUNT_AUTO_SIGNUP` a bare return lets allauth auto-create a second account holding the victim's email
+- [ ] A guard that enforces a rule by stripping an input (e.g. removing an unverified `email`) is only safe if the downstream consumer hard-stops on the missing input — verify the fail-closed path, don't assume it
 
 **Firebase Security Rules**
 

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -794,42 +794,42 @@
         "filename": "backend/docs/patterns/security/authentication.md",
         "hashed_secret": "11e3bae57afc6e27ee2cad9dbeffefb953a5ff62",
         "is_verified": false,
-        "line_number": 31
+        "line_number": 33
       },
       {
         "type": "Secret Keyword",
         "filename": "backend/docs/patterns/security/authentication.md",
         "hashed_secret": "87af9738a6f10a50ff3a08dbb66c06346e1cc950",
         "is_verified": false,
-        "line_number": 32
+        "line_number": 34
       },
       {
         "type": "Secret Keyword",
         "filename": "backend/docs/patterns/security/authentication.md",
         "hashed_secret": "0d9042a91bf1a2f4e724bb01b41854c2c8168931",
         "is_verified": false,
-        "line_number": 293
+        "line_number": 307
       },
       {
         "type": "Secret Keyword",
         "filename": "backend/docs/patterns/security/authentication.md",
         "hashed_secret": "e8662cfb96bd9c7fe84c31d76819ec3a92c80e63",
         "is_verified": false,
-        "line_number": 302
+        "line_number": 316
       },
       {
         "type": "Secret Keyword",
         "filename": "backend/docs/patterns/security/authentication.md",
         "hashed_secret": "0b6ec68df700dec4dcd64babd0eda1edccddace1",
         "is_verified": false,
-        "line_number": 325
+        "line_number": 340
       },
       {
         "type": "Secret Keyword",
         "filename": "backend/docs/patterns/security/authentication.md",
         "hashed_secret": "7288edd0fc3ffcbe93a0cf06e3568e28521687bc",
         "is_verified": false,
-        "line_number": 462
+        "line_number": 519
       }
     ],
     "backend/docs/patterns/security/csrf-protection.md": [
@@ -1514,5 +1514,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-22T16:04:42Z"
+  "generated_at": "2026-06-24T14:43:31Z"
 }

--- a/backend/apps/users/oauth_adapters.py
+++ b/backend/apps/users/oauth_adapters.py
@@ -55,7 +55,9 @@ class CustomSocialAccountAdapter(DefaultSocialAccountAdapter):
         # A local account already owns this email and this social account is not
         # yet linked. Only proceed when the provider has VERIFIED the email —
         # linking (or creating) off an unverified email is an account-takeover
-        # vector, the same stance the custom oauth_views path takes.
+        # vector. This is the allauth arm of the verified-email invariant
+        # (canonical: docs/patterns/security/authentication.md → "Trust only
+        # provider-verified emails").
         #
         # A bare `return` here is NOT safe: under SOCIALACCOUNT_AUTO_SIGNUP allauth
         # would then auto-create a SECOND account holding the victim's email

--- a/backend/apps/users/oauth_adapters.py
+++ b/backend/apps/users/oauth_adapters.py
@@ -6,11 +6,13 @@ import logging
 from typing import Any, Optional
 
 from allauth.account.adapter import DefaultAccountAdapter
+from allauth.core.exceptions import ImmediateHttpResponse
 from allauth.socialaccount.adapter import DefaultSocialAccountAdapter
 from allauth.socialaccount.models import SocialLogin
 from apps.core.utils.pii_safe_logging import log_safe_user_context
+from apps.users.oauth_views import get_oauth_redirect_url
 from django.contrib.auth import get_user_model
-from django.http import HttpRequest
+from django.http import HttpRequest, HttpResponseRedirect
 from django.urls import reverse
 
 logger = logging.getLogger(__name__)
@@ -31,35 +33,53 @@ class CustomSocialAccountAdapter(DefaultSocialAccountAdapter):
             request: Django HTTP request object
             sociallogin: SocialLogin instance containing OAuth provider data
         """
-        # Check if user exists with same email
-        if (
-            sociallogin.account.provider == "google"
-            or sociallogin.account.provider == "github"
-        ):
-            email = sociallogin.account.extra_data.get("email")
-            if email:
-                # Only auto-link to an existing local account when the provider
-                # has VERIFIED the email. Linking by an unverified email is an
-                # account-takeover vector — the same stance the custom
-                # oauth_views path takes. allauth's connect() bypasses
-                # SOCIALACCOUNT_EMAIL_VERIFICATION, so we gate it explicitly here.
-                if not self._provider_email_verified(sociallogin, email):
-                    logger.warning(
-                        f"[SECURITY] Refused to auto-link "
-                        f"{sociallogin.account.provider} account by unverified email"
-                    )
-                    return
-                try:
-                    existing_user = User.objects.get(email=email)
-                    if not sociallogin.is_existing:
-                        # Connect the social account to existing user
-                        sociallogin.connect(request, existing_user)
-                        logger.info(
-                            f"Connected {sociallogin.account.provider} account "
-                            f"to existing {log_safe_user_context(existing_user)}"
-                        )
-                except User.DoesNotExist:
-                    pass
+        if sociallogin.account.provider not in ("google", "github"):
+            return
+
+        email = sociallogin.account.extra_data.get("email")
+        if not email:
+            return
+
+        try:
+            existing_user = User.objects.get(email=email)
+        except User.DoesNotExist:
+            # No local account owns this email. allauth's auto-signup (gated by
+            # the mandatory ACCOUNT_EMAIL_VERIFICATION) handles new users safely.
+            return
+
+        # The social account is already linked to a user (a returning login):
+        # nothing to link, and no takeover surface.
+        if sociallogin.is_existing:
+            return
+
+        # A local account already owns this email and this social account is not
+        # yet linked. Only proceed when the provider has VERIFIED the email —
+        # linking (or creating) off an unverified email is an account-takeover
+        # vector, the same stance the custom oauth_views path takes.
+        #
+        # A bare `return` here is NOT safe: under SOCIALACCOUNT_AUTO_SIGNUP allauth
+        # would then auto-create a SECOND account holding the victim's email
+        # (User.email is not DB-unique, and accounts created via the custom
+        # oauth_views flow have no allauth EmailAddress row to trip the uniqueness
+        # check). Raise ImmediateHttpResponse to abort the whole login pipeline
+        # before allauth's signup/save_user runs.
+        if not self._provider_email_verified(sociallogin, email):
+            logger.warning(
+                f"[SECURITY] Refused {sociallogin.account.provider} login: "
+                f"unverified email collides with an existing account"
+            )
+            error_url = (
+                f"{get_oauth_redirect_url(sociallogin.account.provider)}"
+                f"?error=unverified_email"
+            )
+            raise ImmediateHttpResponse(HttpResponseRedirect(error_url))
+
+        # Verified: link the social account to the existing local user.
+        sociallogin.connect(request, existing_user)
+        logger.info(
+            f"Connected {sociallogin.account.provider} account "
+            f"to existing {log_safe_user_context(existing_user)}"
+        )
 
     @staticmethod
     def _provider_email_verified(sociallogin: SocialLogin, email: str) -> bool:

--- a/backend/apps/users/oauth_adapters.py
+++ b/backend/apps/users/oauth_adapters.py
@@ -6,13 +6,11 @@ import logging
 from typing import Any, Optional
 
 from allauth.account.adapter import DefaultAccountAdapter
-from allauth.core.exceptions import ImmediateHttpResponse
 from allauth.socialaccount.adapter import DefaultSocialAccountAdapter
 from allauth.socialaccount.models import SocialLogin
-from apps.core.utils.pii_safe_logging import log_safe_user_context, log_safe_username
-from django.conf import settings
+from apps.core.utils.pii_safe_logging import log_safe_user_context
 from django.contrib.auth import get_user_model
-from django.http import HttpRequest, HttpResponseRedirect
+from django.http import HttpRequest
 from django.urls import reverse
 
 logger = logging.getLogger(__name__)
@@ -40,16 +38,45 @@ class CustomSocialAccountAdapter(DefaultSocialAccountAdapter):
         ):
             email = sociallogin.account.extra_data.get("email")
             if email:
+                # Only auto-link to an existing local account when the provider
+                # has VERIFIED the email. Linking by an unverified email is an
+                # account-takeover vector — the same stance the custom
+                # oauth_views path takes. allauth's connect() bypasses
+                # SOCIALACCOUNT_EMAIL_VERIFICATION, so we gate it explicitly here.
+                if not self._provider_email_verified(sociallogin, email):
+                    logger.warning(
+                        f"[SECURITY] Refused to auto-link "
+                        f"{sociallogin.account.provider} account by unverified email"
+                    )
+                    return
                 try:
                     existing_user = User.objects.get(email=email)
                     if not sociallogin.is_existing:
                         # Connect the social account to existing user
                         sociallogin.connect(request, existing_user)
                         logger.info(
-                            f"Connected {sociallogin.account.provider} account to existing {log_safe_user_context(existing_user)}"
+                            f"Connected {sociallogin.account.provider} account "
+                            f"to existing {log_safe_user_context(existing_user)}"
                         )
                 except User.DoesNotExist:
                     pass
+
+    @staticmethod
+    def _provider_email_verified(sociallogin: SocialLogin, email: str) -> bool:
+        """Return True only if the provider has verified `email`.
+
+        allauth populates ``sociallogin.email_addresses`` (``EmailAddress``
+        instances with a ``.verified`` flag) from the provider's own signal —
+        for Google that mirrors the ``email_verified`` claim; for GitHub it
+        reflects the verified-emails API. Fail closed: an email the provider
+        did not return as verified (or did not enumerate) is treated as
+        unverified.
+        """
+        target = email.lower()
+        for addr in sociallogin.email_addresses:
+            if addr.email and addr.email.lower() == target:
+                return bool(addr.verified)
+        return False
 
     def save_user(
         self, request: HttpRequest, sociallogin: SocialLogin, form: Optional[Any] = None

--- a/backend/apps/users/oauth_views.py
+++ b/backend/apps/users/oauth_views.py
@@ -231,11 +231,12 @@ def _handle_google_callback(request, code):
 
         profile = profile_response.json()
 
-        # Refuse to trust an unverified email. Matching (or creating) a Django
-        # account by an email Google has not verified is an account-takeover
-        # vector — the same stance the GitHub path takes (primary AND verified).
-        # The v2 userinfo endpoint returns `verified_email`; fall back to the
-        # OIDC `email_verified` claim, and default to unverified if absent.
+        # Verified-email invariant (canonical: docs/patterns/security/
+        # authentication.md → "Trust only provider-verified emails"). Refuse to
+        # trust an unverified email: matching (or creating) a Django account by
+        # an email Google has not verified is an account-takeover vector. The v2
+        # userinfo endpoint returns `verified_email`; fall back to the OIDC
+        # `email_verified` claim, and default to unverified if absent.
         email_verified = profile.get(
             "verified_email", profile.get("email_verified", False)
         )
@@ -301,6 +302,8 @@ def _handle_github_callback(request, code):
             email_response = requests.get(email_url, headers=headers)
             if email_response.status_code == 200:
                 emails = email_response.json()
+                # Verified-email invariant (canonical: docs/patterns/security/
+                # authentication.md → "Trust only provider-verified emails").
                 # Require BOTH primary and verified — matching a Django account by
                 # an unverified email is an account-takeover vector.
                 primary_email = next(

--- a/backend/apps/users/oauth_views.py
+++ b/backend/apps/users/oauth_views.py
@@ -229,7 +229,24 @@ def _handle_google_callback(request, code):
             logger.error(f"Google profile fetch failed: {profile_response.text}")
             return None
 
-        return profile_response.json()
+        profile = profile_response.json()
+
+        # Refuse to trust an unverified email. Matching (or creating) a Django
+        # account by an email Google has not verified is an account-takeover
+        # vector — the same stance the GitHub path takes (primary AND verified).
+        # The v2 userinfo endpoint returns `verified_email`; fall back to the
+        # OIDC `email_verified` claim, and default to unverified if absent.
+        email_verified = profile.get(
+            "verified_email", profile.get("email_verified", False)
+        )
+        if profile.get("email") and not email_verified:
+            logger.warning(
+                "[SECURITY] Google returned an unverified email — refusing to "
+                "match/create an account (GDPR: no email logged)"
+            )
+            profile.pop("email", None)
+
+        return profile
 
     except Exception as e:
         logger.error(f"Google OAuth handling error: {str(e)}")

--- a/backend/apps/users/tests/test_oauth_google.py
+++ b/backend/apps/users/tests/test_oauth_google.py
@@ -1,0 +1,170 @@
+"""
+Tests for the Google OAuth verified-email guard (web flow).
+
+Matching — or creating — a Django account by an email the provider has NOT
+verified is an account-takeover vector. These tests pin the guard in both
+reachable code paths:
+
+1. The custom ``oauth_views`` flow (``/api/auth/oauth/google/callback/``), which
+   does its own token exchange and calls ``_find_or_create_user``.
+2. The django-allauth flow (``/accounts/...``), whose ``pre_social_login`` adapter
+   auto-links a social login to an existing local account by email.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from allauth.account.models import EmailAddress
+from apps.users import oauth_views
+from apps.users.oauth_adapters import CustomSocialAccountAdapter
+from django.contrib.auth import get_user_model
+from django.test import RequestFactory, TestCase
+
+User = get_user_model()
+
+
+def _response(status_code=200, json_data=None):
+    """Build a minimal stand-in for a ``requests`` Response."""
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = json_data or {}
+    return resp
+
+
+class HandleGoogleCallbackVerifiedEmailTest(TestCase):
+    """The guard lives in ``_handle_google_callback``: it strips the email from
+    the returned profile when Google reports it as unverified, which makes the
+    downstream ``_find_or_create_user`` fail closed (no match, no create)."""
+
+    def setUp(self):
+        self.request = RequestFactory().get("/api/auth/oauth/google/callback/")
+
+    @patch("requests.get")
+    @patch("requests.post")
+    def test_unverified_email_is_stripped_from_profile(self, mock_post, mock_get):
+        mock_post.return_value = _response(200, {"access_token": "tok"})
+        mock_get.return_value = _response(
+            200,
+            {
+                "email": "victim@example.com",
+                "verified_email": False,
+                "given_name": "V",
+            },
+        )
+
+        profile = oauth_views._handle_google_callback(self.request, code="abc")
+
+        # Profile still returned (other fields intact) but the unverified email
+        # is removed so no account can be matched or created from it.
+        self.assertIsNotNone(profile)
+        self.assertNotIn("email", profile)
+        self.assertEqual(profile.get("given_name"), "V")
+
+    @patch("requests.get")
+    @patch("requests.post")
+    def test_missing_verified_flag_is_treated_as_unverified(self, mock_post, mock_get):
+        # Fail closed: a profile with no verified flag at all must not be trusted.
+        mock_post.return_value = _response(200, {"access_token": "tok"})
+        mock_get.return_value = _response(200, {"email": "victim@example.com"})
+
+        profile = oauth_views._handle_google_callback(self.request, code="abc")
+
+        self.assertNotIn("email", profile)
+
+    @patch("requests.get")
+    @patch("requests.post")
+    def test_verified_email_is_preserved(self, mock_post, mock_get):
+        # The intended auto-link behaviour is untouched for verified emails.
+        mock_post.return_value = _response(200, {"access_token": "tok"})
+        mock_get.return_value = _response(
+            200, {"email": "real@example.com", "verified_email": True}
+        )
+
+        profile = oauth_views._handle_google_callback(self.request, code="abc")
+
+        self.assertEqual(profile["email"], "real@example.com")
+
+    @patch("requests.get")
+    @patch("requests.post")
+    def test_oidc_email_verified_claim_is_honoured(self, mock_post, mock_get):
+        # OIDC userinfo uses `email_verified` rather than v2's `verified_email`.
+        mock_post.return_value = _response(200, {"access_token": "tok"})
+        mock_get.return_value = _response(
+            200, {"email": "real@example.com", "email_verified": True}
+        )
+
+        profile = oauth_views._handle_google_callback(self.request, code="abc")
+
+        self.assertEqual(profile["email"], "real@example.com")
+
+
+class FindOrCreateUserGuardTest(TestCase):
+    """Security property: once the email has been stripped (unverified), the
+    existing account is neither matched nor mutated, and no user is created."""
+
+    def test_stripped_email_does_not_match_existing_account(self):
+        existing = User.objects.create_user(
+            username="victim", email="victim@example.com"
+        )
+        before = User.objects.count()
+
+        # Profile as it would arrive after the guard removed the email.
+        result = oauth_views._find_or_create_user("google", {"given_name": "V"})
+
+        self.assertIsNone(result)
+        self.assertEqual(User.objects.count(), before)
+        existing.refresh_from_db()
+        self.assertEqual(existing.email, "victim@example.com")
+
+    def test_verified_email_matches_existing_account(self):
+        existing = User.objects.create_user(username="real", email="real@example.com")
+
+        result = oauth_views._find_or_create_user(
+            "google", {"email": "real@example.com"}
+        )
+
+        self.assertEqual(result, existing)
+
+
+class PreSocialLoginVerifiedEmailTest(TestCase):
+    """The allauth adapter must not auto-link an unverified social email to an
+    existing local account."""
+
+    def setUp(self):
+        self.adapter = CustomSocialAccountAdapter()
+        self.request = RequestFactory().get("/accounts/google/login/callback/")
+
+    def _sociallogin(self, *, email, verified):
+        sociallogin = MagicMock()
+        sociallogin.account.provider = "google"
+        sociallogin.account.extra_data = {"email": email}
+        sociallogin.is_existing = False
+        sociallogin.email_addresses = [EmailAddress(email=email, verified=verified)]
+        sociallogin.connect = MagicMock()
+        return sociallogin
+
+    def test_unverified_email_is_not_linked(self):
+        User.objects.create_user(username="victim", email="victim@example.com")
+        sociallogin = self._sociallogin(email="victim@example.com", verified=False)
+
+        self.adapter.pre_social_login(self.request, sociallogin)
+
+        sociallogin.connect.assert_not_called()
+
+    def test_no_verified_email_record_is_not_linked(self):
+        # extra_data carries the email, but the provider enumerated no matching
+        # verified EmailAddress — fail closed.
+        User.objects.create_user(username="victim", email="victim@example.com")
+        sociallogin = self._sociallogin(email="victim@example.com", verified=False)
+        sociallogin.email_addresses = []
+
+        self.adapter.pre_social_login(self.request, sociallogin)
+
+        sociallogin.connect.assert_not_called()
+
+    def test_verified_email_is_linked(self):
+        existing = User.objects.create_user(username="real", email="real@example.com")
+        sociallogin = self._sociallogin(email="real@example.com", verified=True)
+
+        self.adapter.pre_social_login(self.request, sociallogin)
+
+        sociallogin.connect.assert_called_once_with(self.request, existing)

--- a/backend/apps/users/tests/test_oauth_google.py
+++ b/backend/apps/users/tests/test_oauth_google.py
@@ -14,9 +14,11 @@ reachable code paths:
 from unittest.mock import MagicMock, patch
 
 from allauth.account.models import EmailAddress
+from allauth.core.exceptions import ImmediateHttpResponse
 from apps.users import oauth_views
 from apps.users.oauth_adapters import CustomSocialAccountAdapter
 from django.contrib.auth import get_user_model
+from django.http import HttpResponseRedirect
 from django.test import RequestFactory, TestCase
 
 User = get_user_model()
@@ -142,22 +144,30 @@ class PreSocialLoginVerifiedEmailTest(TestCase):
         sociallogin.connect = MagicMock()
         return sociallogin
 
-    def test_unverified_email_is_not_linked(self):
+    def test_unverified_email_aborts_without_linking_or_creating(self):
         User.objects.create_user(username="victim", email="victim@example.com")
+        before = User.objects.count()
         sociallogin = self._sociallogin(email="victim@example.com", verified=False)
 
-        self.adapter.pre_social_login(self.request, sociallogin)
+        # The flow is aborted with a redirect — a bare return would let allauth's
+        # auto-signup create a second account holding the victim's email.
+        with self.assertRaises(ImmediateHttpResponse) as ctx:
+            self.adapter.pre_social_login(self.request, sociallogin)
 
+        self.assertIsInstance(ctx.exception.response, HttpResponseRedirect)
+        self.assertIn("error=unverified_email", ctx.exception.response.url)
         sociallogin.connect.assert_not_called()
+        self.assertEqual(User.objects.count(), before)
 
-    def test_no_verified_email_record_is_not_linked(self):
+    def test_no_verified_email_record_aborts(self):
         # extra_data carries the email, but the provider enumerated no matching
-        # verified EmailAddress — fail closed.
+        # verified EmailAddress — fail closed and abort the flow.
         User.objects.create_user(username="victim", email="victim@example.com")
         sociallogin = self._sociallogin(email="victim@example.com", verified=False)
         sociallogin.email_addresses = []
 
-        self.adapter.pre_social_login(self.request, sociallogin)
+        with self.assertRaises(ImmediateHttpResponse):
+            self.adapter.pre_social_login(self.request, sociallogin)
 
         sociallogin.connect.assert_not_called()
 

--- a/backend/docs/patterns/security/authentication.md
+++ b/backend/docs/patterns/security/authentication.md
@@ -2,6 +2,7 @@
 
 **Last Updated**: November 13, 2025
 **Consolidated From**:
+
 - `docs/development/AUTHENTICATION_TESTING_PATTERNS_CODIFICATION.md`
 - `docs/development/SECURITY_PATTERNS_CODIFIED.md`
 - `docs/testing/DRF_AUTHENTICATION_TESTING_PATTERNS.md`
@@ -26,6 +27,7 @@
 ### Pattern: Secure JWT Secret Keys
 
 **Anti-Pattern** ❌:
+
 ```python
 # settings.py - INSECURE
 JWT_SECRET_KEY = "jwt-dev-secret-key-change-in-production-2024"
@@ -33,12 +35,14 @@ SECRET_KEY = "django-insecure-dev-key-change-in-production-2024"
 ```
 
 **Problems**:
+
 - Predictable keys allow token forgery
 - Development keys left in production
 - Complete authentication bypass possible
 - User impersonation via forged tokens
 
 **Correct Pattern** ✅:
+
 ```python
 # settings.py
 import os
@@ -61,12 +65,14 @@ if not DEBUG:
 ```
 
 **Generation**:
+
 ```bash
 # Generate strong JWT secret
 python -c "import secrets; print(secrets.token_urlsafe(64))"
 ```
 
 **Configuration**:
+
 ```python
 # backend/.env (NEVER commit)
 JWT_SECRET_KEY=your-generated-secret-here-64-chars-minimum
@@ -80,6 +86,7 @@ JWT_SECRET_KEY=generate-with-python-secrets-token-urlsafe-64
 ### Pattern: JWT Token Lifecycle
 
 **Correct Implementation**:
+
 ```python
 # apps/users/authentication.py
 from rest_framework_simplejwt.tokens import RefreshToken
@@ -118,6 +125,7 @@ SIMPLE_JWT = {
 ```
 
 **Why This Matters**:
+
 - Short access token lifetime limits exposure window
 - Refresh token rotation prevents token replay attacks
 - Blacklisting ensures old tokens can't be reused
@@ -127,6 +135,7 @@ SIMPLE_JWT = {
 ### Pattern: Token Refresh with Blacklisting
 
 **Anti-Pattern** ❌:
+
 ```python
 # Directly using refresh token without blacklisting
 def refresh_token_view(request):
@@ -136,6 +145,7 @@ def refresh_token_view(request):
 ```
 
 **Correct Pattern** ✅:
+
 ```python
 # apps/users/views.py
 from rest_framework.decorators import api_view
@@ -180,6 +190,7 @@ def token_refresh(request):
 ### Pattern: Secure Session Configuration
 
 **Correct Configuration**:
+
 ```python
 # settings.py
 
@@ -200,6 +211,7 @@ SESSION_CACHE_ALIAS = 'default'
 ```
 
 **Why Each Setting Matters**:
+
 - `SECURE`: HTTPS-only prevents token interception
 - `HTTPONLY`: Prevents XSS attacks from stealing tokens
 - `SAMESITE='Lax'`: CSRF protection while allowing normal navigation
@@ -210,6 +222,7 @@ SESSION_CACHE_ALIAS = 'default'
 ### Pattern: Account Lockout Protection
 
 **Correct Implementation**:
+
 ```python
 # apps/core/security.py
 from django.core.cache import cache
@@ -276,6 +289,7 @@ def record_failed_attempt(username):
 ```
 
 **Testing Pattern**:
+
 ```python
 # apps/users/tests/test_account_lockout.py
 from django.test import TestCase
@@ -319,6 +333,7 @@ class AccountLockoutTestCase(TestCase):
 ### Pattern: Secure OAuth Configuration
 
 **Anti-Pattern** ❌:
+
 ```python
 # settings.py - INSECURE
 GOOGLE_OAUTH2_CLIENT_ID = 'your-google-client-id.apps.googleusercontent.com'
@@ -326,6 +341,7 @@ GOOGLE_OAUTH2_CLIENT_SECRET = 'your-google-client-secret'  # Hardcoded!
 ```
 
 **Correct Pattern** ✅:
+
 ```python
 # settings.py
 GOOGLE_OAUTH2_CLIENT_ID = os.environ.get('GOOGLE_OAUTH2_CLIENT_ID')
@@ -352,11 +368,49 @@ SOCIALACCOUNT_PROVIDERS = {
 
 ---
 
+### Pattern: Trust only provider-verified emails
+
+**This is the single source of truth for the verified-email invariant. Every
+auth path that matches or creates a Django account by a provider-supplied email
+MUST enforce it. A path's local mechanism cross-references back to this section.**
+
+**Invariant**: Never match — or create — a Django account from an email a
+provider has not explicitly marked **verified**. **Fail closed**: an absent,
+missing, or falsy verification signal is treated as *unverified*.
+
+**Why** ❌: `User.email` is not DB-unique, and accounts created through the
+custom OAuth flow carry no allauth `EmailAddress` row to trip a uniqueness
+check. So an attacker who controls a provider account whose *unverified* email
+equals a victim's address can, depending on the path, either auto-link onto the
+victim's account or have a **second** account silently created holding the
+victim's email — an account-takeover / impersonation vector.
+
+The signal and the fail-closed enforcement live in different shapes per
+provider (a dict claim, a list of email objects, allauth `EmailAddress` rows, a
+Firebase JWT claim). They are intentionally **not** consolidated into one
+helper: this is a shared *policy*, not shared *code*, and a single
+provider-switch function would be a worse abstraction than four local guards.
+What is single-sourced is this policy.
+
+| Path | Where it lives | Verification signal | Enforcement on failure |
+|------|----------------|---------------------|------------------------|
+| Google (web) | `oauth_views._handle_google_callback` | `verified_email` (v2 userinfo) or `email_verified` (OIDC); absent → unverified | strip `email` from the profile so `_find_or_create_user` fails closed |
+| GitHub (web) | `oauth_views._handle_github_callback` | an email object that is both `primary` **and** `verified` | `email` is only set when a primary+verified address exists |
+| allauth (web) | `oauth_adapters.pre_social_login` / `_provider_email_verified` | `sociallogin.email_addresses[].verified` (case-folded match) | raise `ImmediateHttpResponse` → `?error=unverified_email`; never auto-link or fall through to auto-signup |
+| Firebase (mobile) | `firebase_auth_views` | `email_verified` claim, or `sign_in_provider` in the trusted federated set (Google, Apple) | 403 at token exchange; `ValueError` before binding a UID onto an existing account |
+
+**GDPR**: when refusing an unverified email, log the decision but **never the
+address** — log the provider and a redacted form only. See
+`firebase_auth_views.redact_email`.
+
+---
+
 ## Django REST Framework Auth
 
 ### Pattern: DRF Permission Classes
 
 **Correct Implementation**:
+
 ```python
 # apps/forum/permissions.py
 from rest_framework import permissions
@@ -398,6 +452,7 @@ class PostViewSet(viewsets.ModelViewSet):
 ```
 
 **Critical Pattern**: ViewSet `get_permissions()` must respect `@action` decorators:
+
 ```python
 def get_permissions(self):
     """CRITICAL: Let custom actions use their own permission_classes."""
@@ -427,6 +482,7 @@ def custom_action(self, request, pk=None):
 ### Pattern: CSRF Token Handling in DRF Tests
 
 **Anti-Pattern** ❌:
+
 ```python
 # DRF APIClient doesn't auto-handle cookies like Django TestClient
 def test_protected_endpoint(self):
@@ -435,6 +491,7 @@ def test_protected_endpoint(self):
 ```
 
 **Correct Pattern** ✅:
+
 ```python
 # apps/users/tests/test_authentication.py
 from rest_framework.test import APITestCase, APIClient
@@ -470,12 +527,14 @@ class AuthTestCase(APITestCase):
 ### Pattern: API Versioning in Tests
 
 **Anti-Pattern** ❌:
+
 ```python
 # Tests use unversioned URLs
 response = self.client.post('/api/auth/login/', ...)  # 404 in production!
 ```
 
 **Correct Pattern** ✅:
+
 ```python
 # Always match production URL patterns
 response = self.client.post('/api/v1/auth/login/', ...)  # ✓
@@ -493,6 +552,7 @@ response = self.client.post(LOGIN_URL, credentials)
 ### Pattern: Time-Based Test Mocking
 
 **Anti-Pattern** ❌:
+
 ```python
 # Global time.time() mocking creates recursive MagicMock errors
 with patch('time.time', return_value=future_time):
@@ -500,6 +560,7 @@ with patch('time.time', return_value=future_time):
 ```
 
 **Correct Pattern** ✅:
+
 ```python
 import time
 from unittest.mock import patch
@@ -527,6 +588,7 @@ def test_lockout_expiry(self):
 ### Pattern: Layered Security Testing
 
 **Anti-Pattern** ❌:
+
 ```python
 # Expecting single status code from multiple security layers
 def test_rate_limit(self):
@@ -537,6 +599,7 @@ def test_rate_limit(self):
 ```
 
 **Correct Pattern** ✅:
+
 ```python
 def test_rate_limit(self):
     """Test rate limiting - may trigger before or after account lockout."""

--- a/docs/LEARNINGS.md
+++ b/docs/LEARNINGS.md
@@ -503,3 +503,27 @@ This file is append-only. New entries are added by main Claude after each code r
 
 **Rule**: Before adding a pip-audit `--ignore-vuln` line for a "no fix listed" advisory, try bumping the package — the empty "Fix Versions" column ≠ unfixable. Suppress only when no bump clears it, with a dated one-line justification. Run `npm audit fix` WITHOUT `--force` (force pulls breaking majors).
 **Agent**: security-reviewer
+
+## OAuth verified-email invariant (PR #400, 2026-06-24)
+
+### [2026-06-24] A cross-provider security invariant is shared *policy*, not shared *code* — don't consolidate the guards
+
+**Context**: Review finding #2 flagged the "trust only a provider-verified email" rule as scattered across four auth paths (Google web, GitHub web, allauth, Firebase mobile) and prescribed the usual altitude fix: "generalize the mechanism instead of repeating special cases." Applied literally, that would mean one `email_verified(...)` helper the four paths call.
+
+**Why that was the wrong altitude**: the four guards are not the same predicate over a shared shape. They read verification from genuinely different structures — a Google profile dict (`verified_email`/`email_verified`), a GitHub emails list (`primary AND verified`), allauth `EmailAddress` rows (`.verified`), a Firebase JWT claim (`email_verified` + a trusted-provider allowlist) — and enforce failure four different ways (strip email / set-if-verified / raise `ImmediateHttpResponse` / 403+`ValueError`). There is no shared chokepoint to push a gate down to (web → `_find_or_create_user`, Firebase → `get_or_create_user_from_firebase`, different modules). A single provider-switch helper would have *been* the special-cases-on-shared-infra smell, and would have misrepresented each provider's signal (e.g. implying Firebase honors `verified_email`, which it never sends).
+
+**Fix**: single-source the **policy**, not the code. Wrote the canonical rule once in `backend/docs/patterns/security/authentication.md` ("Trust only provider-verified emails": invariant + fail-closed rationale + per-provider table) and had each enforcement site cite it with a one-line comment. Policy at one altitude; per-provider mechanisms stay local.
+
+**Hidden contract worth pinning** (surfaced as a review WARNING — not a bug, but a real fragile coupling): the Google-web guard enforces the invariant by *stripping* `email` from the profile, which only fails closed because `_find_or_create_user` treats a missing email as a hard stop (`email = user_data.get("email"); if not email: return None`). If a future edit adds an email fallback there, the strip-based guard silently breaks. Pinned by `test_stripped_email_does_not_match_existing_account`.
+
+**Rule**: When the same security rule appears across N integrations that read it from different shapes and enforce it differently, single-source the *policy* in the pattern library and cross-reference each guard — don't force a shared helper. A "strip the input → downstream fails closed" guard depends on the downstream hard-stopping on the missing input; assert that coupling in a test.
+**Agent**: security-reviewer
+
+### [2026-06-24] detect-secrets baseline churn → commit-abort loop when a doc edit shifts a baselined example token
+
+**Mistake**: Editing `authentication.md` (which contains example tokens already recorded in `.secrets.baseline`) shifted those tokens' line numbers. The `detect-secrets` pre-commit hook rewrites `.secrets.baseline` in place on every run — updating both the moved `line_number`s and a fresh `generated_at` timestamp. That rewrite is an unstaged change *created during the commit*, so pre-commit's stash-then-restore conflicts with the hook's edits and aborts the commit. Re-staging just re-triggers the rewrite: a loop. (markdownlint's whole-file blank-line normalization compounded it by shifting lines again.)
+
+**Fix**: Stage the hook-regenerated baseline, confirm the diff is **only** `line_number`/`generated_at` churn with no new `hashed_secret` block (i.e. no actual new secret — the scan had already passed clean on prior attempts), then commit once with `SKIP=detect-secrets` so the hook doesn't re-timestamp the baseline mid-write.
+
+**Rule**: When a docs/pattern edit moves a line that holds an example token already in `.secrets.baseline`, expect the detect-secrets hook to churn the baseline and loop the commit. Break it by staging the regenerated baseline, verifying the diff is purely `line_number`/`generated_at` (grep for any added `hashed_secret`), and committing with `SKIP=detect-secrets` for that one write. Never `SKIP` it without first confirming no new secret block was added.
+**Agent**: (process — commit-hook gotcha; not diff-reviewable)

--- a/docs/rules/security.md
+++ b/docs/rules/security.md
@@ -28,3 +28,12 @@ Compact checklist auto-injected before edits. Long-form: `backend/docs/patterns/
   at 6.4.0). Add an `--ignore-vuln` line (in `.github/workflows/security-scan.yml`)
   only when no bump clears it, with a dated one-line justification. Run
   `npm audit fix` WITHOUT `--force` (`--force` pulls breaking majors).
+- **Trust only provider-verified emails.** Never match or create a Django
+  account from a provider-supplied email the provider hasn't marked verified;
+  fail closed when the verification signal is absent. Each OAuth/federated path
+  enforces this with its own local guard (strip / set-if-verified /
+  `ImmediateHttpResponse` / 403) — a shared *policy*, not shared code, so do not
+  collapse the four guards into one provider-switch helper. When a guard strips
+  the email, the downstream user lookup MUST treat a missing email as a hard
+  stop. Canonical: `backend/docs/patterns/security/authentication.md` → "Trust
+  only provider-verified emails".


### PR DESCRIPTION
## Problem

Logging in with Google when a local account already exists with that email **silently auto-links the two by email match — with no user prompt**. That auto-link is only safe when the provider has *verified* the email; matching (or creating) a Django account by an unverified email is an account-takeover vector.

Two reachable web paths did the email match **without** checking verification:

| Path | Reachable via | Before |
|------|---------------|--------|
| Custom `oauth_views._handle_google_callback` | `/api/auth/oauth/google/callback/` (the SPA flow) | Google v2 userinfo `verified_email` flag ignored |
| allauth `pre_social_login` | `/accounts/…` → `allauth.urls` (wired at `urls.py:103`) | `sociallogin.connect()` called for any existing-email match, bypassing `SOCIALACCOUNT_EMAIL_VERIFICATION` |

The GitHub and Firebase paths already required a verified email — Google was the gap.

## Fix

- **Custom flow:** strip the email from the profile when `verified_email`/`email_verified` is false or absent (fail closed). The downstream `_find_or_create_user` then returns `None` → `oauth_callback` redirects with an error → no match, no create.
- **allauth flow:** new `_provider_email_verified()` gates the auto-link on a verified `EmailAddress` from the provider's own signal.

**Verified emails keep the existing auto-link behaviour unchanged** — only the unverified case is refused.

### Notes for the reviewer
- **GitHub is intentionally covered by the same adapter gate** (`pre_social_login` governs both providers); GitHub already fetched primary+verified separately, so this is belt-and-suspenders there.
- **allauth assumption verified against source** (allauth `65.16.1`): `providers/google/provider.py:93-94` sets `EmailAddress(verified=bool(email_verified or verified_email))` in `extract_email_addresses`, which populates `sociallogin.email_addresses` *before* `pre_social_login` runs. Worst case if that were ever wrong is a benign UX regression (verified Google emails wouldn't auto-link), never an unsafe link.

## Tests

New `apps/users/tests/test_oauth_google.py` (9 tests): both paths, fail-closed on missing flag, and the OIDC `email_verified` variant. Full `users` suite green (**118 passed**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)