### PR TITLE
238: clear residual drf-spectacular schema warnings (forum + project-wide auth)

### DIFF
--- a/backend/apps/users/apps.py
+++ b/backend/apps/users/apps.py
@@ -7,6 +7,12 @@ class UsersConfig(AppConfig):
 
     def ready(self):
         """Import signals and audit log registration when the app is ready."""
+        # Register the OpenAPI security scheme for CookieJWTAuthentication.
+        # drf-spectacular discovers extensions by import; without this the schema
+        # documents no security scheme. drf-spectacular is a hard project
+        # dependency (DEFAULT_SCHEMA_CLASS), so let an import error surface loudly
+        # rather than silently un-documenting auth across the whole API.
+        import apps.users.schema  # noqa: F401
         import apps.users.signals
 
         # Register audit log only if auditlog app is installed and migrated

--- a/backend/apps/users/schema.py
+++ b/backend/apps/users/schema.py
@@ -1,0 +1,25 @@
+"""drf-spectacular schema extensions for the users app.
+
+Registers an OpenAPI security scheme for `CookieJWTAuthentication` (the project's
+default authenticator). Without it, drf-spectacular emits a "could not resolve
+authenticator" warning for *every* authenticated endpoint and documents no
+security scheme, so Swagger's "Authorize" button is unavailable. drf-spectacular
+discovers extensions by import, so this module is imported in `UsersConfig.ready`.
+"""
+
+from drf_spectacular.extensions import OpenApiAuthenticationExtension
+
+
+class CookieJWTScheme(OpenApiAuthenticationExtension):
+    target_class = "apps.users.authentication.CookieJWTAuthentication"
+    # NOT "cookieAuth": that name is already claimed by drf-spectacular's built-in
+    # SessionAuthentication scheme (the `sessionid` cookie). Reusing it triggers a
+    # "2 components with identical names … different identities" warning and an
+    # incorrect schema. This is a distinct cookie (`access_token`), so it needs a
+    # distinct name.
+    name = "jwtCookieAuth"
+
+    def get_security_definition(self, auto_schema):
+        # The JWT access token is sent in the httpOnly `access_token` cookie
+        # (CookieJWTAuthentication falls back to an Authorization: Bearer header).
+        return {"type": "apiKey", "in": "cookie", "name": "access_token"}

--- a/backend/packages/wagtail_forum/wagtail_forum/api/serializers.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/api/serializers.py
@@ -54,6 +54,14 @@ FORUM_BODY_SCHEMA = {
         },
     },
 }
+CAPABILITIES_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "can_react": {"type": "boolean"},
+        "can_reply": {"type": "boolean"},
+        "can_create_topic": {"type": "boolean"},
+    },
+}
 
 
 class BoardSerializer(serializers.ModelSerializer):
@@ -328,6 +336,7 @@ class MeProfileSerializer(serializers.ModelSerializer):
         ]
         read_only_fields = ["trust_level", "post_count"]
 
+    @extend_schema_field(CAPABILITIES_SCHEMA)
     def get_capabilities(self, obj):
         # v1: static all-True. Trust/lock-aware gating (e.g. can_react only at
         # trust>=1) is a documented follow-up.

--- a/backend/packages/wagtail_forum/wagtail_forum/api/views.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/api/views.py
@@ -119,6 +119,13 @@ class BoardListView(generics.ListAPIView):
         return Response({"results": data})
 
 
+@extend_schema(
+    responses={200: TopicListSerializer(many=True)},
+    description=(
+        "List a board's live topics, most-recent activity first "
+        "(cursor-paginated). Returns 404 for a hidden/non-live board."
+    ),
+)
 class TopicListView(generics.ListAPIView):
     serializer_class = TopicListSerializer
     pagination_class = TopicCursorPagination
@@ -131,6 +138,10 @@ class TopicListView(generics.ListAPIView):
         return super().get_permissions()
 
     def get_queryset(self):
