### PR TITLE
docs: codify testing + OAuth-cookie findings from todo 242

### DIFF
--- a/docs/LEARNINGS.md
+++ b/docs/LEARNINGS.md
@@ -567,3 +567,34 @@ This file is append-only. New entries are added by main Claude after each code r
 
 **Fix**: Set `SPECTACULAR_SETTINGS["SERVE_PERMISSIONS"] = ["rest_framework.permissions.IsAdminUser"]` — one knob gates all three views (and any future spectacular view), preferable to per-path `.as_view(permission_classes=…)`. Left `SERVE_AUTHENTICATION=None` so the project's `DEFAULT_AUTHENTICATION_CLASSES` apply. Also flipped `SWAGGER_UI_SETTINGS.persistAuthorization` to `False`. Verified live in prod after the Railway auto-deploy: anonymous `GET` now → 401 on all three (was 200). Two non-obvious test facts emerged: (a) `permission_classes` binds at **import time**, so `@override_settings(SPECTACULAR_SETTINGS=…)` can't exercise the gate — test the real configured behavior; (b) `IsAdminUser` returns **401** to anonymous (JWT authenticator supplies `WWW-Authenticate`) but **403** to an authenticated non-staff user.
 **Agent**: security-reviewer (codified as a check + a write-time trigger)
+
+## Cross-site OAuth state ride a session cookie blocked by SameSite=Strict (todo 242, 2026-06-27)
+
+### [2026-06-27] Web Google sign-in's session-cookie OAuth `state` is silently dropped cross-site in prod
+
+**Mistake**: The web Google-OAuth UI (todo 242) is correct front-end code — `GET
+/api/auth/oauth/google/login/` with `credentials: 'include'`, then
+`window.location.assign(oauth_url)` — but it will fail **every** prod login with
+`?error=invalid_state` and **no client-side error**, because the backend stores
+the OAuth `state` CSRF guard in `request.session`. The frontend
+(`houseplant-md.com`) and backend (Railway) are different sites, so the
+`sessionid` the login endpoint sets is a **third-party cookie**; with Django's prod
+default `SESSION_COOKIE_SAMESITE = "Strict"` (settings.py:1010) the browser never
+stores it, so it isn't present at the callback and `secrets.compare_digest(...)`
+fails.
+
+**Root cause**: SameSite=`Strict`/`Lax` suppresses a cookie on cross-site requests.
+The OAuth-state handshake here is inherently cross-site (SPA origin ≠ API origin),
+so the session cookie carrying `state` must be `SameSite=None; Secure` to be stored
+and replayed. This is a separate knob from the JWT-cookie SameSite already
+configured for authenticated API calls.
+
+**Fix**: Set `SESSION_COOKIE_SAMESITE=None` (with `SESSION_COOKIE_SECURE=True`,
+already `not DEBUG`) in Railway. **Necessary but maybe NOT sufficient**: Safari ITP
+blocks third-party cookies outright and Chrome is deprecating them, so a cross-site
+session-cookie OAuth handshake can fail even when SameSite is correct. The durable
+fix is to stop relying on a third-party cookie for `state` — carry it in a signed
+query param (e.g. `itsdangerous`/JWT round-tripped through the provider) instead.
+Tracked as the prod-verification half under todo 240; the 242 UI ships
+fail-closed (a missing/invalid session → readable error + link back to `/login`).
+**Agent**: security-reviewer (deployment precondition; no code change in 242)

--- a/docs/rules/testing.md
+++ b/docs/rules/testing.md
@@ -68,3 +68,11 @@ Compact checklist auto-injected before edits.
   test fixtures.** A literal password kwarg trips the `detect-secrets` pre-commit
   gate (which aborts the commit, with the real reason often scrolled off the top of
   the hook output); `force_login(user)` authenticates without one, so drop it.
+- **jsdom: don't `vi.spyOn(window.location, 'assign')`** — `assign`/`replace`/
+  `reload` are non-configurable, so the spy throws `Cannot redefine property:
+  assign`. Replace the whole `window.location` property via `Object.defineProperty`
+  in `beforeEach` (restore in `afterEach`). See `web/docs/patterns/testing.md`.
+- **`getByRole` `name` as a regex is a SUBSTRING match → ambiguous when two
+  controls share a label.** `{ name: /sign in/i }` matches both `"Sign in"` and
+  `"Sign in with Google"` → "Found multiple elements". Use an exact string
+  (`{ name: 'Sign in' }`) once a page has both.

--- a/docs/rules/triggers.json
+++ b/docs/rules/triggers.json
@@ -284,5 +284,21 @@
     "source": "codify: chore/codify-248-schema-gating",
     "added": "2026-06-27",
     "severity": "warn"
