### PR TITLE
security: bump joserfc 1.6.4 → 1.6.7 (CVE-2026-48990)

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -109,7 +109,7 @@ jedi==0.19.2
 Jinja2==3.1.6
 jiter==0.11.1
 joblib==1.5.2
-joserfc==1.6.4
+joserfc==1.6.7
 jsonschema==4.25.1
 jsonschema-specifications==2025.9.1
 kombu==5.6.2


### PR DESCRIPTION
## Summary

CVE-2026-48990 was published for **joserfc 1.6.4**, so `pip-audit` now fails the **Backend Python Security Scan** on every PR and on `main`. The fix is **1.6.7** (per pip-audit's "Fix Versions" column).

This is a one-line dependency bump, split out from PR #411 (mobile emulator test) where the failure first surfaced — it's unrelated to that work and blocks the whole repo.

## Change
- `backend/requirements.txt`: `joserfc==1.6.4` → `joserfc==1.6.7`

`joserfc` is the only pin affected and nothing else constrains it below 1.6.7.

## Verification
- Isolated `pip-audit` on `joserfc==1.6.7`: **"No known vulnerabilities found"** (clears CVE-2026-48990, introduces no new advisory).
- The CI Backend Python Security Scan on this PR is the authoritative gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)