+        # Suppress drf-spectacular's "Failed to obtain model" warning: during
+        # schema generation there is no `slug` kwarg to look the board up by.
+        if getattr(self, "swagger_fake_view", False):
+            return Topic.objects.none()
         board = _get_board(self.kwargs["slug"])
         return (
             Topic.objects.filter(board=board, live=True)

--- a/backend/packages/wagtail_forum/wagtail_forum/tests/api/test_schema.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/tests/api/test_schema.py
@@ -53,3 +53,40 @@ def test_read_serializer_method_fields_are_typed_not_default_string():
     topic = components["TopicDetail"]["properties"]
     assert topic["board"]["type"] == "object"
     assert topic["opening_post_id"]["type"] == "integer"
+
+
+@pytest.mark.django_db
+def test_me_profile_capabilities_typed_as_object():
+    """MeProfileSerializer.get_capabilities is typed via @extend_schema_field
+    instead of drf-spectacular's `string` fallback (todo 238)."""
+    from drf_spectacular.generators import SchemaGenerator
+
+    schema = SchemaGenerator().get_schema(request=None, public=True)
+    capabilities = schema["components"]["schemas"]["MeProfile"]["properties"][
+        "capabilities"
+    ]
+    assert capabilities["type"] == "object"
+    props = capabilities["properties"]
+    assert set(props) == {"can_react", "can_reply", "can_create_topic"}
+    assert props["can_react"]["type"] == "boolean"
+    assert props["can_reply"]["type"] == "boolean"
+    assert props["can_create_topic"]["type"] == "boolean"
+
+
+@pytest.mark.django_db
+def test_cookie_jwt_authenticator_documents_a_security_scheme():
+    """CookieJWTAuthentication (the project default authenticator) is resolved to
+    a cookie security scheme instead of an `could not resolve authenticator`
+    warning + empty securitySchemes (todo 238). Project-wide: this makes Swagger's
+    Authorize button work for every authenticated endpoint."""
+    from drf_spectacular.generators import SchemaGenerator
+
+    schema = SchemaGenerator().get_schema(request=None, public=True)
+    schemes = schema["components"]["securitySchemes"]
+    # Named jwtCookieAuth, not cookieAuth — the latter is drf-spectacular's
+    # built-in SessionAuthentication scheme (sessionid); reusing it collides.
+    assert schemes["jwtCookieAuth"] == {
+        "type": "apiKey",
+        "in": "cookie",
+        "name": "access_token",
+    }

--- a/backend/packages/wagtail_forum/wagtail_forum/tests/api/test_schema.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/tests/api/test_schema.py
@@ -90,3 +90,20 @@ def test_cookie_jwt_authenticator_documents_a_security_scheme():
         "in": "cookie",
         "name": "access_token",
     }
+
+
+@pytest.mark.django_db
+def test_topic_list_view_guards_schema_generation():
+    """TopicListView.get_queryset returns an empty queryset under
+    `swagger_fake_view` (drf-spectacular's schema-generation flag) instead of
+    raising KeyError on the absent `slug` kwarg. That guard is what suppresses the
+    "Failed to obtain model" warning (todo 238) — the schema tests above resolve
+    the model from `serializer_class`, so they would NOT catch the guard's removal.
+    This pins it: drop the guard and `_get_board(self.kwargs["slug"])` raises
+    KeyError here, failing loudly instead of silently regressing the warning."""
+    from wagtail_forum.api.views import TopicListView
+
+    view = TopicListView()
+    view.swagger_fake_view = True
+    view.kwargs = {}  # schema generation supplies no URL kwargs
+    assert list(view.get_queryset()) == []

