### PR TITLE
security-scan: bump joserfc to 1.6.8, suppress unfixable nltk PYSEC-2026-597

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -49,6 +49,7 @@ jobs:
           # CVE-2026-42304 (Twisted 25.5.0): no stable fix exists (fix is RC-only 26.4.0rc2). Remove when Twisted >=26.4.0 stable releases.
           # PYSEC-2026-89  (Markdown 3.8.1): no upstream fix (OSV: all versions affected); markdown not imported by app code; DoS path unreachable.
           # PYSEC-2026-97  (nltk 3.9.4):     no upstream fix (already latest); filestring() path traversal not called by app code.
+          # PYSEC-2026-597 (nltk 3.9.4):     no upstream fix (OSV last_affected=3.9.4, the latest release); percent-encoded path traversal in nltk.data.load()/find(), which app code never calls (nltk is transitive; zero nltk imports in apps/, packages/, plant_community/).
           # PYSEC-2024-277 (joblib 1.5.2):   supplier-disputed; not imported by app code.
           # PYSEC-2025-183 (PyJWT 2.13.0):   supplier-disputed; mitigated by JWT_SECRET_KEY (the SIMPLE_JWT SIGNING_KEY PyJWT signs with), validated >=50 chars fail-fast at settings import in ALL environments (settings.py:658).
           # CVE-2026-31236 (llm 0.27.1):     no upstream fix per OSV/PyPI advisory; llm is a wagtail-ai transitive dep, not imported directly by app code. Remove when a patched llm release ships.
@@ -56,6 +57,7 @@ jobs:
             --ignore-vuln CVE-2026-42304 \
             --ignore-vuln PYSEC-2026-89 \
             --ignore-vuln PYSEC-2026-97 \
+            --ignore-vuln PYSEC-2026-597 \
             --ignore-vuln PYSEC-2024-277 \
             --ignore-vuln PYSEC-2025-183 \
             --ignore-vuln CVE-2026-31236

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -109,7 +109,7 @@ jedi==0.19.2
 Jinja2==3.1.6
 jiter==0.11.1
 joblib==1.5.2
-joserfc==1.6.7
+joserfc==1.6.8
 jsonschema==4.25.1
 jsonschema-specifications==2025.9.1
 kombu==5.6.2


### PR DESCRIPTION
## Summary

Two new upstream advisories turned **Backend Python Security Scan** red on every branch (first seen on PR #432 — unrelated to its code):

- **joserfc 1.6.7 → CVE-2026-49852**: upstream fix exists — pin bumped to **1.6.8** (Authlib's constraint is `joserfc>=1.6.0`, compatible; only importer is Authlib, no direct app imports).
- **nltk 3.9.4 → PYSEC-2026-597 (CVE-2026-12243)**: percent-encoded path traversal in `nltk.data.load()`/`find()`. OSV lists `last_affected = 3.9.4`, which is the **latest release** — nothing to upgrade to. nltk is transitive with zero imports in `apps/`, `packages/`, `plant_community/`, same rationale as the already-suppressed PYSEC-2026-97 → added to the pip-audit ignore list with a rationale comment (revisit tracked in todo 089, per the existing comment block).

## Testing

Ran the exact CI pip-audit command locally with the new ignore flag against the bumped requirements.txt:

```
No known vulnerabilities found, 4 ignored
```

exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)