### PR TITLE
234: mitigate flaky Web Vitest CI unhandled rejection (self-diagnosing reporter)

### DIFF
--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -42,21 +42,8 @@ jobs:
         run: npm run lint
 
       - name: Unit and component tests (Vitest)
-        # TEMPORARY (todo 234 flake hunt) — loop the suite many times in one CI job so the
-        # rare post-test unhandled rejection surfaces here; the setup.ts reporter prints its
-        # originating stack. Stop on first failure so the failing attempt is the tail of the
-        # log. REVERT to the single `npm run test -- --run` line before merge.
-        run: |
-          for i in $(seq 1 40); do
-            echo "::group::vitest attempt $i"
-            npm run test -- --run
-            rc=$?
-            echo "::endgroup::"
-            if [ "$rc" -ne 0 ]; then
-              echo "::error::flake reproduced on attempt $i (exit $rc)"
-              exit "$rc"
-            fi
-          done
+        # --run forces a single pass (Vitest defaults to watch mode interactively).
+        run: npm run test -- --run
 
       # Playwright E2E is intentionally NOT run here. web/playwright.config.ts
       # defines a webServer block that auto-starts the Vite dev server, and the

--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -50,3 +50,29 @@ jobs:
       # specs exercise the live backend API (see web/CLAUDE.md). Wiring that into
       # CI needs the Django backend + Postgres/Redis stood up alongside the web
       # server — out of scope for this web-only gate. Track e2e-in-CI separately.
+
+  # TEMPORARY (todo 234 flake hunt) — DELETE this whole job before merge.
+  # Fans out N independent COLD runners, each doing one single-pass `vitest --run`,
+  # to replicate the original cold separate-job failures (a warm in-job loop did not
+  # reproduce). fail-fast:false so every sample runs; the setup.ts reporter prints the
+  # originating stack on any trip. Not a required check — web-checks above is untouched.
+  flake-hunt:
+    name: 'flake hunt (cold sample ${{ matrix.sample }})'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        sample: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24]
+    defaults:
+      run:
+        working-directory: web
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+      - run: npm ci
+      - name: Vitest cold single pass
+        run: npm run test -- --run

--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -42,8 +42,21 @@ jobs:
         run: npm run lint
 
       - name: Unit and component tests (Vitest)
-        # --run forces a single pass (Vitest defaults to watch mode interactively).
-        run: npm run test -- --run
+        # TEMPORARY (todo 234 flake hunt) — loop the suite many times in one CI job so the
+        # rare post-test unhandled rejection surfaces here; the setup.ts reporter prints its
+        # originating stack. Stop on first failure so the failing attempt is the tail of the
+        # log. REVERT to the single `npm run test -- --run` line before merge.
+        run: |
+          for i in $(seq 1 40); do
+            echo "::group::vitest attempt $i"
+            npm run test -- --run
+            rc=$?
+            echo "::endgroup::"
+            if [ "$rc" -ne 0 ]; then
+              echo "::error::flake reproduced on attempt $i (exit $rc)"
+              exit "$rc"
+            fi
+          done
 
       # Playwright E2E is intentionally NOT run here. web/playwright.config.ts
       # defines a webServer block that auto-starts the Vite dev server, and the

--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -50,29 +50,3 @@ jobs:
       # specs exercise the live backend API (see web/CLAUDE.md). Wiring that into
       # CI needs the Django backend + Postgres/Redis stood up alongside the web
       # server — out of scope for this web-only gate. Track e2e-in-CI separately.
-
-  # TEMPORARY (todo 234 flake hunt) — DELETE this whole job before merge.
-  # Fans out N independent COLD runners, each doing one single-pass `vitest --run`,
-  # to replicate the original cold separate-job failures (a warm in-job loop did not
-  # reproduce). fail-fast:false so every sample runs; the setup.ts reporter prints the
-  # originating stack on any trip. Not a required check — web-checks above is untouched.
-  flake-hunt:
-    name: 'flake hunt (cold sample ${{ matrix.sample }})'
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        sample: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24]
-    defaults:
-      run:
-        working-directory: web
-    steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-node@v6
-        with:
-          node-version-file: .nvmrc
-          cache: npm
-          cache-dependency-path: web/package-lock.json
-      - run: npm ci
-      - name: Vitest cold single pass
-        run: npm run test -- --run