--- a/todos/248-pending-p2-gate-public-openapi-schema-endpoints.md
+++ b/todos/248-pending-p2-gate-public-openapi-schema-endpoints.md
@@ -1,0 +1,86 @@
+---
+status: pending
+priority: p2
+issue_id: "248"
+tags: [security, openapi, api, authz, schema]
+dependencies: []
+---
+
+# Gate the public OpenAPI schema / Swagger / Redoc endpoints in production
+
+## Problem
+
+`api/schema/`, `api/docs/`, and `api/redoc/` are registered unconditionally in
+`backend/plant_community_backend/urls.py` (lines 89–97) with **no** `permission_classes`
+and **no** `DEBUG` guard (the `if settings.DEBUG:` block at line 169 is separate and
+later). So the full generated OpenAPI schema — every endpoint path, every parameter
+name, and the documented security schemes — plus the interactive Swagger UI and Redoc
+are reachable by **anonymous users in production**.
+
+`SPECTACULAR_SETTINGS["SERVE_INCLUDE_SCHEMA"] = False` does **not** close this: it only
+stops the schema from listing its own `/api/schema/` path as an operation; it does not
+add any auth to `SpectacularAPIView`.
+
+## Findings
+
+Surfaced by the `security-reviewer` agent (HIGH) during the completion code review for
+todo 238 (drf-spectacular schema warnings). Todo 238 added a `jwtCookieAuth` security
+scheme to the schema; that scheme (and the rest of the API surface) is now publicly
+discoverable until these endpoints are gated. The exposure itself **pre-dates** 238 —
+238 only made it more visible — so it was split out here rather than expanding 238's
+scope.
+
+Confirmed against the code:
+
+- `backend/plant_community_backend/urls.py:35-37` imports `SpectacularAPIView`,
+  `SpectacularRedocView`, `SpectacularSwaggerView`.
+- `urls.py:89` `path("api/schema/", SpectacularAPIView.as_view(), name="api-schema")`
+  — no permission, no DEBUG guard.
+- `urls.py:91-98` the `api/docs/` (Swagger) and `api/redoc/` views — same.
+
+A related **low** finding (same review): `SPECTACULAR_SETTINGS["SWAGGER_UI_SETTINGS"]`
+sets `persistAuthorization: True` (settings.py:484), which persists a manually entered
+auth value in browser `localStorage`. Benign for a purely cookie-based flow (the field
+is never auto-populated from the httpOnly cookie), but inconsistent with the
+httpOnly-cookie posture — flip to `False` while here.
+
+## Open question (product decision)
+
+Is the API schema *intended* to be public (a documented public API) or internal-only?
+If a public developer portal is a goal, the right fix may be to keep `api/docs/` public
+but scrub/curate it, not lock it. Resolve this before implementing — it changes the fix.
+
+## Recommended Action
+
+Once the open question is answered, EITHER:
+
+1. **Lock it down** — pass `permission_classes=[IsAdminUser]` to each of the three
+   `.as_view()` calls, OR wrap the three `path(...)` entries in `if settings.DEBUG:`
+   (dev-only docs). `IsAdminUser` is preferable if staff need prod docs.
+2. **Keep public deliberately** — document that decision in `urls.py` and close this
+   todo with a note; still flip `persistAuthorization` to `False`.
+
+## Technical Details
+
+- `backend/plant_community_backend/urls.py:89-98` — the three schema endpoints.
+- `backend/plant_community_backend/settings.py:452-494` — `SPECTACULAR_SETTINGS`
+  (`SERVE_INCLUDE_SCHEMA=False`, `SWAGGER_UI_SETTINGS.persistAuthorization=True`).
+- CI: `backend-checks` runs `manage.py spectacular` (generation), unaffected by URL
+  permissions. A test should hit `GET /api/schema/` as an anonymous client and assert
+  the chosen behavior (403 if gated; 200 if deliberately public).
+
+## Acceptance Criteria
+
+- [ ] The public-vs-internal question above is resolved and recorded.
+- [ ] If gated: an anonymous `GET /api/schema/` (and `/api/docs/`, `/api/redoc/`)
+      returns 401/403 in a non-DEBUG configuration; a staff/admin request still works.
+- [ ] `persistAuthorization` is `False` (or its retention is explicitly justified).
+- [ ] A test pins the chosen access policy for `/api/schema/`.
+
+## Work Log
+
+### 2026-06-27 - Filed
+
+- Split out of the todo 238 completion code review (security-reviewer HIGH). 238 is
+  scoped to schema *warnings*; this is endpoint *authz* in `urls.py` (not in 238's
+  diff), so it was deferred here per the user's "accept + file follow-up" decision.

--- a/todos/archive/238-completed-p3-drf-spectacular-schema-warnings.md
+++ b/todos/archive/238-completed-p3-drf-spectacular-schema-warnings.md
@@ -1,5 +1,5 @@
 ---
-status: pending
+status: completed
 priority: p3
 issue_id: "238"
 tags: [api, openapi, schema, tech-debt, forum]
@@ -99,19 +99,100 @@ Captured from `manage.py spectacular` during PR #394 (2026-06-23):
 
 ## Acceptance Criteria
 
