### PR TITLE
231: forum spec2 PR-3a — backend inline image upload + rendition serialization

### DIFF
--- a/backend/apps/forum_host/api.py
+++ b/backend/apps/forum_host/api.py
@@ -50,6 +50,13 @@ class PostWriteView(forum_views.PostWriteView):
 
 
 @method_decorator(
+    ratelimit(key="user", rate=_rate("image_upload"), method="POST"), name="post"
+)
+class PostImageUploadView(forum_views.PostImageUploadView):
+    pass
+
+
+@method_decorator(
     ratelimit(key="user", rate=_rate("reaction_toggle"), method="POST"), name="post"
 )
 class ReactionToggleView(forum_views.ReactionToggleView):

--- a/backend/apps/forum_host/api_urls.py
+++ b/backend/apps/forum_host/api_urls.py
@@ -14,6 +14,7 @@ from wagtail_forum.api.views import BoardListView, TopicDetailView
 
 from .api import (
     MeProfileView,
+    PostImageUploadView,
     PostListView,
     PostWriteView,
     ReactionToggleView,
@@ -29,6 +30,7 @@ urlpatterns = [
     path("boards/<slug:slug>/topics/", TopicListView.as_view(), name="topic-list"),
     path("topics/<int:topic_id>/", TopicDetailView.as_view(), name="topic-detail"),
     path("topics/<int:topic_id>/posts/", PostListView.as_view(), name="post-list"),
+    path("images/", PostImageUploadView.as_view(), name="image-upload"),
     path("posts/<int:post_id>/", PostWriteView.as_view(), name="post-detail"),
     path(
         "posts/<int:post_id>/reactions/",

--- a/backend/apps/forum_host/constants.py
+++ b/backend/apps/forum_host/constants.py
@@ -11,6 +11,7 @@ DEFAULT_FORUM_RATELIMITS = {
     "post_delete": "20/h",
     "reaction_toggle": "60/m",
     "profile_update": "10/h",
+    "image_upload": "30/h",
     "search": "30/m",
     "sync": "60/m",
 }

--- a/backend/apps/forum_host/tests/test_ratelimits.py
+++ b/backend/apps/forum_host/tests/test_ratelimits.py
@@ -99,6 +99,7 @@ def test_wrapped_routes_use_the_throttled_views():
         "topic-list": throttled.TopicListView,
         "post-list": throttled.PostListView,
         "post-detail": throttled.PostWriteView,
+        "image-upload": throttled.PostImageUploadView,
         "reaction-toggle": throttled.ReactionToggleView,
         "me-profile": throttled.MeProfileView,
         "search": throttled.SearchView,
@@ -157,6 +158,37 @@ def test_throttle_is_per_user_not_global():
     assert first.status_code == 201
     assert blocked.status_code == 429
     assert other.status_code == 201
+
+
+@override_settings(FORUM_RATELIMITS={"image_upload": "1/h"})
+@pytest.mark.django_db
+def test_image_upload_is_throttled_per_user():
+    import io
+
+    from django.core.files.uploadedfile import SimpleUploadedFile
+    from PIL import Image as PILImage
+
+    user = User.objects.create_user(username="up", password="x")
+    client = APIClient()
+    client.force_authenticate(user)
+
+    def upload():
+        buf = io.BytesIO()
+        PILImage.new("RGB", (10, 10), "red").save(buf, format="JPEG")
+        buf.seek(0)
+        return client.post(
+            "/api/v1/forum/images/",
+            {"image": SimpleUploadedFile("a.jpg", buf.read(), "image/jpeg")},
+            format="multipart",
+        )
+
+    with freeze_time("2026-06-10 12:00:00"):
+        first = upload()
+        blocked = upload()
+
+    assert first.status_code == 201
+    assert blocked.status_code == 429  # NOT 403 — Ratelimited subclasses it
+    assert "Retry-After" in blocked
 
 
 @override_settings(FORUM_RATELIMITS={"post_update": "1/h"})

--- a/backend/packages/wagtail_forum/wagtail_forum/api/sanitize.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/api/sanitize.py
@@ -16,8 +16,11 @@ import json
 import nh3
 from rest_framework import serializers
 from wagtail.blocks import ChooserBlock, RichTextBlock, StructBlock
+from wagtail.images import get_image_model
+from wagtail.images.blocks import ImageChooserBlock
 
 from ..blocks import ForumBodyBlock
+from ..collections import get_forum_image_collection
 
 # Allowlist scoped to ForumBodyBlock's RichTextBlock features (bold, italic, link,
 # ol, ul, code) plus the structural tags Wagtail emits. nh3 drops everything else,
@@ -62,6 +65,11 @@ def validate_forum_body(value):
     if len(json.dumps(value)) > MAX_BODY_CHARS:
         raise serializers.ValidationError("Post body is too large.")
     body_block = ForumBodyBlock()
+    image_types = {
+        name
+        for name, block in body_block.child_blocks.items()
+        if isinstance(block, ImageChooserBlock)
+    }
 
     # Reject unknown block types explicitly: StreamBlock.to_python silently
     # DROPS them (the client's content would vanish without an error). Also
@@ -85,24 +93,47 @@ def validate_forum_body(value):
                 isinstance(v, str) for v in block_value.values()
             ):
                 raise serializers.ValidationError("Invalid post body.")
+        elif block["type"] in image_types:
+            # An image chooser value is the referenced image's integer PK; bool
+            # is an int subclass, so exclude it. Membership is verified below.
+            if not isinstance(block_value, int) or isinstance(block_value, bool):
+                raise serializers.ValidationError("Invalid post body.")
         elif not isinstance(block_value, str):
             raise serializers.ValidationError("Invalid post body.")
 
-    # Reject chooser blocks (image, …) outright on the API path: the dry-run
-    # below does not resolve the referenced PK, so a caller could store a
-    # nonexistent ID (breaks rendering) or reference a restricted-collection
-    # asset by guessing IDs — an IDOR-by-reference (audit L5). There is no
-    # forum upload path yet; Spec 2 adds one with collection validation.
-    chooser_types = {
+    # Non-image chooser blocks stay rejected outright: there is no upload/
+    # validation path for them, so a caller could store a nonexistent PK
+    # (breaks rendering) or reference a restricted asset by guessing IDs.
+    other_chooser_types = {
         name
         for name, block in body_block.child_blocks.items()
-        if isinstance(block, ChooserBlock)
+        if isinstance(block, ChooserBlock) and name not in image_types
     }
     for block in value:
-        if isinstance(block, dict) and block.get("type") in chooser_types:
+        if isinstance(block, dict) and block.get("type") in other_chooser_types:
             raise serializers.ValidationError(
                 "Blocks referencing site objects (e.g. images) cannot be "
                 "submitted via the API."
+            )
+
+    # Image blocks ARE allowed, but only when every referenced PK is an image in
+    # the forum collection — the to_python dry-run never resolves chooser PKs, so
+    # an unchecked id is an IDOR-by-reference (audit L5). One bulk query.
+    image_ids = [
+        block["value"]
+        for block in value
+        if isinstance(block, dict) and block.get("type") in image_types
+    ]
+    if image_ids:
+        valid_ids = set(
+            get_image_model()
+            .objects.filter(id__in=image_ids, collection=get_forum_image_collection())
+            .values_list("id", flat=True)
+        )
+        if any(image_id not in valid_ids for image_id in image_ids):
+            raise serializers.ValidationError(
+                "Post body references an image that is not in the forum "
+                "image collection."
             )
 
     try:

--- a/backend/packages/wagtail_forum/wagtail_forum/api/serializers.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/api/serializers.py
@@ -1,5 +1,6 @@
 from rest_framework import serializers
 from wagtail.blocks import RichTextBlock
+from wagtail.images import get_image_model
 from wagtail.rich_text import expand_db_html
 
 from ..models import ForumBoard, ForumProfile, Post, Reaction, Topic
@@ -121,21 +122,82 @@ class TopicDetailSerializer(serializers.ModelSerializer):
         return post.id if post else None
 
 
-def serialize_forum_body(stream_value):
+def serialize_image_for_api(image, request=None):
+    """An image block's API value: {id, url, alt, width, height}.
+
+    Serves a bounded `max-1200x1200` rendition (not the 5000px-capped original).
+    The URL is made absolute against the request so the web client — served from
+    a different origin than the media backend — resolves it correctly.
+    """
+    rendition = image.get_rendition("max-1200x1200")
+    url = rendition.url
+    if request is not None:
+        url = request.build_absolute_uri(url)
+    return {
+        "id": image.id,
+        "url": url,
+        "alt": image.title or "",
+        "width": rendition.width,
+        "height": rendition.height,
+    }
+
+
+def build_forum_image_map(posts):
+    """Map {image_id: Image} for every image block across *posts* (one query).
+
+    Reads each post's raw StreamField data — NOT the resolved bound blocks — so
+    collecting ids costs no per-image query, then batch-fetches with prefetched
+    renditions. Keeps the post-list query count flat regardless of how many
+    images a page references (no N+1). Returns {} when no image blocks exist, so
+    a text-only page issues no extra query.
+    """
+    image_ids = set()
+    for post in posts:
+        for raw in post.body.raw_data:
+            if raw.get("type") == "image" and isinstance(raw.get("value"), int):
+                image_ids.add(raw["value"])
+    if not image_ids:
+        return {}
+    images = (
+        get_image_model()
+        .objects.filter(id__in=image_ids)
+        .prefetch_renditions("max-1200x1200")
+    )
+    return {img.id: img for img in images}
+
+
+def serialize_forum_body(stream_value, image_map=None, request=None):
     """StreamField -> [{type, value, id}] for the React StreamFieldRenderer.
 
-    RichText (paragraph) blocks are run through expand_db_html() so Wagtail's
-    link rewriter runs (SECURITY: blocks.py:18-21) — never raw value.source.
-    Phase 1 bodies contain only text blocks (heading/paragraph/quote/code);
-    image-block rendition serialization arrives in Phase 3.
+    Iterates the RAW StreamField data, never the resolved StreamValue: merely
+    iterating a StreamValue makes Wagtail bulk-resolve each block type, and for
+    image blocks that is an `Image.objects.in_bulk()` PER POST — an N+1 across a
+    page (the whole reason build_forum_image_map batches up front). Working from
+    raw data sidesteps that: image blocks resolve through *image_map*; every
+    other block's to_python/get_api_representation is DB-free.
+
+    RichText (paragraph) raw value IS the stored HTML source, run through
+    expand_db_html() so Wagtail's link rewriter runs (SECURITY: blocks.py:18-21)
+    — never the unrewritten source. A referenced image missing from the map
+    (e.g. deleted after posting) serializes as None.
     """
+    image_map = image_map or {}
+    child_blocks = stream_value.stream_block.child_blocks
     blocks = []
-    for bound in stream_value:
-        if isinstance(bound.block, RichTextBlock):
-            value = expand_db_html(bound.value.source)
-        else:
-            value = bound.block.get_api_representation(bound.value)
-        blocks.append({"type": bound.block_type, "value": value, "id": bound.id})
+    for raw in stream_value.raw_data:
+        block_type = raw.get("type")
+        raw_value = raw.get("value")
+        child = child_blocks.get(block_type)
+        if block_type == "image":
+            image = image_map.get(raw_value)
+            value = serialize_image_for_api(image, request) if image else None
+        elif isinstance(child, RichTextBlock):
+            value = expand_db_html(raw_value or "")
+        elif child is not None:
+            value = child.get_api_representation(child.to_python(raw_value))
+        else:  # unknown type (cannot occur in stored data — validated on write)
+            value = raw_value
+        blocks.append({"type": block_type, "value": value, "id": raw.get("id")})
     return blocks
 
 
@@ -190,7 +252,11 @@ class PostSerializer(serializers.ModelSerializer):
 
     @extend_schema_field(FORUM_BODY_SCHEMA)
     def get_body(self, obj):
-        return serialize_forum_body(obj.body)
+        return serialize_forum_body(
+            obj.body,
+            self.context.get("forum_image_map"),
+            self.context.get("request"),
+        )
 
     @extend_schema_field(OpenApiTypes.DATETIME)
     def get_edited_at(self, obj):

--- a/backend/packages/wagtail_forum/wagtail_forum/api/upload_validation.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/api/upload_validation.py
@@ -1,0 +1,72 @@
+"""4-layer validation for forum image uploads (Spec 2 PR-3).
+
+Mirrors the canonical pattern in `backend/docs/patterns/security/file-upload.md`
+(extension, MIME, size, PIL decode + decompression-bomb + dimension caps). The
+logic is copied in rather than imported because the package must not depend on
+the host's `apps.*` namespace (`tests/test_reusability.py`).
+"""
+
+import logging
+
+from rest_framework.exceptions import ValidationError
+
+from ..conf import get_setting
+
+logger = logging.getLogger("wagtail_forum")
+
+
+def validate_image_upload(image_file):
+    """Raise ``ValidationError`` (-> 400) if *image_file* fails any of 4 layers."""
+    from PIL import Image as PILImage
+
+    extensions = get_setting("IMAGE_ALLOWED_EXTENSIONS")
+    mime_types = get_setting("IMAGE_ALLOWED_MIME_TYPES")
+    max_size = get_setting("IMAGE_MAX_SIZE_BYTES")
+    max_pixels = get_setting("IMAGE_MAX_PIXELS")
+    max_width = get_setting("IMAGE_MAX_WIDTH")
+    max_height = get_setting("IMAGE_MAX_HEIGHT")
+
+    # Layer 1: extension allowlist (blocks .php/.exe masquerading as an image).
+    name = image_file.name or ""
+    ext = name.rsplit(".", 1)[-1].lower() if "." in name else ""
+    if ext not in extensions:
+        raise ValidationError(f"Invalid file type. Allowed: {', '.join(extensions)}.")
+
+    # Layer 2: MIME allowlist (catches a declared content-type that isn't an image).
+    if image_file.content_type not in mime_types:
+        raise ValidationError(f'Invalid file content type "{image_file.content_type}".')
+
+    # Layer 3: size cap (DoS guard).
+    if image_file.size > max_size:
+        raise ValidationError(f"File too large. Maximum {max_size // (1024 * 1024)}MB.")
+
+    # Layer 4: PIL magic-number decode + decompression-bomb + dimension caps.
+    try:
+        PILImage.MAX_IMAGE_PIXELS = max_pixels
+        image_file.seek(0)
+        with PILImage.open(image_file) as img:
+            img.verify()
+            width, height = img.size
+            if width > max_width or height > max_height:
+                raise ValidationError(
+                    f"Image dimensions too large. Maximum {max_width}x{max_height}."
+                )
+            if (img.format or "").lower() not in ("jpeg", "png", "gif", "webp"):
+                raise ValidationError(f'Invalid image format "{img.format}".')
+        image_file.seek(0)  # reset the pointer for the subsequent save
+    except ValidationError:
+        raise  # a dimension/format rejection above — don't relabel it "invalid"
+    except PILImage.DecompressionBombError:
+        logger.warning(
+            "[SECURITY] Forum image rejected (decompression bomb): name=%s size=%s",
+            image_file.name,
+            image_file.size,
+        )
+        raise ValidationError("Image file rejected as a decompression bomb.")
+    except Exception as exc:  # not a decodable image
+        logger.warning(
+            "[SECURITY] Forum image rejected (invalid): name=%s error=%s",
+            image_file.name,
+            exc,
+        )
+        raise ValidationError("Invalid image file.")

--- a/backend/packages/wagtail_forum/wagtail_forum/api/urls.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/api/urls.py
@@ -3,6 +3,7 @@ from django.urls import path
 from .views import (
     BoardListView,
     MeProfileView,
+    PostImageUploadView,
     PostListView,
     PostWriteView,
     ReactionToggleView,
@@ -19,6 +20,7 @@ urlpatterns = [
     path("boards/<slug:slug>/topics/", TopicListView.as_view(), name="topic-list"),
     path("topics/<int:topic_id>/", TopicDetailView.as_view(), name="topic-detail"),
     path("topics/<int:topic_id>/posts/", PostListView.as_view(), name="post-list"),
+    path("images/", PostImageUploadView.as_view(), name="image-upload"),
     path("posts/<int:post_id>/", PostWriteView.as_view(), name="post-detail"),
     path(
         "posts/<int:post_id>/reactions/",

--- a/backend/packages/wagtail_forum/wagtail_forum/api/views.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/api/views.py
@@ -8,9 +8,11 @@ from django.utils.dateparse import parse_datetime
 from rest_framework import generics
 from rest_framework import status as http_status
 from rest_framework.exceptions import NotFound, PermissionDenied, ValidationError
+from rest_framework.parsers import FormParser, MultiPartParser
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
+from wagtail.images import get_image_model
 from wagtail.search.backends import get_search_backend
 
 try:  # Schema annotations are optional — hosts without drf-spectacular still work.
@@ -25,6 +27,7 @@ except ImportError:  # pragma: no cover
 
 
 from ..blocks import ForumBodyBlock
+from ..collections import get_forum_image_collection
 from ..models import ForumBoard, Post, Reaction, Topic
 from ..workflow import submit_edit_for_moderation, submit_for_moderation
 from .exceptions import Conflict, UnprocessableEntity
@@ -40,7 +43,10 @@ from .serializers import (
     TopicCreateSerializer,
     TopicDetailSerializer,
     TopicListSerializer,
+    build_forum_image_map,
+    serialize_image_for_api,
 )
+from .upload_validation import validate_image_upload
 
 logger = logging.getLogger("wagtail_forum")
 
@@ -266,6 +272,22 @@ class PostListView(generics.ListAPIView):
         )
         return topic.posts.filter(live=True).select_related("author")
 
+    def list(self, request, *args, **kwargs):
+        # Build the page's image map ONCE (one batched query) and feed it to the
+        # serializer via context, so image-block rendition serialization never
+        # fans out into a per-image lookup (the post-list query count is pinned).
+        queryset = self.filter_queryset(self.get_queryset())
+        page = self.paginate_queryset(queryset)
+        objects = page if page is not None else queryset
+        context = {
+            **self.get_serializer_context(),
+            "forum_image_map": build_forum_image_map(objects),
+        }
+        serializer = self.get_serializer(objects, many=True, context=context)
+        if page is not None:
+            return self.get_paginated_response(serializer.data)
+        return Response(serializer.data)
+
     @extend_schema(
         request=ReplyCreateSerializer,
         responses={201: dict, 404: dict, 409: dict, 422: dict},
@@ -378,7 +400,13 @@ class PostWriteView(APIView):
             )
             moderation_status = "pending"
         post.refresh_from_db()
-        data = PostSerializer(post, context={"request": request}).data
+        data = PostSerializer(
+            post,
+            context={
+                "request": request,
+                "forum_image_map": build_forum_image_map([post]),
+            },
+        ).data
         data["moderation_status"] = moderation_status
         return Response(data)
 
@@ -400,6 +428,50 @@ class PostWriteView(APIView):
         # Wagtail editors, matching submit_for_moderation's publish(user=None).
         post.unpublish(user=None)
         return Response(status=http_status.HTTP_204_NO_CONTENT)
+
+
+class PostImageUploadView(APIView):
+    """Upload an inline post image (4-layer validated) into the forum collection.
+
+    Topic-independent (Spec 2 PR-3): a new-thread composer has no topic id yet,
+    and an image is scoped by collection, not topic. The body references the
+    returned id via an `image` block (membership-checked in api/sanitize.py).
+    """
+
+    permission_classes = [IsAuthenticated]
+    versioning_class = None
+    parser_classes = [MultiPartParser, FormParser]
+
+    @extend_schema(
+        request={
+            "multipart/form-data": {
+                "type": "object",
+                "properties": {"image": {"type": "string", "format": "binary"}},
+            }
+        },
+        responses={201: dict, 400: dict, 401: dict},
+        description=(
+            "Upload an inline post image (4-layer validated: extension, MIME, "
+            "size, PIL decode) into the forum image collection. Returns "
+            "{id, url, alt, width, height}; reference the returned id from an "
+            "`image` body block. Requires authentication."
+        ),
+    )
+    def post(self, request):
+        image_file = request.FILES.get("image")
+        if image_file is None:
+            raise ValidationError("No image file provided.")
+        validate_image_upload(image_file)
+        image = get_image_model().objects.create(
+            title=(image_file.name or "forum-image")[:255],
+            file=image_file,
+            collection=get_forum_image_collection(),
+            uploaded_by_user=request.user,
+        )
+        return Response(
+            serialize_image_for_api(image, request),
+            status=http_status.HTTP_201_CREATED,
+        )
 
 
 class ReactionToggleView(APIView):

--- a/backend/packages/wagtail_forum/wagtail_forum/collections.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/collections.py
@@ -1,0 +1,22 @@
+"""The forum's image collection (Spec 2 PR-3).
+
+Inline post images upload into this Wagtail collection, and a post body may only
+reference images that live in it (membership-checked in ``api/sanitize.py`` —
+closes the audit-L5 IDOR-by-reference). The collection is created lazily and
+idempotently so neither the upload view nor body validation depends on a
+separate seeding step.
+"""
+
+from wagtail.models import Collection
+
+from .conf import get_setting
+
+
+def get_forum_image_collection():
+    """Return the forum image collection, creating it under root if absent."""
+    name = get_setting("IMAGE_COLLECTION_NAME")
+    root = Collection.get_first_root_node()
+    existing = root.get_children().filter(name=name).first()
+    if existing is not None:
+        return existing
+    return root.add_child(name=name)

--- a/backend/packages/wagtail_forum/wagtail_forum/conf.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/conf.py
@@ -8,6 +8,22 @@ DEFAULTS = {
     "SPAM_MAX_LINKS": 3,
     "SPAM_BANNED_WORDS": [],
     "TRUST_THRESHOLDS": {1: 1, 2: 5, 3: 50, 4: 200},  # trust_level -> min post_count
+    # Inline-image upload (Spec 2 PR-3). 4-layer validation limits + the
+    # forum-scoped Wagtail collection uploads land in; a post body may only
+    # reference images in this collection (membership-checked on write — closes
+    # the audit-L5 IDOR-by-reference).
+    "IMAGE_ALLOWED_EXTENSIONS": ["jpg", "jpeg", "png", "gif", "webp"],
+    "IMAGE_ALLOWED_MIME_TYPES": [
+        "image/jpeg",
+        "image/png",
+        "image/gif",
+        "image/webp",
+    ],
+    "IMAGE_MAX_SIZE_BYTES": 10 * 1024 * 1024,  # 10MB — DoS guard
+    "IMAGE_MAX_PIXELS": 100_000_000,  # PIL decompression-bomb threshold
+    "IMAGE_MAX_WIDTH": 5000,
+    "IMAGE_MAX_HEIGHT": 5000,
+    "IMAGE_COLLECTION_NAME": "Forum Images",
 }
 
 

--- a/backend/packages/wagtail_forum/wagtail_forum/tests/api/test_post_image_upload.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/tests/api/test_post_image_upload.py
@@ -1,0 +1,190 @@
+"""Forum inline-image upload (Spec 2 PR-3): 4-layer validation + happy path.
+
+Mirrors backend/docs/patterns/security/file-upload.md. The route is
+topic-independent (POST /forum/images/) — see api/views.PostImageUploadView.
+"""
+
+import io
+from unittest.mock import patch
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.core.files.uploadedfile import SimpleUploadedFile
+from PIL import Image as PILImage
+from rest_framework.test import APIClient
+from wagtail.images import get_image_model
+from wagtail_forum.collections import get_forum_image_collection
+from wagtail_forum.conf import get_setting
+
+User = get_user_model()
+pytestmark = pytest.mark.urls("wagtail_forum.tests.api.urls")
+
+URL = "/forum/images/"
+
+
+def _jpeg(width=10, height=10):
+    buf = io.BytesIO()
+    PILImage.new("RGB", (width, height), color="red").save(buf, format="JPEG")
+    buf.seek(0)
+    return buf.read()
+
+
+def _upload(name="ok.jpg", content=None, content_type="image/jpeg"):
+    return SimpleUploadedFile(
+        name, content if content is not None else _jpeg(), content_type=content_type
+    )
+
+
+def _auth_client():
+    client = APIClient()
+    client.force_authenticate(User.objects.create_user(username="up", password="x"))
+    return client
+
+
+@pytest.mark.django_db
+def test_upload_requires_authentication():
+    resp = APIClient().post(URL, {"image": _upload()}, format="multipart")
+    assert resp.status_code == 401
+
+
+@pytest.mark.django_db
+def test_valid_image_uploads_into_forum_collection_and_returns_shape():
+    resp = _auth_client().post(URL, {"image": _upload()}, format="multipart")
+    assert resp.status_code == 201
+    assert set(resp.data) == {"id", "url", "alt", "width", "height"}
+    assert resp.data["url"].startswith("http://testserver")
+    image = get_image_model().objects.get(id=resp.data["id"])
+    assert image.collection_id == get_forum_image_collection().id
+
+
+@pytest.mark.django_db
+def test_missing_file_rejected():
+    resp = _auth_client().post(URL, {}, format="multipart")
+    assert resp.status_code == 400
+
+
+@pytest.mark.django_db
+def test_invalid_extension_rejected():
+    # Layer 1: a .php payload renamed nowhere near an image extension.
+    bad = SimpleUploadedFile(
+        "hack.php", b'<?php echo "x"; ?>', content_type="application/x-php"
+    )
+    resp = _auth_client().post(URL, {"image": bad}, format="multipart")
+    assert resp.status_code == 400
+
+
+@pytest.mark.django_db
+def test_invalid_mime_rejected():
+    # Layer 2: a jpg extension but a non-image declared content type.
+    bad = _upload(name="a.jpg", content=_jpeg(), content_type="application/x-php")
+    resp = _auth_client().post(URL, {"image": bad}, format="multipart")
+    assert resp.status_code == 400
+
+
+@pytest.mark.django_db
+def test_oversized_file_rejected():
+    # Layer 3: passes extension+MIME but exceeds the size cap.
+    big = b"x" * (get_setting("IMAGE_MAX_SIZE_BYTES") + 1)
+    resp = _auth_client().post(URL, {"image": _upload(content=big)}, format="multipart")
+    assert resp.status_code == 400
+
+
+@pytest.mark.django_db
+def test_non_image_bytes_rejected():
+    # Layer 4: a correct extension + MIME but the bytes are not a real image.
+    bad = _upload(content=b"this is not an image")
+    resp = _auth_client().post(URL, {"image": bad}, format="multipart")
+    assert resp.status_code == 400
+
+
+@pytest.mark.django_db
+def test_oversized_dimensions_rejected():
+    # Layer 4: decodes as a valid JPEG but exceeds the dimension cap.
+    huge = _jpeg(width=get_setting("IMAGE_MAX_WIDTH") + 1, height=10)
+    resp = _auth_client().post(
+        URL, {"image": _upload(content=huge)}, format="multipart"
+    )
+    assert resp.status_code == 400
+
+
+@pytest.mark.django_db
+def test_decompression_bomb_rejected():
+    # Layer 4: PIL raises DecompressionBombError before the file is stored.
+    with patch("PIL.Image.open") as mock_open:
+        mock_open.side_effect = PILImage.DecompressionBombError("too many pixels")
+        resp = _auth_client().post(URL, {"image": _upload()}, format="multipart")
+    assert resp.status_code == 400
+    assert get_image_model().objects.count() == 0
+
+
+@pytest.mark.django_db
+def test_image_round_trips_through_create_and_read():
+    """The real user path end-to-end: upload an image, post a reply whose body
+    references it (plus heading/code blocks), and read the whole body back. This
+    exercises membership validation -> to_python storage -> serialize_forum_body
+    (rewritten in PR-3a) for image AND the text/struct block types together."""
+    from wagtail.models import Page
+    from wagtail_forum.models import (
+        ForumBoard,
+        ForumIndex,
+        ForumProfile,
+        Post,
+        Topic,
+        TrustLevel,
+    )
+    from wagtail_forum.workflow import ensure_default_workflow
+
+    ensure_default_workflow()
+    root = Page.objects.get(id=1)
+    index = root.add_child(instance=ForumIndex(title="Forum", slug="forum"))
+    board = index.add_child(instance=ForumBoard(title="General", slug="general"))
+    author = User.objects.create_user(username="mem", password="x")
+    profile = ForumProfile.for_user(author)
+    profile.trust_level = TrustLevel.MEMBER  # autopublish, so the reply goes live
+    profile.save()
+    topic = Topic.objects.create(
+        board=board, title="T", slug="t", author=author, live=True
+    )
+    Post.objects.create(
+        topic=topic,
+        author=author,
+        is_opening_post=True,
+        live=True,
+        body=[{"type": "paragraph", "value": "<p>op</p>"}],
+    )
+
+    client = APIClient()
+    client.force_authenticate(author)
+
+    upload = client.post(URL, {"image": _upload()}, format="multipart")
+    assert upload.status_code == 201
+    image_id = upload.data["id"]
+
+    reply = client.post(
+        f"/forum/topics/{topic.id}/posts/",
+        {
+            "body": [
+                {"type": "paragraph", "value": "<p>look</p>"},
+                {"type": "image", "value": image_id},
+                {"type": "heading", "value": "Notes"},
+                {"type": "code", "value": {"language": "py", "code": "x = 1"}},
+            ]
+        },
+        format="json",
+    )
+    assert reply.status_code == 201
+    assert reply.data["status"] == "published"  # MEMBER trust autopublishes
+
+    listing = client.get(f"/forum/topics/{topic.id}/posts/")
+    assert listing.status_code == 200
+    # The published reply is in the live listing — proves to_python stored it.
+    bodies = [p["body"] for p in listing.data["results"] if p["id"] == reply.data["id"]]
+    assert len(bodies) == 1
+    blocks = {b["type"]: b["value"] for b in bodies[0]}
+    assert set(blocks) == {"paragraph", "image", "heading", "code"}
+    assert blocks["paragraph"] == "<p>look</p>"
+    assert blocks["heading"] == "Notes"
+    assert blocks["code"] == {"language": "py", "code": "x = 1"}
+    assert blocks["image"]["id"] == image_id
+    assert blocks["image"]["url"].startswith("http://testserver")
+    assert blocks["image"]["width"] > 0 and blocks["image"]["height"] > 0

--- a/backend/packages/wagtail_forum/wagtail_forum/tests/api/test_post_list.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/tests/api/test_post_list.py
@@ -62,6 +62,67 @@ def test_post_list_is_cursor_paginated_with_bounded_queries():
     assert len(ctx.captured_queries) == 3
 
 
+def _topic_with_image_posts(n):
+    from wagtail.images import get_image_model
+    from wagtail.images.tests.utils import get_test_image_file
+    from wagtail_forum.collections import get_forum_image_collection
+
+    root = Page.objects.get(id=1)
+    index = root.add_child(instance=ForumIndex(title="Forum", slug="forum"))
+    board = index.add_child(instance=ForumBoard(title="General", slug="general"))
+    author = User.objects.create_user(username="ada", password="x")
+    collection = get_forum_image_collection()
+    topic = Topic.objects.create(
+        board=board, title="T", slug="t", author=author, live=True
+    )
+    for i in range(n):
+        image = get_image_model().objects.create(
+            title=f"img{i}", file=get_test_image_file(), collection=collection
+        )
+        Post.objects.create(
+            topic=topic,
+            author=author,
+            is_opening_post=(i == 0),
+            live=True,
+            body=[
+                {"type": "paragraph", "value": "<p>hi</p>"},
+                {"type": "image", "value": image.id},
+            ],
+        )
+    return topic
+
+
+@pytest.mark.django_db
+def test_post_list_serializes_image_blocks_to_renditions():
+    topic = _topic_with_image_posts(1)
+    resp = APIClient().get(f"/forum/topics/{topic.id}/posts/")
+    assert resp.status_code == 200
+    blocks = resp.data["results"][0]["body"]
+    assert [b["type"] for b in blocks] == ["paragraph", "image"]
+    image_value = blocks[1]["value"]
+    assert set(image_value) == {"id", "url", "alt", "width", "height"}
+    assert image_value["alt"] == "img0"
+    assert image_value["url"].startswith("http://testserver")  # absolute, cross-origin
+    assert image_value["width"] > 0 and image_value["height"] > 0
+
+
+@pytest.mark.django_db
+def test_post_list_with_images_is_not_n_plus_one():
+    topic = _topic_with_image_posts(3)
+    client = APIClient()
+    # Warm renditions (generated once, then cached) so the pin measures the
+    # production steady state, not first-render rendition generation.
+    assert client.get(f"/forum/topics/{topic.id}/posts/").status_code == 200
+    with CaptureQueriesContext(connection) as ctx:
+        resp = client.get(f"/forum/topics/{topic.id}/posts/")
+    assert resp.status_code == 200
+    # 3 base queries (Q1 visibility prefetch, Q2 topic lookup, Q3 posts page) +
+    # the batched image fetch + its prefetched renditions — FLAT regardless of
+    # how many image blocks the page carries (two-pass batching, no N+1).
+    # Pinned EXACTLY (docs/rules/testing.md); explain any change to this number.
+    assert len(ctx.captured_queries) == 5
+
+
 @pytest.mark.django_db
 def test_post_list_hides_posts_on_hidden_topic():
     topic = _topic_with_posts(1)

--- a/backend/packages/wagtail_forum/wagtail_forum/tests/test_blocks.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/tests/test_blocks.py
@@ -1,3 +1,4 @@
+import pytest
 from wagtail_forum.blocks import ForumBodyBlock
 
 
@@ -23,15 +24,51 @@ def test_body_block_rejects_unknown_block_type():
         validate_forum_body([{"type": "raw_html", "value": "<script>x</script>"}])
 
 
-def test_image_blocks_are_rejected_on_the_api_path():
-    # ChooserBlock PKs are not resolved by the dry-run validation, so an API
-    # caller could reference restricted-collection images by id (audit L5).
-    import pytest
+@pytest.mark.django_db
+def test_image_block_with_nonexistent_id_is_rejected():
+    # The to_python dry-run never resolves chooser PKs, so a nonexistent id
+    # would break rendering — the membership check rejects it (audit L5 guard).
     from rest_framework.serializers import ValidationError
     from wagtail_forum.api.sanitize import validate_forum_body
 
     with pytest.raises(ValidationError):
         validate_forum_body([{"type": "image", "value": 12345}])
+
+
+@pytest.mark.django_db
+def test_image_block_in_forum_collection_is_accepted():
+    # PR-3 relaxes the blanket chooser rejection: an image that lives in the
+    # forum collection round-trips through body validation unchanged.
+    from wagtail.images import get_image_model
+    from wagtail.images.tests.utils import get_test_image_file
+    from wagtail_forum.api.sanitize import validate_forum_body
+    from wagtail_forum.collections import get_forum_image_collection
+
+    image = get_image_model().objects.create(
+        title="seedling",
+        file=get_test_image_file(),
+        collection=get_forum_image_collection(),
+    )
+    cleaned = validate_forum_body([{"type": "image", "value": image.id}])
+    assert cleaned == [{"type": "image", "value": image.id}]
+
+
+@pytest.mark.django_db
+def test_image_block_outside_forum_collection_is_rejected():
+    # Guessing a restricted asset's id is the exact IDOR the membership check
+    # closes: an image in any other collection must not be referenceable.
+    from rest_framework.serializers import ValidationError
+    from wagtail.images import get_image_model
+    from wagtail.images.tests.utils import get_test_image_file
+    from wagtail.models import Collection
+    from wagtail_forum.api.sanitize import validate_forum_body
+
+    other = Collection.get_first_root_node().add_child(name="Private")
+    image = get_image_model().objects.create(
+        title="secret", file=get_test_image_file(), collection=other
+    )
+    with pytest.raises(ValidationError):
+        validate_forum_body([{"type": "image", "value": image.id}])
 
 
 def test_oversized_body_chars_rejected():
@@ -58,6 +95,10 @@ def test_non_string_block_values_are_rejected_not_500():
         [{"type": "quote", "value": ["x"]}],
         [{"type": "code", "value": "not-a-dict"}],
         [{"type": "code", "value": {"language": "py", "code": 1}}],
+        # An image value must be the referenced PK (int); a string or a bool
+        # (int subclass) is rejected by the type guard before the DB lookup.
+        [{"type": "image", "value": "12"}],
+        [{"type": "image", "value": True}],
     ):
         with pytest.raises(ValidationError):
             validate_forum_body(bad)

--- a/backend/packages/wagtail_forum/wagtail_forum/tests/test_collections.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/tests/test_collections.py
@@ -1,0 +1,16 @@
+import pytest
+from wagtail.models import Collection
+from wagtail_forum.collections import get_forum_image_collection
+
+
+@pytest.mark.django_db
+def test_get_forum_image_collection_is_idempotent():
+    first = get_forum_image_collection()
+    second = get_forum_image_collection()
+
+    assert first.pk == second.pk
+    assert first.name == "Forum Images"
+    assert first.is_descendant_of(Collection.get_first_root_node())
+    # A second call must not create a duplicate sibling.
+    root = Collection.get_first_root_node()
+    assert root.get_children().filter(name="Forum Images").count() == 1

--- a/docs/superpowers/plans/2026-06-24-forum-spec2-pr3-images.md
+++ b/docs/superpowers/plans/2026-06-24-forum-spec2-pr3-images.md
@@ -1,0 +1,90 @@
+# Forum Spec 2 — PR-3 (images): implementation plan
+
+**Todo:** `231-in_progress-p1-forum-spec2-read-api-web-client.md` (archives after PR-3).
+**Spec:** `docs/superpowers/specs/2026-06-20-forum-spec2-read-write-client-design.md` (Phase 3).
+**Predecessors merged to main:** PR-1 (#394 read cleanup), PR-2a (#395 backend write),
+PR-2b (#396 web write).
+
+PR-3 is the inline-image story — the only thing still on legacy paths. Split into
+**PR-3a (backend)** and **PR-3b (web)** like PR-2a/PR-2b: the backend is security-sensitive
+(file upload + sanitizer relaxation + IDOR guard) and earns isolated review; the web suite
+mocks `fetch`, so PR-3b is independently verifiable. PR-3a is the prerequisite for live
+integration.
+
+## Design decisions (this session)
+
+- **Compose UX = TRUE INTERLEAVING** (user choice): images render exactly where placed.
+  Custom TipTap image node + a bidirectional body serializer. Backend forces images to be
+  separate `image` StreamField blocks anyway — nh3's rich-text allowlist (`api/sanitize.py`)
+  has no `img`, so inline `<img>` in a paragraph is stripped by design.
+- **Upload route is topic-independent: `POST /api/v1/forum/images/`** (deviates from the
+  spec's `POST /topics/{id}/images/`). New-thread compose has no topic id, and the image is
+  never scoped to a topic — it's a Wagtail Image referenced by id in a body block. Security =
+  collection membership (sanitize) + `IsAuthenticated`; the topic would be decorative.
+- **Rendition JSON = flat `{id, url, alt, width, height}`** (matches the existing web
+  renderer idiom; the spec's `{id, renditions}` is reconciled to flat here).
+- **Image serialization is a serializer special-case, not an `ImageChooserBlock` subclass**
+  — avoids a StreamField migration; mirrors how RichText is already special-cased.
+
+## Current state (verified)
+
+- `image = ImageChooserBlock()` is already live in `ForumBodyBlock` (`blocks.py:27`); the
+  model accepts it. Gaps are entirely API-layer.
+- `validate_forum_body` (`api/sanitize.py`) rejects image blocks at **two** sites: the
+  int-value type guard (L88-89) and the blanket chooser rejection (L96-106).
+- `serialize_forum_body(stream_value)` (`api/serializers.py:124-139`) falls image blocks into
+  the `else` branch → bare int id, no renditions.
+- No upload endpoint, no forum Collection anywhere in the package.
+- Bodies are serialized via `PostSerializer.get_body` only in **`PostListView`** (paginated)
+  and **`PostWriteView.patch`** (single) — the two two-pass sites. `TopicDetailView` does NOT
+  serialize a body.
+- `tests/api/test_post_list.py` pins exactly 3 queries with **text-only** posts → stays green
+  if `build_forum_image_map` short-circuits on empty image-id sets.
+
+## PR-3a — backend (TDD, package-local; no `apps.*` imports — `test_reusability` guard)
+
+1. **`conf.py`** — add image config to `DEFAULTS` (overridable via `WAGTAILFORUM_*`):
+   `IMAGE_ALLOWED_EXTENSIONS`, `IMAGE_ALLOWED_MIME_TYPES`, `IMAGE_MAX_SIZE_BYTES` (10MB),
+   `IMAGE_MAX_PIXELS` (100M), `IMAGE_MAX_WIDTH`/`IMAGE_MAX_HEIGHT` (5000),
+   `IMAGE_COLLECTION_NAME` ("Forum Images").
+2. **`collections.py`** — `get_forum_image_collection()`: idempotent get-or-create of a child
+   under `Collection.get_first_root_node()`. *Test: called twice → one collection.*
+3. **`api/sanitize.py`** — relax `validate_forum_body`: (a) permit an int value when
+   `type=="image"` in the type guard; (b) replace the blanket image rejection with one bulk
+   membership query `get_image_model().objects.filter(id__in=image_ids,
+   collection=get_forum_image_collection())` → reject nonexistent/out-of-collection ids; keep
+   all other choosers rejected. *Tests: nonexistent id (12345) still raises (keep existing
+   test, update rationale); a valid forum-collection id round-trips; other-collection id
+   raises.*
+4. **`api/upload.py`** — package-local 4-layer validator (copy garden_calendar logic) +
+   `PostImageUploadView` (`IsAuthenticated`, `versioning_class=None`, `MultiPartParser`) →
+   `get_image_model().objects.create(file=…, collection=…, uploaded_by_user=request.user,
+   title=<from filename>)` → `{id, url, alt, width, height}` via the shared rendition helper.
+   *Tests `tests/api/test_post_image_upload.py`: each layer rejects (bad ext, MIME spoof,
+   oversize, non-image, bomb via PIL mock), valid round-trip, 401 anon.*
+5. **`api/serializers.py`** — `build_forum_image_map(posts)` (reads `body.raw_data`, one
+   `filter(id__in).prefetch_renditions(...)`), `serialize_forum_body(stream_value, image_map)`
+   image special-case → flat shape from the map (no per-block query), update `FORUM_BODY_SCHEMA`.
+   `PostSerializer.get_body` reads `self.context["forum_image_map"]`.
+6. **`api/views.py`** — `PostListView.list()` builds the map from the paginated page →
+   serializer context; `PostWriteView.patch` builds it for the one post. *New query-pin test
+   for an image body; existing text-only pin untouched.*
+7. **Routes/throttle** — `api/urls.py` `path("images/", PostImageUploadView, name="image-upload")`;
+   `forum_host/api_urls.py` mirror via a throttled wrapper; `forum_host/api.py` `image_upload`
+   wrapper (`method="POST"`, `name="post"`); `forum_host/constants.py` add `image_upload`
+   (e.g. `"30/h"`). *Update parity, callback-pin (`wrapped`), and add a throttle test in
+   `tests/test_ratelimits.py`.*
+
+**Verify:** `python manage.py test packages.wagtail_forum apps.forum_host.tests.test_ratelimits
+--noinput`; `python manage.py spectacular --file /dev/null` exits 0 with `/forum/images/`.
+
+## PR-3b — web (TDD Vitest; separate branch off main, after PR-3a merges)
+
+Types (`ImageBlock` in `types/blog.ts` union) · `StreamFieldRenderer` `image` case ·
+TipTap image node + "Add image" toolbar button + trim nh3-flattened buttons
+(heading/quote/strike/code-block) · bidirectional `toBodyBlocks`/`fromBodyBlocks` ·
+`uploadPostImage` → `POST /api/v1/forum/images/` · delete the three dead legacy fns
+(`fetchPostImages`/`deletePostImage`/`reorderPostImages`) + dead types (`Attachment`,
+`BackendImage`, `mapImageToAttachment`) + orphaned `ImageUploadWidget`. Detailed in the
+approved plan-mode file `~/.claude/plans/snug-soaring-volcano.md`; expand into its own plan
+doc when PR-3a is merged.


### PR DESCRIPTION
## What

PR-3a of the **Forum Spec 2** epic (todo 231) — the backend half of inline images. Image blocks were already a live `ForumBodyBlock`, but rejected on write, unrendered on read, and had no upload path. This closes all three. PR-3b (web client) follows on a separate branch.

## Changes

- **Forum image Collection** — `wagtail_forum/collections.py::get_forum_image_collection()`: idempotent get-or-create under the treebeard root. Package-core (domain-agnostic; passes the zero-coupling reusability test).
- **Upload** — `POST /forum/images/` `PostImageUploadView` (`IsAuthenticated`, `versioning_class=None`, 4-layer validation in `api/upload_validation.py`, package-local). **Topic-independent** by design: a new-thread composer has no topic id yet, and an image is scoped by collection, not topic. Returns `{id, url, alt, width, height}`. Host-throttled (`image_upload` 30/h → **429**).
- **Write validation** — `validate_forum_body` now permits image blocks **only when the PK is in the forum collection** (one bulk membership query); nonexistent / out-of-collection ids still reject (closes the audit-L5 IDOR-by-reference). All other chooser types stay rejected.
- **Read serialization** — `serialize_forum_body` emits a `max-1200x1200` rendition dict for image blocks, resolved from a per-page `{id: Image}` map (`build_forum_image_map`). It iterates **`raw_data`, not the resolved `StreamValue`** — iterating a `StreamValue` bulk-resolves image blocks via `Image.objects.in_bulk()` **per post** (an N+1). Pinned flat at **5 queries** (verified N=1 ≡ N=4). URLs are absolutized via `build_absolute_uri` (web is served from a different origin than media).
- Routes mirrored in `apps/forum_host/api_urls.py` + throttled wrapper; parity / callback-pin / throttle tests updated.

## Spec deviation

Spec sketched `POST /topics/{id}/images/`; this uses topic-independent `POST /forum/images/` — the topic in the path would be decorative (security is collection-membership + auth) and would block new-thread image compose.

## Tests

147 forum package + host tests green (was 131 after PR-2a). New: collection idempotency, sanitize membership (accept in-collection / reject nonexistent + out-of-collection / reject bad value types), 4-layer upload rejections + happy path + auth + throttle, image rendition serialization + the N+1 pin, and an **end-to-end round-trip** (upload → reply body with image+heading+code → read back). `manage.py spectacular` exits 0 with `/forum/images/` documented.

## Acceptance criteria (todo 231)

- AC4 (route-parity green with the final URL surface) — ✅ images route added to both tables, parity + callback tests pass.
- AC2 (web off machina) — PR-3b.

🤖 Generated with [Claude Code](https://claude.com/claude-code)