### PR TITLE
241: DOCKERFILE builder — keep secrets out of image layers (RAILPACK was incompatible)

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,32 @@
+# Local virtualenv and Python caches (never belong in the image)
+venv/
+.venv/
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+*.egg-info/
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+htmlcov/
+.coverage
+
+# Secrets and local env (MUST NOT be baked into image layers)
+.env
+.env.*
+
+# Runtime/local artifacts — regenerated or not needed in the image
+media/
+staticfiles/
+logs/
+*.log
+
+# VCS and editor noise
+.git/
+.gitignore
+.DS_Store
+
+# Repo bookkeeping not needed at runtime
+todos/
+github-issues/

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,38 @@
+# Backend image for Railway (DOCKERFILE builder).
+#
+# Why a Dockerfile instead of NIXPACKS/RAILPACK (todo 241):
+#   1. Secrets: with the DOCKERFILE builder Railway only exposes build-time
+#      variables that are explicitly declared with `ARG`. This file declares
+#      NONE, so no app secrets are passed into the build — nothing is baked into
+#      image layers (NIXPACKS emitted `ENV SECRET_KEY=...` etc. and tripped the
+#      BuildKit `SecretsUsedInArgOrEnv` lint).
+#   2. Editable local package: `requirements.txt` installs `-e ./packages/
+#      wagtail_forum`. RAILPACK copies only requirements.txt before `pip install`
+#      and fails ("not a valid editable requirement"). Here we `COPY . .` first,
+#      so the local package path exists at install time.
+FROM python:3.13-slim
+
+# System deps: libpq for psycopg, build-essential as a safety net for any
+# dependency that lacks a cp313 wheel. Apt lists are dropped to keep the layer small.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends build-essential libpq-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1
+
+WORKDIR /app
+
+# Copy the full build context BEFORE installing so `-e ./packages/wagtail_forum`
+# resolves. No secret ARG/ENV above this line → no secrets in image layers.
+COPY . .
+
+RUN pip install --upgrade pip && pip install -r requirements.txt
+
+# Railway's railway.json `deploy.startCommand` overrides this at deploy time
+# (migrate + seed + collectstatic + gunicorn). CMD is a sane fallback for a bare
+# `docker run`; secrets are injected by Railway at runtime, never at build.
+EXPOSE 8000
+CMD ["gunicorn", "plant_community_backend.wsgi:application", "--bind", "0.0.0.0:8000", "--workers", "2", "--timeout", "120"]

--- a/backend/railway.json
+++ b/backend/railway.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://railway.com/railway.schema.json",
   "build": {
-    "builder": "NIXPACKS"
+    "builder": "DOCKERFILE"
   },
   "deploy": {
     "startCommand": "python manage.py migrate --noinput && python manage.py seed_default_forum && python manage.py collectstatic --noinput --verbosity 0 && gunicorn plant_community_backend.wsgi:application --bind 0.0.0.0:$PORT --workers 2 --timeout 120",


### PR DESCRIPTION
## What

Replaces the `NIXPACKS` builder with a hand-written **Dockerfile** (`backend/Dockerfile` + `backend/.dockerignore`; `railway.json` builder → `DOCKERFILE`).

## Why

NIXPACKS generated `ARG`+`ENV` for 9 secret-named service vars, baking them into image layers (`SecretsUsedInArgOrEnv`). The intended one-line fix (RAILPACK) **failed to build**: RAILPACK copies only `requirements.txt` before `pip install`, so the editable local dep `-e ./packages/wagtail_forum` errors. A Dockerfile fixes both problems:

- **Copy order** — `COPY . .` *then* `pip install`, so the editable package resolves.
- **No baking** — with the DOCKERFILE builder Railway only exposes build vars you explicitly `ARG`. This Dockerfile declares **none**, so no app secrets enter the build → nothing is persisted in image layers. Secrets are injected by Railway at **runtime**.

## Dockerfile

`python:3.13-slim` + `build-essential`/`libpq-dev` (safety net for any non-wheel dep) → `COPY . .` → `pip install -r requirements.txt`. The runtime start chain (migrate/seed/collectstatic/gunicorn) stays in `railway.json`'s `startCommand`. `.dockerignore` excludes the local `venv/` (652M), `media/`, `.env`, and caches.

## Verification (post-merge)

Railway auto-deploys from `main` on merge. Expected: build log no longer contains `SecretsUsedInArgOrEnv`, build + deploy succeed, app healthy. A failed build leaves the current NIXPACKS deploy untouched (prod stays up). If it fails, revert and fix forward.

## Follow-up

Rotate `SECRET_KEY` + `JWT_SECRET_KEY` after this lands (now meaningful — the new builder doesn't bake), retiring the old baked values. Closes todo 241 (with AC2 rotation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)