-- [ ] `manage.py spectacular` emits **no** `unable to resolve type hint` warning for
+- [x] `manage.py spectacular` emits **no** `unable to resolve type hint` warning for
       `MeProfileSerializer` and **no** `Failed to obtain model` warning for
       `TopicListView` (grep the command output).
-- [ ] `manage.py spectacular` emits **no** `could not resolve authenticator
+- [x] `manage.py spectacular` emits **no** `could not resolve authenticator
       CookieJWTAuthentication` warning (project-wide), and the generated schema's
       `components.securitySchemes` contains the cookie scheme.
-- [ ] `manage.py spectacular` still exits 0; the `wagtail_forum` package suite and
+- [x] `manage.py spectacular` still exits 0; the `wagtail_forum` package suite and
       `apps/forum_host` route-parity/rate-limit tests stay green.
-- [ ] A test pins the new typing/security (e.g. assert `MeProfile.capabilities.type
+- [x] A test pins the new typing/security (e.g. assert `MeProfile.capabilities.type
       == "object"` and a `securitySchemes` entry exists), matching the regression
       test added for the read serializers in PR #394.
 
 ## Work Log
+
+### 2026-06-27 - Started by completing-todos skill (run 2026-06-27-0237)
+
+- Picked up by automated workflow.
+
+### 2026-06-27 - Implemented (run 2026-06-27-0237)
+
+Three changes (all mirroring the PR #394 pattern) + a regression test:
+
+1. **`api/serializers.py`** — added `CAPABILITIES_SCHEMA` constant and decorated
+   `MeProfileSerializer.get_capabilities` with `@extend_schema_field(...)` (reusing
+   the existing optional drf-spectacular import shim — no hard dependency added).
+2. **`api/views.py`** — added the `swagger_fake_view` guard to
+   `TopicListView.get_queryset` (`return Topic.objects.none()`), plus a class-level
+   `@extend_schema` documenting the GET 200 for parity with the sibling read views.
+3. **`apps/users/schema.py`** (new) — `CookieJWTScheme(OpenApiAuthenticationExtension)`
+   registering the project default authenticator, imported in `UsersConfig.ready()`.
+
+**Deviation from the todo's suggested `name = "cookieAuth"`:** that name is already
+claimed by drf-spectacular's built-in `SessionAuthentication` scheme (the `sessionid`
+cookie). Reusing it produced a NEW warning — `Encountered 2 components with identical
+names "cookieAuth" and different identities … This will very likely result in an
+incorrect schema`. Renamed the scheme to **`jwtCookieAuth`** (a distinct cookie,
+`access_token`), which clears the collision. Generated schema now documents all three
+default auth methods: `cookieAuth` (sessionid), `jwtAuth` (bearer), `jwtCookieAuth`
+(access_token).
+
+**Verification evidence:**
+
+- `manage.py spectacular` → `EXIT: 0`. Grep of stderr for the four targeted patterns
+  (`MeProfileSerializer`, `Failed to obtain model.*TopicListView`, `could not resolve
+  authenticator CookieJWTAuthentication`, `identical names .cookieAuth`) → `match
+  count: 0`. (Pre-existing out-of-scope `unable to resolve type hint` / `Failed to
+  obtain model` warnings remain in `plant_identification`/`blog`/`garden*` serializers —
+  none reference `MeProfileSerializer` or `TopicListView`.)
+- Generated `securitySchemes` block contains
+  `jwtCookieAuth: {type: apiKey, in: cookie, name: access_token}`.
+- `pytest packages/wagtail_forum/.../tests/api/test_schema.py` → `4 passed` (2 existing
+  + 2 new: `test_me_profile_capabilities_typed_as_object`,
+  `test_cookie_jwt_authenticator_documents_a_security_scheme`).
+- `pytest packages/wagtail_forum apps/forum_host --create-db` → `149 passed`.
+- `manage.py check` → `System check identified no issues (0 silenced)`.
+- `pytest apps/users --create-db` → `118 passed` (app whose `apps.py` was modified).
+
+### 2026-06-27 - Code review (run 2026-06-27-0237)
+
+Dispatched `django-drf-reviewer`, `security-reviewer`, `test-quality-reviewer`
+(the orchestrator hit a stream idle timeout, so the relevant domain reviewers were
+dispatched directly). DRF reviewer verified all three correctness constraints clean
+(no hard drf_spectacular dep added to the package; `swagger_fake_view` guard matches
+the sibling views byte-for-byte; class-level `@extend_schema` does not clobber the
+method-level POST schema — same shape as `PostListView`).
+
+**Repaired (two LOW, both in-diff):**
+
+- `apps/users/apps.py` — the `try/except ImportError: pass` around the
+  `apps.users.schema` import silently swallowed a *broken* schema.py import. Since
+  drf-spectacular is a hard project dependency (`DEFAULT_SCHEMA_CLASS`), simplified to
+  a plain `import` (matches the un-guarded `signals` import above) so a real error
+  surfaces loudly instead of un-documenting auth in silence.
+- `tests/api/test_schema.py` — the capabilities test pinned the property *key set*
+  but not the inner value types; added `can_react/can_reply/can_create_topic ==
+  "boolean"` assertions (mirrors the sibling Post-field test). Re-ran: `4 passed`.
+
+**Known issues — accepted at completion (user decision: accept + file follow-up):**
+
+- **[HIGH, pre-existing, out-of-scope] `urls.py:89-97`** — `api/schema/`, `api/docs/`,
+  `api/redoc/` are publicly served in prod (no `permission_classes`, no DEBUG guard).
+  Not in this todo's diff; 238 only added the `jwtCookieAuth` description to the
+  already-public schema (the `access_token` cookie name is already client-observable).
+  **Filed as todo 248 (p2).**
+- **[LOW, pre-existing] `settings.py:484`** `SWAGGER_UI_SETTINGS.persistAuthorization:
+  True` — benign for a cookie-only flow; folded into todo 248's scope.
+
+### 2026-06-27 - Completed by completing-todos skill (run 2026-06-27-0237)
+
+- Verification: all 4 acceptance criteria passed (spectacular exit 0 + 3 target
+  warnings gone + securitySchemes contains `jwtCookieAuth`; 149 forum/forum_host
+  tests, 4 schema tests, 118 users tests, `manage.py check` all green).
+- Review: 3 reviewers, 1 HIGH (pre-existing/out-of-scope → todo 248, accepted by
+  user) + 2 LOW (both repaired in-diff). No in-scope blocking findings.
 
 ### 2026-06-23 - Filed
 


