### PR TITLE
241: fix — bake collectstatic at build + gunicorn-only start + health redirect-exempt

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -31,8 +31,20 @@ COPY . .
 
 RUN pip install --upgrade pip && pip install -r requirements.txt
 
+# Collect static assets at BUILD time so the runtime start command is gunicorn-only.
+# Why: in Railway's runtime container under python:3.13-slim, `collectstatic` copies
+# each file pathologically slowly (~3s/file × 262 ≈ 13min — a filesystem-perf issue,
+# proven by a --verbosity 2 diagnostic deploy), which ate the whole healthcheck window
+# so gunicorn never started. Running it once here (build infra, not healthcheck-gated)
+# moves that cost off the deploy path. The env vars are throwaway, build-only, and
+# inline on RUN (NOT ENV/ARG instructions) → nothing is baked into image layers and the
+# SecretsUsedInArgOrEnv lint is not tripped. DEBUG=True lets settings import without the
+# prod/Redis validation. The trailing `# pragma` is a shell comment (command still runs)
+# that tells detect-secrets the throwaway JWT value is intentional, not a real secret.
+RUN DEBUG=True JWT_SECRET_KEY=build-only-throwaway-value-not-a-real-key-000000000000000 DATABASE_URL=sqlite:////tmp/build.sqlite3 python manage.py collectstatic --noinput --verbosity 1  # pragma: allowlist secret
+
 # Railway's railway.json `deploy.startCommand` overrides this at deploy time
-# (migrate + seed + collectstatic + gunicorn). CMD is a sane fallback for a bare
-# `docker run`; secrets are injected by Railway at runtime, never at build.
+# (now gunicorn-only — migrate/seed run in preDeployCommand, static baked above).
+# CMD is a sane fallback for a bare `docker run`; secrets are injected at runtime.
 EXPOSE 8000
 CMD ["gunicorn", "plant_community_backend.wsgi:application", "--bind", "0.0.0.0:8000", "--workers", "2", "--timeout", "120"]

--- a/backend/plant_community_backend/settings.py
+++ b/backend/plant_community_backend/settings.py
@@ -972,6 +972,12 @@ SECURE_SSL_REDIRECT = not DEBUG
 if config("TRUST_PROXY_SSL_HEADER", default=False, cast=bool):
     SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 
+# Railway's platform healthcheck probes the container over plain HTTP and does not
+# set X-Forwarded-Proto, so with SECURE_SSL_REDIRECT the health endpoint would 301
+# and the healthcheck (which requires a 200) would fail the deploy. Exempt only that
+# one path from the HTTPS redirect; it exposes no sensitive data.
+SECURE_REDIRECT_EXEMPT = [r"^api/v1/plant-identification/health/$"]
+
 # Per-IP rate limiting behind a reverse proxy (todo 218). django-ratelimit's
 # key="ip" keys on REMOTE_ADDR, which behind Railway's proxy is the *proxy*
 # address — so the per-IP limit never accumulates per real client. apps.core

--- a/backend/railway.json
+++ b/backend/railway.json
@@ -5,9 +5,9 @@
   },
   "deploy": {
     "preDeployCommand": "python manage.py migrate --noinput && python manage.py seed_default_forum",
-    "startCommand": "python manage.py collectstatic --noinput --verbosity 2 && gunicorn plant_community_backend.wsgi:application --bind 0.0.0.0:$PORT --workers 2 --timeout 120",
+    "startCommand": "gunicorn plant_community_backend.wsgi:application --bind 0.0.0.0:$PORT --workers 2 --timeout 120",
     "healthcheckPath": "/api/v1/plant-identification/health/",
-    "healthcheckTimeout": 800,
+    "healthcheckTimeout": 300,
     "restartPolicyType": "ON_FAILURE",
     "restartPolicyMaxRetries": 5
   }


### PR DESCRIPTION
## Root cause (proven by diagnostic #427)

`collectstatic --verbosity 2` in prod: it **completes** ("262 static files copied") but is **pathologically slow in Railway's runtime** under `python:3.13-slim` — ~3s/small-file × 262 ≈ **13 min** (a filesystem-perf issue NIXPACKS-Ubuntu didn't hit). It consumed the whole healthcheck window, so gunicorn never started. Not a hang, not the 301.

## Fix (all locally validated: Postgres+Redis, DEBUG=False)

- **Dockerfile** — run `collectstatic` at **build** (~1.5s on build infra; throwaway inline `DEBUG`/`JWT` env, *not* `ENV`/`ARG` → nothing baked, **AC1 clean**). Runtime start = **gunicorn-only** → serves in seconds.
- **settings.py** — `SECURE_REDIRECT_EXEMPT` the health path (Railway's healthcheck probes over HTTP without `X-Forwarded-Proto`; otherwise `SECURE_SSL_REDIRECT` 301s it and the 200-requiring healthcheck fails). Surgical — only that path.
- **railway.json** — `startCommand`=gunicorn only; `preDeployCommand`=migrate+seed; healthcheck retained (timeout 300).

Local checks: build bakes 274 files in ~1.5s; gunicorn-only serves; **health=200 with AND without the proxy header**; static asset=200; non-exempt paths still 301.

## Outcome (guarded → no outage risk)

Deploys cleanly → the Dockerfile serves in prod with no secrets in image layers → **AC1 genuinely closed**; I then rotate `SECRET_KEY`/`JWT_SECRET_KEY` and finalize todo 241 as truly fixed. If not, fails safely with logs; prod stays on NIXPACKS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)