### PR TITLE
241: DOCKERFILE builder, guarded by healthcheck + preDeployCommand (safe retry)

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,32 @@
+# Local virtualenv and Python caches (never belong in the image)
+venv/
+.venv/
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+*.egg-info/
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+htmlcov/
+.coverage
+
+# Secrets and local env (MUST NOT be baked into image layers)
+.env
+.env.*
+
+# Runtime/local artifacts — regenerated or not needed in the image
+media/
+staticfiles/
+logs/
+*.log
+
+# VCS and editor noise
+.git/
+.gitignore
+.DS_Store
+
+# Repo bookkeeping not needed at runtime
+todos/
+github-issues/

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,38 @@
+# Backend image for Railway (DOCKERFILE builder).
+#
+# Why a Dockerfile instead of NIXPACKS/RAILPACK (todo 241):
+#   1. Secrets: with the DOCKERFILE builder Railway only exposes build-time
+#      variables that are explicitly declared with `ARG`. This file declares
+#      NONE, so no app secrets are passed into the build — nothing is baked into
+#      image layers (NIXPACKS emitted `ENV SECRET_KEY=...` etc. and tripped the
+#      BuildKit `SecretsUsedInArgOrEnv` lint).
+#   2. Editable local package: `requirements.txt` installs `-e ./packages/
+#      wagtail_forum`. RAILPACK copies only requirements.txt before `pip install`
+#      and fails ("not a valid editable requirement"). Here we `COPY . .` first,
+#      so the local package path exists at install time.
+FROM python:3.13-slim
+
+# System deps: libpq for psycopg, build-essential as a safety net for any
+# dependency that lacks a cp313 wheel. Apt lists are dropped to keep the layer small.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends build-essential libpq-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1
+
+WORKDIR /app
+
+# Copy the full build context BEFORE installing so `-e ./packages/wagtail_forum`
+# resolves. No secret ARG/ENV above this line → no secrets in image layers.
+COPY . .
+
+RUN pip install --upgrade pip && pip install -r requirements.txt
+
+# Railway's railway.json `deploy.startCommand` overrides this at deploy time
+# (migrate + seed + collectstatic + gunicorn). CMD is a sane fallback for a bare
+# `docker run`; secrets are injected by Railway at runtime, never at build.
+EXPOSE 8000
+CMD ["gunicorn", "plant_community_backend.wsgi:application", "--bind", "0.0.0.0:8000", "--workers", "2", "--timeout", "120"]

--- a/backend/railway.json
+++ b/backend/railway.json
@@ -1,10 +1,13 @@
 {
   "$schema": "https://railway.com/railway.schema.json",
   "build": {
-    "builder": "NIXPACKS"
+    "builder": "DOCKERFILE"
   },
   "deploy": {
-    "startCommand": "python manage.py migrate --noinput && python manage.py seed_default_forum && python manage.py collectstatic --noinput --verbosity 0 && gunicorn plant_community_backend.wsgi:application --bind 0.0.0.0:$PORT --workers 2 --timeout 120",
+    "preDeployCommand": "python manage.py migrate --noinput && python manage.py seed_default_forum",
+    "startCommand": "python manage.py collectstatic --noinput --verbosity 0 && gunicorn plant_community_backend.wsgi:application --bind 0.0.0.0:$PORT --workers 2 --timeout 120",
+    "healthcheckPath": "/api/v1/plant-identification/health/",
+    "healthcheckTimeout": 300,
     "restartPolicyType": "ON_FAILURE",
     "restartPolicyMaxRetries": 5
   }


### PR DESCRIPTION
## What

Re-attempts the **DOCKERFILE builder** (keeps app secrets out of image layers — AC1), this time made **outage-proof** with a healthcheck + a pre-deploy command.

## Background

The first DOCKERFILE attempt (#423) built cleanly and met AC1, but the container hung at startup. Because **no healthcheck** was configured, Railway swapped traffic to the hung container immediately → ~1h40m 502 outage (reverted #424).

I then ran **6 local reproductions** (sqlite/Postgres, DEBUG on/off, pre-migrated DB, reachable Redis, full prod-like env). **Every one built and served.** So the Dockerfile is correct in every local config — the hang is triggered only by real prod values / Railway runtime, which can't be reproduced locally without prod secrets.

## Why this is safe (verified against Railway docs)

- **`healthcheckPath`** = `/api/v1/plant-identification/health/` (returns **200** unauthenticated — verified on live prod). Per Railway: *"Railway will query the endpoint until it receives an HTTP 200... Only then will the new deployment be made active and the previous deployment inactive."* → a hung container **never** gets traffic; the deploy fails after `healthcheckTimeout` (300s) and the current NIXPACKS deploy keeps serving. **No outage.**
- **`preDeployCommand`** = `migrate && seed` runs in a one-off instance. Per Railway: *"if a pre-deploy command fails... the deployment will be halted."* → if the DB-startup step is where it hangs, the deploy halts with diagnostic logs and prod is untouched.
- `collectstatic` stays in `startCommand` (its output must live in the serving container) — backstopped by the healthcheck.

## Outcome (either way, zero outage risk)

- **Deploys cleanly** → the Dockerfile serves in prod, AC1 is genuinely closed, and I'll rotate `SECRET_KEY`/`JWT_SECRET_KEY` + reopen/finalize todo 241.
- **Fails loudly** → preDeploy/healthcheck logs reveal the root cause; prod stays on NIXPACKS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)