### PR TITLE
docs: codify 248 schema-endpoint gating findings

### DIFF
--- a/.claude/agents/security-reviewer.md
+++ b/.claude/agents/security-reviewer.md
@@ -51,6 +51,7 @@ Review only the files passed to you. Do not read the full repo. You run in paral
 - [ ] OAuth/federated account match-or-create gates on a **provider-verified** email (Google `verified_email`/`email_verified`, GitHub `primary AND verified`, allauth `EmailAddress.verified`, Firebase `email_verified` or trusted provider) and fails closed when the signal is absent — matching an existing account by an unverified email is an account-takeover vector; auto-creating off one is a duplicate-account vector. See `authentication.md` → "Trust only provider-verified emails"
 - [ ] An allauth `pre_social_login` that finds an unverified-email collision must ABORT the pipeline (`raise ImmediateHttpResponse(...)`), never bare-`return` — under `SOCIALACCOUNT_AUTO_SIGNUP` a bare return lets allauth auto-create a second account holding the victim's email
 - [ ] A guard that enforces a rule by stripping an input (e.g. removing an unverified `email`) is only safe if the downstream consumer hard-stops on the missing input — verify the fail-closed path, don't assume it
+- [ ] drf-spectacular schema/docs endpoints (`SpectacularAPIView`/`SpectacularSwaggerView`/`SpectacularRedocView`) must be permission-gated — they default to `SERVE_PERMISSIONS = [AllowAny]`, exposing the full OpenAPI schema + Swagger/Redoc UIs to anonymous users. Require `SPECTACULAR_SETTINGS["SERVE_PERMISSIONS"] = [IsAdminUser]` (or a `DEBUG` guard). `SERVE_INCLUDE_SCHEMA=False` does NOT gate them. See `docs/LEARNINGS.md` (todo 248)
 
 **Firebase Security Rules**
 

--- a/docs/LEARNINGS.md
+++ b/docs/LEARNINGS.md
@@ -556,3 +556,14 @@ This file is append-only. New entries are added by main Claude after each code r
 
 **Fix/decision**: Both are low-risk and were merged as-is. The clean fix for (1) is to create the collection at deploy time in `seed_default_forum` (single-threaded release step) so request-time get-or-create always finds it — filed as follow-up todo 247, not hot-patched. (2) is the canonical 4-layer pattern (`garden_calendar` does the same) and is benign because every caller assigns the *same* constant, so concurrent writes can't vary the threshold; left as-is. If a per-request limit is ever needed, drop the global and compare `width * height > limit` explicitly. Recorded so neither is "rediscovered" as a new bug.
 **Agent**: security-reviewer / performance-reviewer
+
+## OpenAPI schema endpoints publicly exposed (todo 248, 2026-06-27)
+
+### [2026-06-27] drf-spectacular schema/docs/redoc were anonymous-readable in production
+
+**Mistake**: `api/schema/`, `api/docs/`, and `api/redoc/` were registered in `urls.py` with no `permission_classes` and no `DEBUG` guard, so the full generated OpenAPI schema (every endpoint path, parameter, and the documented `jwtCookieAuth` security scheme) plus the interactive Swagger/Redoc UIs were reachable by anonymous users in prod. Pre-dated todo 238 (which only made it more visible by adding the auth scheme); split out and fixed in 248.
+
+**Root cause**: drf-spectacular's `SpectacularAPIView`/`SpectacularSwaggerView`/`SpectacularRedocView` all default `permission_classes = spectacular_settings.SERVE_PERMISSIONS`, whose package default is `['rest_framework.permissions.AllowAny']`. `SERVE_INCLUDE_SCHEMA=False` (which the project already set) does NOT add auth — it only stops the schema from listing its own path. So registering the views verbatim from the docs leaves them wide open.
+
+**Fix**: Set `SPECTACULAR_SETTINGS["SERVE_PERMISSIONS"] = ["rest_framework.permissions.IsAdminUser"]` — one knob gates all three views (and any future spectacular view), preferable to per-path `.as_view(permission_classes=…)`. Left `SERVE_AUTHENTICATION=None` so the project's `DEFAULT_AUTHENTICATION_CLASSES` apply. Also flipped `SWAGGER_UI_SETTINGS.persistAuthorization` to `False`. Verified live in prod after the Railway auto-deploy: anonymous `GET` now → 401 on all three (was 200). Two non-obvious test facts emerged: (a) `permission_classes` binds at **import time**, so `@override_settings(SPECTACULAR_SETTINGS=…)` can't exercise the gate — test the real configured behavior; (b) `IsAdminUser` returns **401** to anonymous (JWT authenticator supplies `WWW-Authenticate`) but **403** to an authenticated non-staff user.
+**Agent**: security-reviewer (codified as a check + a write-time trigger)

