### PR TITLE
230: dedupe delegation philosophy to global CLAUDE.md; close housekeeping todo

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -308,24 +308,10 @@ kimi-challenge --decision "<the approach>" --paths <relevant-files>
 
 Claude still makes the final call — kimi-challenge surfaces the weaknesses.
 
-### Delegation rules
+### When to delegate
 
-**AUTO-delegate (no prompt needed):**
-
-- Reading 3+ files for exploration or context
-- Single file >400 lines when goal is understanding (not editing)
-- Boilerplate: pytest tests, DRF viewsets/serializers, Flutter widgets, Riverpod providers
-- Post-session documentation updates
-
-**NEVER delegate:**
-
-- Architecture decisions, refactoring plans, feature design
-- Debugging (requires reasoning about error state)
-- Security-sensitive code: auth, permissions, input validation, migrations
-- Tasks requiring exact line numbers for editing — use Read directly
-- Tasks under ~2000 tokens (overhead not worth it)
-
-**Ask first (ambiguous):**
-
-- "Summarize what changed in this PR"
-- Anything touching auth or permissions even if it seems mechanical
+The delegation philosophy (AUTO-delegate / NEVER-delegate / Ask-first tiers) is
+cross-project and lives in `~/.claude/CLAUDE.md` — not repeated here, to avoid
+loading the same guidance twice. The per-tool reference above is the
+project-specific layer (commands, the `kimi-review` commit gate, the `plant_id`
+profile).

--- a/todos/archive/230-completed-p3-harness-housekeeping-sweep.md
+++ b/todos/archive/230-completed-p3-harness-housekeeping-sweep.md
@@ -1,5 +1,5 @@
 ---
-status: in_progress
+status: completed
 priority: p3
 issue_id: "230"
 tags: [harness, docs, housekeeping, memory]
@@ -68,14 +68,39 @@ duplicates enforcement that now lives in triggers/hooks.
 - [x] MEMORY.md index has no entries flagged stale. (done 2026-06-21 — deleted
       `project_forum_app_path.md` (self-flagged STALE, superseded by the
       wagtail-forum-rebuild memory) and its index line; 0 STALE markers remain.)
-- [ ] No instruction text is loaded twice (global + project CLAUDE.md overlap
-      resolved). (DEFERRED 2026-06-21 — the Kimi delegation guidance is in BOTH
-      `~/.claude/CLAUDE.md` (global, all projects) and project `CLAUDE.md:250+`.
-      Resolving it edits the user's GLOBAL cross-project config and requires a
-      judgment call on which copy to keep — not done unilaterally at a sweep tail.
-      This todo stays in_progress until that's decided.)
+- [x] No instruction text is loaded twice (global + project CLAUDE.md overlap
+      resolved). (done 2026-06-24 — user chose Option A: the AUTO-delegate /
+      NEVER-delegate / Ask-first philosophy now lives ONLY in global
+      `~/.claude/CLAUDE.md`, enriched with the generic items the project copy had
+      (>400-line files, exact-line-numbers→Read, <~2000-token tasks, post-session
+      doc updates, the Ask-first tier) so nothing was lost. Project `CLAUDE.md`
+      keeps only its project-specific per-tool reference + `kimi-review` commit-gate
+      detail and a one-line "When to delegate" pointer to the global file.
+      `kimi-review` deliberately left OUT of the global script list — its
+      documented role is the repo commit-gate, not cross-project guidance. Verified
+      by re-reading both files: the philosophy now exists in exactly one place.)
 
 ## Work Log
+
+### 2026-06-24 - Part 4 done, todo closed
+
+- **Part 4 (CLAUDE.md dedup): RESOLVED.** User chose Option A (keep the shared
+  philosophy in global, point from project). Edits:
+  - Global `~/.claude/CLAUDE.md`: enriched to be the single, complete cross-project
+    delegation philosophy — added the generic items it lacked (single file >400
+    lines → ask-kimi; post-session doc updates; exact-line-numbers → use Read;
+    tasks <~2000 tokens; the "Ask first" tier; folded input-validation/migrations
+    into the security NEVER line). Local user-config file, outside the repo → not
+    in the PR.
+  - Project `CLAUDE.md`: replaced the duplicated `### Delegation rules`
+    (AUTO/NEVER/Ask-first lists) with a one-line `### When to delegate` pointer to
+    the global file. Kept the per-tool reference (lines ~250–309) intact — it is
+    project-specific (commands, the `kimi-review` commit gate, `plant_id` profile)
+    and was never duplicated. `kimi-review` deliberately NOT added to the global
+    script list (its role is the repo commit-gate).
+  - Verification: re-read both files — the AUTO/NEVER/Ask-first philosophy now
+    exists in exactly one place (global); nothing dropped. AC #4 satisfied; all
+    four ACs complete → archived.
 
 ### 2026-06-21 - Parts 1–3 done, part 4 deferred (run 2026-06-21-1412)
 


### PR DESCRIPTION
## What

Closes the last open acceptance criterion (**AC #4**) of todo 230 and archives it.

The Kimi delegation philosophy (`AUTO-delegate` / `NEVER-delegate` / `Ask-first`)
was stated in **both** the global `~/.claude/CLAUDE.md` and the project
`CLAUDE.md`, so it loaded twice in this repo. Resolution (user-approved, Option A):

- **Project `CLAUDE.md`** now points to the global file for the cross-project
  delegation philosophy, replacing its duplicated `### Delegation rules` block with
  a one-line `### When to delegate` pointer. The per-tool command reference
  (`ask-kimi`/`kimi-write`/`extract-chat`/`kimi-review`/`kimi-challenge`, incl. the
  `kimi-review` commit-gate + `plant_id` profile) is **unchanged** — it is
  project-specific and was never duplicated.
- **Global `~/.claude/CLAUDE.md`** (local user config, *outside this repo* — not in
  this PR) was enriched separately to carry the complete cross-project philosophy
  so nothing was lost (>400-line files, exact-line-numbers→Read, <~2000-token
  tasks, post-session doc updates, the Ask-first tier). `kimi-review` was
  deliberately left out of its script list — its role is the repo commit-gate.

## Why

AC #4 was deferred on 2026-06-21 because it edits global cross-project config and
needed a judgment call on the canonical copy — reserved for the repo owner.

## Verification

- Re-read both files: the AUTO/NEVER/Ask-first philosophy now exists in exactly one
  place (global); no generic guidance dropped.
- `kimi-review` staged-diff gate passed (no CRITICAL/WARNING findings).
- Todo 230 archived to `todos/archive/230-completed-p3-harness-housekeeping-sweep.md`
  with `status: completed`; all four ACs checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)