+  },
+  {
+    "id": "jsdom-spyon-window-location",
+    "domains": [
+      "testing",
+      "react"
+    ],
+    "path_glob": [
+      "web/src/**/*.test.tsx"
+    ],
+    "content_present": "spyOn\\(\\s*window\\.location",
+    "message": "jsdom makes window.location.assign/replace/reload NON-configurable — vi.spyOn(window.location, 'assign') throws 'Cannot redefine property: assign'. Replace the whole window.location via Object.defineProperty in beforeEach (restore in afterEach). See web/docs/patterns/testing.md.",
+    "pattern_ref": "web/docs/patterns/testing.md",
+    "source": "codify: feat/web-google-signin",
+    "added": "2026-06-27",
+    "severity": "warn"
   }
 ]

--- a/web/docs/patterns/testing.md
+++ b/web/docs/patterns/testing.md
@@ -119,3 +119,69 @@ Gotchas:
 - Test-fixture passwords (`password: '...'`) trip detect-secrets — add
   `// pragma: allowlist secret` on the literal's line, and put it on a `const` so
   Prettier can't shift the comment off that line.
+
+---
+
+## Mocking browser navigation (`window.location.assign`) in jsdom
+
+jsdom makes `window.location.assign` (and `.replace`/`.reload`) **non-configurable**,
+so `vi.spyOn(window.location, 'assign')` throws `TypeError: Cannot redefine
+property: assign`. Replace the whole `window.location` property instead, and
+restore it in `afterEach` (the property itself *is* configurable; its methods
+are not). Canonical — `src/components/auth/GoogleSignInButton.test.tsx`:
+
+```typescript
+describe('GoogleSignInButton', () => {
+  const assignMock = vi.fn();
+  let originalLocation: Location;
+
+  beforeEach(() => {
+    originalLocation = window.location;
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      writable: true,
+      value: { assign: assignMock, href: '' }, // only stub what the component reads
+    });
+    assignMock.mockReset();
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      writable: true,
+      value: originalLocation,
+    });
+  });
+
+  it('redirects on click', async () => {
+    render(<GoogleSignInButton />);
+    fireEvent.click(screen.getByRole('button', { name: 'Sign in with Google' }));
+    await waitFor(() => expect(assignMock).toHaveBeenCalledWith(expectedUrl));
+  });
+});
+```
+
+A minimal `{ assign, href }` stub is enough when the component under test reads
+nothing else off `location` and renders without a Router.
+
+---
+
+## Disambiguate `getByRole` by exact name when controls share a label substring
+
+A `name` **regex** does a *substring* match, so `getByRole('button', { name:
+/sign in/i })` matches BOTH `"Sign in"` and `"Sign in with Google"` once a page
+has both → `TestingLibraryElementError: Found multiple elements`. When two
+controls share a label substring, switch to an **exact string** `name` (full,
+normalised accessible-name match):
+
+```typescript
+// ✅ exact — targets only the password submit button
+screen.getByRole('button', { name: 'Sign in' });
+screen.getByRole('button', { name: 'Sign in with Google' });
+
+// ❌ substring regex — ambiguous once a second "Sign in…" control exists
+screen.getByRole('button', { name: /sign in/i });
+```
+
+This bit `LoginPage.test.tsx` the moment the Google button landed next to the
+password submit. The `/regex/` form is still fine when only one control matches.


### PR DESCRIPTION
Codification follow-up to #418 (web Google sign-in). Docs-only; no code.

This commit was authored during the `/codify` pass but #418's auto-merge fired
before it could ride that PR, so it lands separately here.

## What's codified

- **`web/docs/patterns/testing.md` + `docs/rules/testing.md`**
  - jsdom makes `window.location.assign`/`replace`/`reload` **non-configurable** →
    `vi.spyOn(window.location, 'assign')` throws `Cannot redefine property`.
    Replace the whole `window.location` property via `Object.defineProperty`.
  - `getByRole` `name` **regex is a substring match** → ambiguous once two controls
    share a label (`"Sign in"` vs `"Sign in with Google"`). Use an exact string.
- **`docs/LEARNINGS.md`** — cross-site OAuth `state` rides the Django session
  cookie; SameSite=Strict (prod default) drops it → silent `invalid_state`. Needs
  `SESSION_COOKIE_SAMESITE=None` (necessary, maybe not sufficient vs Safari ITP /
  third-party-cookie deprecation). Tracked under todo 240.
- **`docs/rules/triggers.json`** — write-time trigger for the `spyOn(window.location)`
  signature (validated: fires on the anti-pattern, silent on the fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)