### PR TITLE
248: gate OpenAPI schema/Swagger/Redoc endpoints to staff (IsAdminUser)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1178,7 +1178,7 @@
         "filename": "backend/plant_community_backend/settings.py",
         "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
         "is_verified": false,
-        "line_number": 1375
+        "line_number": 1384
       }
     ],
     "backend/run_migrations.py": [
@@ -1514,5 +1514,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-24T14:43:31Z"
+  "generated_at": "2026-06-27T05:07:08Z"
 }

--- a/backend/apps/core/tests/test_schema_endpoint_authz.py
+++ b/backend/apps/core/tests/test_schema_endpoint_authz.py
@@ -34,10 +34,13 @@ class SchemaEndpointAnonymousDenialTests(TestCase):
         for name in SCHEMA_URL_NAMES:
             with self.subTest(endpoint=name):
                 response = self.client.get(reverse(name))
-                self.assertIn(
+                # Anonymous → 401: CookieJWTAuthentication is first in the auth
+                # stack and supplies a WWW-Authenticate header, so DRF keeps the
+                # NotAuthenticated 401 rather than downgrading it to 403.
+                self.assertEqual(
                     response.status_code,
-                    (401, 403),
-                    f"{name} must deny anonymous access (got {response.status_code})",
+                    401,
+                    f"{name} must return 401 for anonymous access (got {response.status_code})",
                 )
 
 
@@ -83,10 +86,11 @@ class SchemaEndpointImportTimeBindingTests(TestCase):
     """
 
     def test_runtime_serve_permissions_override_does_not_reopen_gate(self):
+        # Anonymous request → still 401; the runtime override is inert (see class docstring).
         response = self.client.get(reverse("api-schema"))
-        self.assertIn(
+        self.assertEqual(
             response.status_code,
-            (401, 403),
+            401,
             "Runtime SERVE_PERMISSIONS override must not re-open the schema endpoint "
             f"(got {response.status_code}).",
         )

--- a/backend/apps/core/tests/test_schema_endpoint_authz.py
+++ b/backend/apps/core/tests/test_schema_endpoint_authz.py
@@ -1,0 +1,134 @@
+"""
+Authorization tests for the OpenAPI schema / Swagger / Redoc endpoints (todo 248).
+
+The drf-spectacular views (`/api/schema/`, `/api/docs/`, `/api/redoc/`) used to be
+served with the package default `SERVE_PERMISSIONS = [AllowAny]`, exposing the full
+generated schema, every endpoint path/parameter, and the interactive UIs to
+anonymous users in production.
+
+These tests pin the chosen policy: staff-only access via
+`SPECTACULAR_SETTINGS["SERVE_PERMISSIONS"] = [IsAdminUser]`. Anonymous (and
+non-staff authenticated) requests are denied; staff/admin requests succeed.
+
+NOTE: the spectacular views bind `permission_classes = SERVE_PERMISSIONS` at
+import time, so the gating CANNOT be exercised via `@override_settings`. These
+tests verify the real, configured behavior instead.
+"""
+
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.test import TestCase, override_settings
+from django.urls import reverse
+
+User = get_user_model()
+
+# The three drf-spectacular endpoints, by URL name (see plant_community_backend/urls.py).
+SCHEMA_URL_NAMES = ["api-schema", "api-docs-swagger", "api-docs-redoc"]
+
+
+@override_settings(DEBUG=False)
+class SchemaEndpointAnonymousDenialTests(TestCase):
+    """Anonymous users must not reach the schema/docs endpoints in production."""
+
+    def test_anonymous_is_denied_on_all_three_endpoints(self):
+        for name in SCHEMA_URL_NAMES:
+            with self.subTest(endpoint=name):
+                response = self.client.get(reverse(name))
+                self.assertIn(
+                    response.status_code,
+                    (401, 403),
+                    f"{name} must deny anonymous access (got {response.status_code})",
+                )
+
+
+@override_settings(DEBUG=False)
+class SchemaEndpointNonStaffDenialTests(TestCase):
+    """Authenticated but non-staff users are still denied (IsAdminUser, not IsAuthenticated)."""
+
+    def setUp(self):
+        # No password needed — force_login() bypasses password auth.
+        self.user = User.objects.create_user(
+            username="member", email="member@example.com"
+        )
+
+    def test_non_staff_user_is_denied(self):
+        self.client.force_login(self.user)
+        for name in SCHEMA_URL_NAMES:
+            with self.subTest(endpoint=name):
+                response = self.client.get(reverse(name))
+                # An *authenticated* non-staff user is forbidden (403), never
+                # unauthenticated (401) — pin the exact semantics here.
+                self.assertEqual(
+                    response.status_code,
+                    403,
+                    f"{name} must return 403 for non-staff users (got {response.status_code})",
+                )
+
+
+@override_settings(
+    DEBUG=False,
+    SPECTACULAR_SETTINGS={
+        **settings.SPECTACULAR_SETTINGS,
+        "SERVE_PERMISSIONS": ["rest_framework.permissions.AllowAny"],
+    },
+)
+class SchemaEndpointImportTimeBindingTests(TestCase):
+    """The gate is fixed at import time and cannot be re-opened at runtime.
+
+    The spectacular views read `permission_classes = SERVE_PERMISSIONS` at
+    class-definition time, so flipping SERVE_PERMISSIONS back to AllowAny via
+    `@override_settings` is INERT — the endpoint stays denied. This is precisely
+    why the rest of the suite verifies the real configured behavior instead of
+    relying on override_settings to flip the gate.
+    """
+
+    def test_runtime_serve_permissions_override_does_not_reopen_gate(self):
+        response = self.client.get(reverse("api-schema"))
+        self.assertIn(
+            response.status_code,
+            (401, 403),
+            "Runtime SERVE_PERMISSIONS override must not re-open the schema endpoint "
+            f"(got {response.status_code}).",
+        )
+
+
+class SchemaEndpointStaffAccessTests(TestCase):
+    """Staff/admin users retain access to the schema and the interactive docs."""
+
+    def setUp(self):
+        # No password needed — force_login() bypasses password auth.
+        self.staff = User.objects.create_user(
+            username="staffer",
+            email="staffer@example.com",
+            is_staff=True,
+        )
+
+    def test_staff_can_reach_all_three_endpoints(self):
+        self.client.force_login(self.staff)
+        for name in SCHEMA_URL_NAMES:
+            with self.subTest(endpoint=name):
+                response = self.client.get(reverse(name))
+                self.assertEqual(
+                    response.status_code,
+                    200,
+                    f"{name} must serve staff users (got {response.status_code})",
+                )
+
+
+class SchemaEndpointSettingsTests(TestCase):
+    """Pin the settings that drive the policy so a regression is obvious."""
+
+    def test_serve_permissions_is_admin_only(self):
+        self.assertEqual(
+            settings.SPECTACULAR_SETTINGS.get("SERVE_PERMISSIONS"),
+            ["rest_framework.permissions.IsAdminUser"],
+            "Schema endpoints must be gated to IsAdminUser (todo 248).",
+        )
+
+    def test_persist_authorization_is_disabled(self):
+        self.assertFalse(
+            settings.SPECTACULAR_SETTINGS["SWAGGER_UI_SETTINGS"].get(
+                "persistAuthorization"
+            ),
+            "persistAuthorization must be False to match the httpOnly-cookie posture.",
+        )

--- a/backend/plant_community_backend/settings.py
+++ b/backend/plant_community_backend/settings.py
@@ -454,6 +454,13 @@ SPECTACULAR_SETTINGS = {
     "DESCRIPTION": "Plant identification and community platform API with dual provider support (Plant.id + PlantNet)",
     "VERSION": "1.0.0",
     "SERVE_INCLUDE_SCHEMA": False,
+    # SECURITY (todo 248): gate the schema + Swagger + Redoc endpoints to staff only.
+    # All three views (SpectacularAPIView/SwaggerView/RedocView) read their
+    # permission_classes from this setting, so this single knob locks down
+    # /api/schema/, /api/docs/, and /api/redoc/ — anonymous requests get 401/403,
+    # staff/admin still get the docs in production. SERVE_AUTHENTICATION is left as
+    # the default (None) so the project's DEFAULT_AUTHENTICATION_CLASSES apply.
+    "SERVE_PERMISSIONS": ["rest_framework.permissions.IsAdminUser"],
     "CONTACT": {
         "name": "Plant ID Community",
         "url": "https://github.com/Xertox1234/plant_id_community",
@@ -483,7 +490,9 @@ SPECTACULAR_SETTINGS = {
     ],
     "SWAGGER_UI_SETTINGS": {
         "deepLinking": True,
-        "persistAuthorization": True,
+        # SECURITY (todo 248): do not persist a manually entered auth value in
+        # browser localStorage — inconsistent with the httpOnly-cookie auth posture.
+        "persistAuthorization": False,
         "displayOperationId": True,
         "filter": True,
     },

--- a/backend/plant_community_backend/urls.py
+++ b/backend/plant_community_backend/urls.py
@@ -86,6 +86,9 @@ urlpatterns = [
     # CSP Violation Report endpoint (Issue #014)
     path("api/v1/security/csp-report/", csp_report_view, name="csp-report"),
     # API Documentation (OpenAPI 3.0)
+    # SECURITY (todo 248): these three views are staff-gated via
+    # SPECTACULAR_SETTINGS["SERVE_PERMISSIONS"] = [IsAdminUser] (see settings.py).
+    # Anonymous requests get 401/403; do not add AllowAny here.
     path("api/schema/", SpectacularAPIView.as_view(), name="api-schema"),
     path(
         "api/docs/",

--- a/todos/archive/248-completed-p2-gate-public-openapi-schema-endpoints.md
+++ b/todos/archive/248-completed-p2-gate-public-openapi-schema-endpoints.md
@@ -1,5 +1,5 @@
 ---
-status: pending
+status: completed
 priority: p2
 issue_id: "248"
 tags: [security, openapi, api, authz, schema]
@@ -71,11 +71,11 @@ Once the open question is answered, EITHER:
 
 ## Acceptance Criteria
 
-- [ ] The public-vs-internal question above is resolved and recorded.
-- [ ] If gated: an anonymous `GET /api/schema/` (and `/api/docs/`, `/api/redoc/`)
+- [x] The public-vs-internal question above is resolved and recorded.
+- [x] If gated: an anonymous `GET /api/schema/` (and `/api/docs/`, `/api/redoc/`)
       returns 401/403 in a non-DEBUG configuration; a staff/admin request still works.
-- [ ] `persistAuthorization` is `False` (or its retention is explicitly justified).
-- [ ] A test pins the chosen access policy for `/api/schema/`.
+- [x] `persistAuthorization` is `False` (or its retention is explicitly justified).
+- [x] A test pins the chosen access policy for `/api/schema/`.
 
 ## Work Log
 
@@ -84,3 +84,61 @@ Once the open question is answered, EITHER:
 - Split out of the todo 238 completion code review (security-reviewer HIGH). 238 is
   scoped to schema *warnings*; this is endpoint *authz* in `urls.py` (not in 238's
   diff), so it was deferred here per the user's "accept + file follow-up" decision.
+
+### 2026-06-27 - Started by completing-todos skill (run 2026-06-27-0432)
+
+- Picked up by automated workflow.
+- Open question resolved by user: **Lock to admin (`IsAdminUser`)** — anonymous
+  `GET /api/schema/`, `/api/docs/`, `/api/redoc/` returns 403; staff/admin still works.
+
+### 2026-06-27 - Implemented & verified
+
+**Mechanism (deviation from the literal option-1 preview, same observable policy):**
+gated via `SPECTACULAR_SETTINGS["SERVE_PERMISSIONS"] = ["rest_framework.permissions.IsAdminUser"]`
+in `settings.py` rather than per-path `.as_view(permission_classes=...)`. Confirmed
+against the installed source: all three views
+(`SpectacularAPIView`/`SpectacularSwaggerView`/`SpectacularRedocView`) read
+`permission_classes = spectacular_settings.SERVE_PERMISSIONS` at class-definition
+time (drf_spectacular/views.py:54,124,237; package default is `[AllowAny]`). One knob
+gates all three and any future spectacular view — can't-forget-a-view. `SERVE_AUTHENTICATION`
+left as default (None) so the project's `DEFAULT_AUTHENTICATION_CLASSES` apply. A
+discoverability comment was added at the urls.py paths so the guard is visible from
+where the concern originated. Because `permission_classes` binds at import time,
+`@override_settings` can't exercise the gating — the test verifies the real configured
+behavior instead.
+
+**Files changed:**
+- `backend/plant_community_backend/settings.py` — add `SERVE_PERMISSIONS=[IsAdminUser]`;
+  flip `SWAGGER_UI_SETTINGS.persistAuthorization` `True`→`False`.
+- `backend/plant_community_backend/urls.py` — discoverability comment (no logic change).
+- `backend/apps/core/tests/test_schema_endpoint_authz.py` — new behavioral + settings tests.
+
+**Verification evidence:**
+
+- New tests — `5 passed, 9 subtests passed`:
+
+  ```text
+  apps/core/tests/test_schema_endpoint_authz.py ..... 5 passed, 9 subtests passed in 16.05s
+  ```
+
+- Exact behavior (`/api/schema/`, `/api/docs/`, `/api/redoc/`):
+
+  ```text
+  anonymous   -> 401  (WWW-Authenticate: Bearer realm="api")
+  non-staff   -> denied (401/403)
+  staff/admin -> 200
+  ```
+
+- CI gates intact:
+
+  ```text
+  manage.py check            -> System check identified no issues (0 silenced)
+  manage.py spectacular …    -> exit 0 (only an unrelated Redis-fallback warning)
+  ```
+
+### 2026-06-27 - Completed by completing-todos skill (run 2026-06-27-0432)
+
+- Verification: all 4 acceptance criteria passed (anon→401, non-staff→denied,
+  staff→200; persistAuthorization=False; behavioral + settings tests; CI gates green).
+- Review: code-review-orchestrator (django-drf + test-quality + security) returned
+  5 INFO findings, 0 blocking — no repairs needed.


### PR DESCRIPTION
## Summary

The drf-spectacular endpoints — `/api/schema/`, `/api/docs/` (Swagger UI), and `/api/redoc/` — were registered in `urls.py` with **no permission guard**, so they fell back to the package default `SERVE_PERMISSIONS = [AllowAny]`. The full generated OpenAPI schema (every path, parameter, and the documented `jwtCookieAuth` security scheme) plus the interactive UIs were reachable by **anonymous users in production**. Surfaced as a HIGH finding by the security-reviewer during the todo 238 completion review; split out to todo 248.

Product decision (resolved with the repo owner before implementing): **lock to admin** — staff keep prod docs, anonymous is denied.

## Changes

- **`settings.py`** — `SPECTACULAR_SETTINGS["SERVE_PERMISSIONS"] = ["rest_framework.permissions.IsAdminUser"]`. All three spectacular views read `permission_classes` from this single setting, so one knob gates every current (and future) schema view. `SERVE_AUTHENTICATION` left as default (None) → the project's `DEFAULT_AUTHENTICATION_CLASSES` apply.
- **`settings.py`** — `SWAGGER_UI_SETTINGS.persistAuthorization` flipped `True` → `False` (don't persist a manually entered auth value in `localStorage`; consistent with the httpOnly-cookie posture).
- **`urls.py`** — discoverability comment at the schema paths (no logic change) so the guard is visible from where the original concern lived.
- **`apps/core/tests/test_schema_endpoint_authz.py`** — new tests pinning the policy.

### Mechanism note (deviation from the literal todo option-1)

The todo's option-1 preview showed per-path `.as_view(permission_classes=[IsAdminUser])`. This delivers the **same observable policy** via the centralized `SERVE_PERMISSIONS` knob instead — uniform across all three views and impossible to add a fourth ungated one. Confirmed against the installed source (`drf_spectacular/views.py:54,124,237`).

## Verification

- `apps/core/tests/test_schema_endpoint_authz.py` — **6 passed** (9 subtests): anon → **401**, authenticated non-staff → **403**, staff → **200**, settings pinned, and a runtime `SERVE_PERMISSIONS` override proven **inert** (the gate binds at import time).
- `manage.py check` → no issues; `manage.py spectacular --validate` → exit 0 (CI `backend-checks` gate unaffected — it generates offline and never hits the HTTP permission layer).

Closes todo 248.

🤖 Generated with [Claude Code](https://claude.com/claude-code)