### PR TITLE
241: revert builder to NIXPACKS (RAILPACK incompatible with editable local package)

### DIFF
--- a/backend/railway.json
+++ b/backend/railway.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://railway.com/railway.schema.json",
   "build": {
-    "builder": "RAILPACK"
+    "builder": "NIXPACKS"
   },
   "deploy": {
     "startCommand": "python manage.py migrate --noinput && python manage.py seed_default_forum && python manage.py collectstatic --noinput --verbosity 0 && gunicorn plant_community_backend.wsgi:application --bind 0.0.0.0:$PORT --workers 2 --timeout 120",


### PR DESCRIPTION
## Why

PR #421 switched the builder to RAILPACK and merged, but the RAILPACK **build failed**:

```
[INFO] pip install -r requirements.txt
[INFO] ERROR: ./packages/wagtail_forum is not a valid editable requirement...
Build Failed
```

RAILPACK copies only `requirements.txt`+`pyproject.toml` before `pip install`, so the editable local dep `-e ./packages/wagtail_forum` (requirements.txt:228) isn't present yet. NIXPACKS copied the whole context first, so it never hit this.

This left `main` on a non-deployable builder (prod stayed healthy on the prior NIXPACKS image since the failed build never swapped in). **This PR restores `main` to a deployable state.**

## Next

The durable fix for the original secret-baking problem will land separately via a **DOCKERFILE** builder (`COPY . .` then `pip install` → editable package works; never `ARG`/`ENV`s secrets → nothing baked). Part of todo 241.

🤖 Generated with [Claude Code](https://claude.com/claude-code)