### PR DESCRIPTION
## Summary

Clears residual `manage.py spectacular` warnings (todo 238). Schema accuracy / DX only — no runtime behavior change (`spectacular` already exited 0; the new guard fires only under `swagger_fake_view`, and `@extend_schema`/`@extend_schema_field` are doc-only).

- **`MeProfileSerializer.get_capabilities`** typed via `@extend_schema_field` (was defaulting to `string`).
- **`TopicListView.get_queryset`** gets the `swagger_fake_view` guard (kills the "Failed to obtain model" warning) + a class-level `@extend_schema` documenting the GET 200, matching the sibling `TopicDetailView`/`PostListView`.
- **`CookieJWTAuthentication`** (the project default authenticator) now has an `OpenApiAuthenticationExtension` (`apps/users/schema.py`), imported in `UsersConfig.ready()` so drf-spectacular discovers it. Documents a cookie security scheme for every authenticated endpoint and makes Swagger "Authorize" work. Named `jwtCookieAuth` — **not** `cookieAuth`, which is already claimed by drf-spectacular's built-in `SessionAuthentication` scheme (reusing it produced an "identical names / different identities → incorrect schema" warning).

## Tests

- 2 new regression tests in `test_schema.py` — capabilities typed as an object with `boolean` fields, and `securitySchemes.jwtCookieAuth == {apiKey, cookie, access_token}`.
- `manage.py spectacular` → **exit 0**, all 3 target warnings gone; generated `securitySchemes` contains `jwtCookieAuth`.
- **149** forum/forum_host + **4** schema + **118** users tests green; `manage.py check` clean.

## Follow-up

Completion code review surfaced a **pre-existing, out-of-scope HIGH**: the OpenAPI `api/schema/`, `api/docs/`, `api/redoc/` endpoints are publicly served in prod (no permission / DEBUG guard, `urls.py`). Split out as **todo 248 (p2)** to keep this PR surgical — this PR only adds the `jwtCookieAuth` description to the already-public schema (the `access_token` cookie name is already client-observable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
