### PR TITLE
241: DIAGNOSTIC — collectstatic --verbosity 2 to locate the prod runtime stall

### DIFF
--- a/backend/railway.json
+++ b/backend/railway.json
@@ -5,9 +5,9 @@
   },
   "deploy": {
     "preDeployCommand": "python manage.py migrate --noinput && python manage.py seed_default_forum",
-    "startCommand": "python manage.py collectstatic --noinput --verbosity 0 && gunicorn plant_community_backend.wsgi:application --bind 0.0.0.0:$PORT --workers 2 --timeout 120",
+    "startCommand": "python manage.py collectstatic --noinput --verbosity 2 && gunicorn plant_community_backend.wsgi:application --bind 0.0.0.0:$PORT --workers 2 --timeout 120",
     "healthcheckPath": "/api/v1/plant-identification/health/",
-    "healthcheckTimeout": 300,
+    "healthcheckTimeout": 800,
     "restartPolicyType": "ON_FAILURE",
     "restartPolicyMaxRetries": 5
   }


### PR DESCRIPTION
## Purpose (diagnostic, not a fix)

The guarded retry (#426) isolated the deploy failure to the start command's `collectstatic` — it ran app-init then stalled >5 min, gunicorn never started, healthcheck failed, prod stayed on NIXPACKS (no outage). Plain `collectstatic` of 274 files is ~1.5s everywhere I can test locally, so **why it stalls in Railway's runtime is unexplained.**

This deploy runs `collectstatic --verbosity 2` (logs each file as it processes) with `healthcheckTimeout=800`, so the deploy log will **name the exact file/step it stalls on** — or show it merely being slow (and completing).

Still guarded by `preDeployCommand` + healthcheck → **zero outage risk**. The validated fix (bake collectstatic at build → gunicorn-only start) lands next, once the cause is understood.

🤖 Generated with [Claude Code](https://claude.com/claude-code)