### PR TITLE
241: switch Railway builder NIXPACKS → RAILPACK (keep secrets out of image layers)

### DIFF
--- a/backend/railway.json
+++ b/backend/railway.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://railway.com/railway.schema.json",
   "build": {
-    "builder": "NIXPACKS"
+    "builder": "RAILPACK"
   },
   "deploy": {
     "startCommand": "python manage.py migrate --noinput && python manage.py seed_default_forum && python manage.py collectstatic --noinput --verbosity 0 && gunicorn plant_community_backend.wsgi:application --bind 0.0.0.0:$PORT --workers 2 --timeout 120",


### PR DESCRIPTION
## What

Switches the backend Railway builder from `NIXPACKS` to `RAILPACK` (Railway's current default) in `backend/railway.json`.

## Why

The `NIXPACKS` builder generates `ARG`+`ENV` instructions for every secret-named service variable, so 9 app secrets get baked into the final image layers (and persist in image history). Every build log warns:

```
[WARN] SecretsUsedInArgOrEnv: Do not use ARG or ENV instructions for sensitive data (ENV "SECRET_KEY") (line 12)
```

Affected secrets: `SECRET_KEY`, `JWT_SECRET_KEY`, `PLANT_ID_API_KEY`, `PLANTNET_API_KEY`, `TREFLE_API_KEY`, `PLANT_HEALTH_API_KEY`, `OPENAI_API_KEY`, `GOOGLE_OAUTH2_CLIENT_SECRET`, `EMAIL_HOST_PASSWORD`.

`RAILPACK` injects build-time env via BuildKit **secret mounts** instead of baking `ENV` layers, so the secrets are no longer persisted in the image. Nothing genuinely needs these at build time — `migrate`/`seed`/`collectstatic`/`gunicorn` all run in the deploy **start** command.

## Verification

After merge, Railway auto-deploys from `main`. The new build log should no longer contain `SecretsUsedInArgOrEnv` for app secrets, and the build/deploy should succeed (the start command is unchanged).

## Follow-up (separate, manual)

Per todo 241 AC2: rotate the 2 self-rotatable Django secrets (`SECRET_KEY`, `JWT_SECRET_KEY`) **after** this lands so the old baked values are retired; accept-risk documented for the 7 externally-issued keys (private registry, no users yet).

Closes part of todo 241.

🤖 Generated with [Claude Code](https://claude.com/claude-code)