--- a/docs/rules/security.md
+++ b/docs/rules/security.md
@@ -37,3 +37,11 @@ Compact checklist auto-injected before edits. Long-form: `backend/docs/patterns/
   the email, the downstream user lookup MUST treat a missing email as a hard
   stop. Canonical: `backend/docs/patterns/security/authentication.md` → "Trust
   only provider-verified emails".
+- **Gate the drf-spectacular schema/docs endpoints.** `SpectacularAPIView`,
+  `SpectacularSwaggerView`, and `SpectacularRedocView` default to
+  `SERVE_PERMISSIONS = [AllowAny]`, so the full OpenAPI schema (every path,
+  parameter, and the documented auth schemes) plus the interactive Swagger/Redoc
+  UIs are anonymous-readable in production. Gate them with
+  `SPECTACULAR_SETTINGS["SERVE_PERMISSIONS"] = ["rest_framework.permissions.IsAdminUser"]`
+  — one knob covers all three views (and any future one). `SERVE_INCLUDE_SCHEMA=False`
+  does NOT gate them (it only hides the schema's own path). Surfaced in prod (todo 248).

--- a/docs/rules/testing.md
+++ b/docs/rules/testing.md
@@ -55,3 +55,16 @@ Compact checklist auto-injected before edits.
   headlessly (`new Editor({ extensions: [StarterKit, …] })` works in jsdom) and
   assert `parse(editor.getHTML())` round-trips — that's the only test that catches
   an inline-vs-block node or a dropped custom attribute before prod.
+- **drf-spectacular views bind `permission_classes` at import time.**
+  `SpectacularAPIView`/Swagger/Redoc read `permission_classes = SERVE_PERMISSIONS`
+  at class-definition, so `@override_settings(SPECTACULAR_SETTINGS=…)` is INERT and
+  can't flip the gate — test the REAL configured behavior (and a test that overrides
+  `SERVE_PERMISSIONS` back to `AllowAny` and asserts STILL-denied is a valid pin of
+  the binding). An `IsAdminUser` endpoint denies an *anonymous* request with **401**
+  (the first authenticator, e.g. JWT, supplies a `WWW-Authenticate` header) but an
+  *authenticated non-staff* request with **403** — assert the exact code, not a
+  `(401, 403)` set. See `test_schema_endpoint_authz.py` (todo 248).
+- **`force_login()` bypasses passwords — omit `password=` in `create_user(...)`
+  test fixtures.** A literal password kwarg trips the `detect-secrets` pre-commit
+  gate (which aborts the commit, with the real reason often scrolled off the top of
+  the hook output); `force_login(user)` authenticates without one, so drop it.

--- a/docs/rules/triggers.json
+++ b/docs/rules/triggers.json
@@ -267,5 +267,22 @@
     "source": "codify: chore/codify-forum-pr3",
     "added": "2026-06-25",
     "severity": "warn"
+  },
+  {
+    "id": "openapi-schema-endpoint-ungated",
+    "domains": [
+      "api",
+      "security"
+    ],
+    "path_glob": [
+      "backend/**/urls.py"
+    ],
+    "content_present": "Spectacular(API|Swagger|Redoc)View",
+    "content_absent": "SERVE_PERMISSIONS",
+    "message": "drf-spectacular view registered — it defaults to SERVE_PERMISSIONS=[AllowAny] (anonymous-readable schema + Swagger/Redoc). Gate via SPECTACULAR_SETTINGS[\"SERVE_PERMISSIONS\"]=[IsAdminUser] in settings.py (todo 248).",
+    "pattern_ref": "docs/rules/security.md",
+    "source": "codify: chore/codify-248-schema-gating",
+    "added": "2026-06-27",
+    "severity": "warn"
   }
 ]

--- a/docs/rules/triggers.json
+++ b/docs/rules/triggers.json
@@ -278,8 +278,8 @@
       "backend/**/urls.py"
     ],
     "content_present": "Spectacular(API|Swagger|Redoc)View",
-    "content_absent": "SERVE_PERMISSIONS",
-    "message": "drf-spectacular view registered — it defaults to SERVE_PERMISSIONS=[AllowAny] (anonymous-readable schema + Swagger/Redoc). Gate via SPECTACULAR_SETTINGS[\"SERVE_PERMISSIONS\"]=[IsAdminUser] in settings.py (todo 248).",
+    "content_absent": "SERVE_PERMISSIONS|permission_classes",
+    "message": "drf-spectacular view registered — confirm it's gated. These default to SERVE_PERMISSIONS=[AllowAny] (anonymous-readable schema + Swagger/Redoc); set SPECTACULAR_SETTINGS[\"SERVE_PERMISSIONS\"]=[IsAdminUser] in settings.py (or per-path permission_classes) and note it here (todo 248).",
     "pattern_ref": "docs/rules/security.md",
     "source": "codify: chore/codify-248-schema-gating",
     "added": "2026-06-27",


### PR DESCRIPTION
## Summary

Codifies the patterns that emerged while fixing todo 248 (drf-spectacular schema/docs/redoc endpoints were anonymous-readable in prod because they default to `SERVE_PERMISSIONS = [AllowAny]`). Routed across all four mechanisms so the lesson fires at write-time, review-time, and lives in the incident log:

- **`docs/rules/security.md`** — bullet: gate the drf-spectacular schema/docs endpoints (default AllowAny; `SERVE_INCLUDE_SCHEMA=False` does not gate them).
- **`docs/rules/testing.md`** — two bullets: (a) drf-spectacular `permission_classes` bind at **import time** → `@override_settings(SPECTACULAR_SETTINGS=…)` is inert, test the real config; `IsAdminUser` → **401** anon vs **403** authenticated-non-staff; (b) `force_login()` bypasses passwords → omit `password=` in fixtures (it trips `detect-secrets`).
- **`docs/LEARNINGS.md`** — dated incident entry (root cause + the two test gotchas).
- **`.claude/agents/security-reviewer.md`** — review-time checklist item.
- **`docs/rules/triggers.json`** — write-time JIT trigger `openapi-schema-endpoint-ungated`: fires when a `Spectacular*View` is registered in a `urls.py` with no nearby `SERVE_PERMISSIONS` reference.

## Verification

- `scripts/inject/test_match_triggers.py` → **34 passed** (index well-formed, pattern_refs resolve).
- Manual fire-check on the new trigger: fires on an ungated `SpectacularAPIView` registration, silent when the file references `SERVE_PERMISSIONS`.
- Pre-commit `kimi-review` gate → no findings.

Docs/config only — no runtime code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)