### PR TITLE
241: allow Railway healthcheck host in ALLOWED_HOSTS (final DOCKERFILE piece)

### DIFF
--- a/backend/plant_community_backend/settings.py
+++ b/backend/plant_community_backend/settings.py
@@ -112,6 +112,13 @@ ALLOWED_HOSTS = config(
     cast=lambda v: [s.strip() for s in v.split(",")],
 )
 
+# Railway's platform healthcheck probes the container with Host: healthcheck.railway.app.
+# Django's ALLOWED_HOSTS check (get_host) rejects unknown hosts with a 400 before the view
+# runs, which fails the healthcheck (it requires a 200). Always allow that internal host —
+# it is only reachable via Railway's healthcheck, never publicly routable to the container.
+if "healthcheck.railway.app" not in ALLOWED_HOSTS:
+    ALLOWED_HOSTS.append("healthcheck.railway.app")
+
 # Application definition
 DJANGO_APPS = [
     "django.contrib.admin",


### PR DESCRIPTION
## What

Append `healthcheck.railway.app` to `ALLOWED_HOSTS`.

## Why

#429 got gunicorn **serving** (the `$PORT` fix worked), but the healthcheck still failed: Railway's platform probe sends `Host: healthcheck.railway.app`, which isn't in `ALLOWED_HOSTS`, so Django returned **400 DisallowedHost** before the view ran → the 200-requiring healthcheck failed → deploy rolled back. (NIXPACKS never hit this — it had no healthcheck configured.)

Validated locally simulating the **exact** probe (`Host: healthcheck.railway.app`, plain HTTP → **200**); a bogus host still → **400**, so the ALLOWED_HOSTS restriction is intact.

## This completes the DOCKERFILE migration

Every failure mode found via guarded deploys + local repro is now fixed & validated:
- collectstatic **baked at build** (runtime was ~3s/file slow)
- **gunicorn-only** start, `$PORT` expanded via `sh -c`
- health path **SSL-redirect-exempt** (probe is plain HTTP)
- healthcheck **Host allowed**

Result: the Dockerfile serves in prod with **zero secrets in image layers (AC1)**. On success I rotate `SECRET_KEY`/`JWT_SECRET_KEY` and finalize todo 241. Guarded (preDeploy + healthcheck) → no outage risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)