--- a/todos/archive/234-completed-p2-flaky-web-vitest-unhandled-rejection.md
+++ b/todos/archive/234-completed-p2-flaky-web-vitest-unhandled-rejection.md
@@ -1,5 +1,5 @@
 ---
-status: in_progress
+status: completed
 priority: p2
 issue_id: "234"
 tags: [web, testing, vitest, ci, flaky]
@@ -60,13 +60,65 @@ a recurring tax on every merge.
 
 ## Acceptance Criteria
 
-- [ ] The originating test file + call site are identified and documented.
-- [ ] The unhandled rejection is fixed at the source (awaited/caught), not globally
-      suppressed.
-- [ ] The Web CI Vitest job passes across multiple consecutive runs of an unrelated
-      change (no intermittent exit-1 with all-tests-passing).
+> **Resolution (2026-06-25): not-reproducible + mitigated.** AC1/AC2 are **not satisfiable** —
+> there is no observable leak to pin or fix (unreproducible in ~346 runs across macOS/Linux/CI,
+> cold + warm; no orphan promise by static analysis; likely already fixed by PRs #406/#407).
+> Rather than fabricate a fix, the leak class is **mitigated** so any recurrence self-diagnoses.
+
+- [ ] ~~Originating test file + call site identified~~ — **not satisfiable**: unreproducible;
+      documented why instead (2026-06-25 work log + static analysis).
+- [ ] ~~Fixed at the source~~ — **n/a**: no observable leak; likely already fixed by the
+      forum-test rewrite. **Mitigated** via a non-suppressing reporter (explicitly *not* suppressed).
+- [x] The Web CI Vitest job passes across multiple consecutive runs — **verified**: 24 cold
+      separate CI jobs + 40 warm in-job runs all green (2026-06-25).
 
 ## Work Log
+
+### 2026-06-25 — Exhaustively investigated; UNREPRODUCIBLE on every platform → mitigated + resolved
+
+**Outcome: resolved as not-reproducible + mitigated.** The flake did not surface in
+**~346 full-suite runs** across every platform/config; static analysis shows no orphan
+promise; the three tests that create the leaked error strings were materially rewritten by
+PRs #406/#407 (forum spec-2 PR-3) *after* this was filed (2026-06-14), so it was almost
+certainly fixed incidentally. Shipped a permanent, non-suppressing `unhandledRejection`
+reporter so any recurrence is instantly self-diagnosing — closing the exact gap that left
+this stuck (run #372's logs were cleared before the stack could be read). Did **not**
+fabricate a source fix for a leak that cannot be observed (would dishonestly "satisfy"
+AC#1/AC#2). PR #410.
+
+**Reproduction attempts (all clean — 0 trips):**
+
+- **macOS** (darwin-arm64, Node 24.9): default `vitest run` 100×; `--maxWorkers=1` 6×;
+  `--no-file-parallelism` 1×; 25× under full CPU saturation (12 `yes` hogs on 10 cores);
+  30× with `--sequence.shuffle`. = 162 runs.
+- **Linux** (Docker `node:24-bookworm`, Node 24.18): 100× shuffled, fresh `npm ci`. *This is
+  the lever the 2026-06-21 attempt lacked* — unhandled-rejection timing (when V8 fires the
+  event vs microtask drain/GC/libuv) is platform-specific, so macOS could never reproduce a
+  CI-Linux flake.
+- **CI** (ubuntu-latest): 40× warm loop in one job; then **24 independent COLD separate jobs**
+  (temporary `flake-hunt` matrix, `fail-fast:false`) to replicate the original cold-job
+  failure condition. All green.
+
+**Why no static fix exists (root-cause analysis — read all 4 forum page tests + service test
++ components):**
+
+- Every forum component attaches its rejection handler **synchronously**, so no orphan can
+  form: `ThreadDetailPage` `Promise.all([fetchThread, fetchPosts])` attaches to both inputs in
+  one tick (both rejections consumed); `ThreadListPage` awaits `fetchCategory`→`fetchThreads`
+  sequentially (2nd never called on the error path, and `mockRejectedValue` is **lazy** → not
+  an orphan); `SearchPage` awaits each call in try/catch.
+- Every error-path test awaits & asserts its rejection (`waitFor` / `await expect().rejects`);
+  `forumService.test.ts` uses `await expect(fetchCategory(999)).rejects.toThrow('Category not found')`.
+- The logger's Sentry path is dead in tests (`import.meta.env.DEV` → `console.log` only), so
+  the "CategoryListPage mocks logger / doesn't leak" correlation is a red herring (its real
+  difference is a single async call vs the others' multi-call patterns).
+- Vitest 4.1.5 **removed** `poolOptions.forks.singleFork`; its replacement `isolate:false`
+  breaks 100+ tests via state-bleed, so the pure single-process amplifier is unavailable.
+
+**Delivered:** `web/src/tests/setup.ts` — non-suppressing `process.on('unhandledRejection')`
+reporter (prints the originating stack; Vitest still exits 1, so it diagnoses without masking).
+**If it ever recurs**, the CI log will contain `[UNHANDLED REJECTION] <stack>` → the exact
+call site is pinned immediately and can be fixed at source per the original AC.
 
 ### 2026-06-21 - Investigated; could NOT reproduce locally → blocked on a real stack (run 2026-06-21-1412)
 

--- a/web/src/tests/setup.ts
+++ b/web/src/tests/setup.ts
@@ -9,6 +9,15 @@ import { afterEach, vi } from 'vitest';
 import { cleanup } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
+// Surface the originating stack of any unhandled promise rejection. Vitest treats a
+// post-test unhandled rejection as a run-level error (exit 1) even when every test file
+// passes, but by default the leaked stack is hard to attribute to a call site. This
+// reporter is intentionally NON-suppressing — it only logs; Vitest still fails the run —
+// so it diagnoses leaks without masking them (see todo 234).
+process.on('unhandledRejection', (reason) => {
+  console.error('\n[UNHANDLED REJECTION]', reason instanceof Error ? reason.stack : reason);
+});
+
 // Cleanup after each test case (e.g., clearing jsdom)
 afterEach(() => {
   cleanup();


### PR DESCRIPTION
## Problem
Web CI's Vitest job intermittently exits 1 with **all test files passing** but one post-test **unhandled promise rejection** (todo 234) — forum-service error strings (`Thread not found`, `Search failed`, `Category not found`) leaked after tests resolve. Non-deterministic and unrelated to the diff → blocked unrelated PRs until re-run by hand.

## Outcome: not-reproducible + mitigated (no honest source fix exists)
The leak **did not reproduce in ~346 full-suite runs**:
- **macOS** (Node 24.9): default 100×, `--maxWorkers=1`, `--no-file-parallelism`, 25× CPU-saturated, 30× `--sequence.shuffle`.
- **Linux** (Docker `node:24-bookworm`, Node 24.18): 100× shuffled, fresh `npm ci` — the platform axis the prior attempt lacked (unhandled-rejection timing is platform-specific).
- **CI** (ubuntu-latest): 40× warm in-job loop, then **24 independent cold separate jobs** (matrix) replicating the original cold-job condition. All green.

**Static analysis shows no orphan promise to fix:** every forum component attaches its rejection handler synchronously (`Promise.all` consumes both inputs; sequential awaits; `mockRejectedValue` is lazy) and every error-path test awaits/asserts its rejection. The three tests that create the leaked error strings were **materially rewritten by PRs #406/#407 after this was filed (2026-06-14)** — so it was almost certainly fixed incidentally. I did **not** fabricate a source fix for a leak that can't be observed.

## What this PR ships
- **`web/src/tests/setup.ts`** — a permanent, **non-suppressing** `process.on('unhandledRejection')` reporter that prints the originating stack. Vitest still exits 1, so it diagnoses without masking (honors the todo's "don't globally suppress" rule). **If the flake ever recurs, the CI log will contain `[UNHANDLED REJECTION] <stack>` → the exact call site is pinned immediately** — closing the gap that left this stuck (run #372's logs were cleared before the stack could be read).
- Archives todo 234 as completed with the full investigation + honest AC disposition.

The temporary CI flake-hunt amplifiers (in-job loop, cold-sample matrix) were added and **fully reverted** within this branch — `web-ci.yml` matches `main`.

Closes #234.