### PR TITLE
241: fix $PORT expansion — wrap gunicorn start in sh -c (final)

### DIFF
--- a/backend/railway.json
+++ b/backend/railway.json
@@ -5,7 +5,7 @@
   },
   "deploy": {
     "preDeployCommand": "python manage.py migrate --noinput && python manage.py seed_default_forum",
-    "startCommand": "gunicorn plant_community_backend.wsgi:application --bind 0.0.0.0:$PORT --workers 2 --timeout 120",
+    "startCommand": "sh -c 'gunicorn plant_community_backend.wsgi:application --bind 0.0.0.0:$PORT --workers 2 --timeout 120'",
     "healthcheckPath": "/api/v1/plant-identification/health/",
     "healthcheckTimeout": 300,
     "restartPolicyType": "ON_FAILURE",


### PR DESCRIPTION
## What

One-line follow-up to the fix (#428): wrap the gunicorn `startCommand` in `sh -c '...'`.

## Why

#428's deploy failed with `Error: '$PORT' is not a valid port number` — gunicorn crash-looped. With the DOCKERFILE builder and a **bare** `gunicorn ...` start command, Railway execs it directly (no shell), so `$PORT` was passed literally. (Earlier `collectstatic && gunicorn` versions had `&&`, forcing a shell — which is why `$PORT` worked under NIXPACKS.)

Wrapping in `sh -c '...'` restores shell expansion. **Validated locally with `PORT=9000`:** gunicorn binds `0.0.0.0:9000`, health=200 (my earlier validation hardcoded `:8000` and never exercised `$PORT` — now tested explicitly).

Everything else from #428 stands (collectstatic baked at build, gunicorn-only start, health SSL-redirect-exempt, preDeploy migrate/seed, healthcheck). Guarded → no outage risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)