### PR TITLE
docs: remove stale warm_moderation_cache references (retired with machina)

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -24,9 +24,9 @@ python manage.py test apps.forum --keepdb
 python manage.py test apps.garden_calendar --keepdb
 python manage.py test apps.users --keepdb
 
-# Cache warming (run after deploy to eliminate cold start penalty)
-python manage.py warm_moderation_cache
-python manage.py warm_moderation_cache --force
+# Optional cache warming — blog AI cache only (the forum moderation cache was
+# retired with django-machina, PR #362; there is no forum cache to warm)
+python manage.py warm_ai_cache --force
 
 python manage.py seed_default_forum    # ensure the forum has a default board (idempotent)
 

--- a/backend/docs/patterns/architecture/caching.md
+++ b/backend/docs/patterns/architecture/caching.md
@@ -2,6 +2,7 @@
 
 **Last Updated**: November 13, 2025
 **Consolidated From**:
+
 - `docs/development/BLOG_CACHING_PATTERNS_REFERENCE.md` (blog caching)
 - `SPAM_DETECTION_PATTERNS_CODIFIED.md` (spam detection caching)
 - `TRUST_LEVEL_PATTERNS_CODIFIED.md` (trust level caching)
@@ -30,6 +31,7 @@
 **Design Decision**: Use static methods class (not singleton, not instance-based) for zero overhead and simple API.
 
 **Benefits**:
+
 - No instantiation required
 - All methods accessible via class name
 - Thread-safe by design (no shared instance state)
@@ -42,6 +44,7 @@
 **Location**: `apps/blog/services/blog_cache_service.py`
 
 **Implementation**:
+
 ```python
 import hashlib
 import json
@@ -177,11 +180,13 @@ class BlogCacheService:
 **Location**: `apps/forum/services/forum_cache_service.py`
 
 **Key Differences from Blog**:
+
 - Shorter TTL (1-6 hours vs 24 hours)
 - More complex keys (category hierarchy)
 - Higher invalidation frequency (user interactions)
 
 **Implementation**:
+
 ```python
 class ForumCacheService:
     """Caching service for forum threads, posts, and categories."""
@@ -233,6 +238,7 @@ class ForumCacheService:
 **Format**: `{prefix}:{slug}`
 
 **Examples**:
+
 ```python
 # Blog post
 cache_key = f"{CACHE_PREFIX_BLOG_POST}:{slug}"
@@ -254,6 +260,7 @@ cache_key = f"{CACHE_PREFIX_FORUM_CATEGORY}:{slug}"
 **Use Case**: List views with multiple filter combinations
 
 **Problem**: Simple concatenation creates collision risk
+
 ```python
 # ❌ COLLISION RISK - Different filters, same concatenation
 filters1 = {"category": "plants", "tag": "care"}
@@ -262,6 +269,7 @@ filters2 = {"category": "plantstag", "tag": "care"}
 ```
 
 **Solution**: SHA-256 hash of JSON-serialized filters
+
 ```python
 import hashlib
 import json
@@ -289,6 +297,7 @@ cache_key = f"{CACHE_PREFIX_BLOG_LIST}:{page}:{limit}:{filters_hash}"
 ```
 
 **Why sort_keys=True**:
+
 ```python
 # Without sort_keys - different hashes for same filters
 hash1 = hash(json.dumps({"a": 1, "b": 2}))  # {"a": 1, "b": 2}
@@ -308,6 +317,7 @@ hash2 = hash(json.dumps({"b": 2, "a": 1}, sort_keys=True))  # {"a": 1, "b": 2} -
 **Format**: `{prefix}:{parent}:{child}:{filters_hash}`
 
 **Implementation**:
+
 ```python
 # Thread list in category
 cache_key = f"{CACHE_PREFIX_FORUM_LIST}:{category_slug}:{page}:{limit}:{filters_hash}"
@@ -319,6 +329,7 @@ cache_key = f"{CACHE_PREFIX_FORUM_POSTS}:{thread_slug}:{page}:{limit}"
 ```
 
 **Benefits**:
+
 - Easy invalidation by parent (delete all threads in category)
 - Clear hierarchy in Redis inspection
 - Supports wildcard pattern matching
@@ -332,6 +343,7 @@ cache_key = f"{CACHE_PREFIX_FORUM_POSTS}:{thread_slug}:{page}:{limit}"
 **Format**: `{prefix}:{user_id}` or `{prefix}:{username}`
 
 **Examples**:
+
 ```python
 # Trust level limits cache
 cache_key = f"trust_limits:user:{user.id}"
@@ -361,6 +373,7 @@ cache_key = f"ratelimit:{group}:{user.id}"
 ### Pattern: Redis Pattern Matching
 
 **Implementation**:
+
 ```python
 @staticmethod
 def invalidate_all_blog_lists() -> None:
@@ -376,6 +389,7 @@ def invalidate_all_blog_lists() -> None:
 ```
 
 **Why hasattr() Check**:
+
 - Django's default cache (memory/database) doesn't support pattern matching
 - Redis backend adds delete_pattern() method
 - Check prevents AttributeError in development
@@ -387,6 +401,7 @@ def invalidate_all_blog_lists() -> None:
 **Use Case**: When Redis pattern matching is unavailable (development, testing).
 
 **Implementation**:
+
 ```python
 class BlogCacheService:
     # Class-level tracking for non-Redis backends
@@ -433,6 +448,7 @@ class BlogCacheService:
 ```
 
 **Why Thread-Safe**:
+
 - Multiple requests may cache/invalidate simultaneously
 - Lock prevents race conditions in set operations
 - Ensures consistent tracking state
@@ -446,6 +462,7 @@ class BlogCacheService:
 **Location**: `apps/blog/signals.py`
 
 **Implementation**:
+
 ```python
 from django.db.models.signals import post_save, post_delete
 from wagtail.signals import page_published, page_unpublished
@@ -508,6 +525,7 @@ def invalidate_blog_post_cache_on_delete(sender, instance, **kwargs):
 ```
 
 **Why Lazy Import**:
+
 ```python
 # ❌ BAD - Circular dependency
 from apps.blog.services import BlogCacheService  # Top of file
@@ -519,6 +537,7 @@ def invalidate_cache(sender, **kwargs):
 ```
 
 **Why isinstance() Not hasattr()**:
+
 ```python
 # ❌ BAD - hasattr fails with Wagtail multi-table inheritance
 if hasattr(instance, 'slug'):  # Many models have 'slug'
@@ -536,6 +555,7 @@ if isinstance(instance, BlogPostPage):  # Only BlogPostPage
 **Complexity**: Posts affect multiple cache levels (thread, category, moderation dashboard).
 
 **Implementation**:
+
 ```python
 @receiver(post_save, sender=Post)
 def invalidate_post_caches(sender, instance, created, **kwargs):
@@ -571,58 +591,42 @@ def invalidate_post_caches(sender, instance, created, **kwargs):
 
 ### Pattern: Management Command Cache Warming
 
-**Use Case**: Pre-populate cache on deployment to eliminate cold start penalty.
+**Use Case**: Pre-populate cache on deployment to eliminate a cold-start penalty.
 
-**Performance Impact**:
-- **Cold start**: 500ms first request
-- **Warmed**: <50ms all requests
+> **Retired forum example.** The original example here (`warm_moderation_cache` /
+> `apps.forum.services.ModerationCacheService`) belonged to the django-machina
+> forum, retired in PR #362. Neither the command nor the service exists anymore,
+> and the Wagtail-native `wagtail_forum` has no moderation-dashboard cache to warm.
+> The live instance of this pattern is the **blog AI cache** below.
 
-**Location**: `apps/forum/management/commands/warm_moderation_cache.py`
+**Location (live)**: `apps/blog/management/commands/warm_ai_cache.py`
 
-**Implementation**:
+**Shape**:
+
 ```python
 from django.core.management.base import BaseCommand
-from apps.forum.services import ModerationCacheService
 
 class Command(BaseCommand):
-    help = 'Warm moderation dashboard cache on deployment'
+    help = "Pre-populate AI cache on deployment to eliminate cold-start penalty"
 
     def add_arguments(self, parser):
         parser.add_argument(
-            '--force',
-            action='store_true',
-            help='Force refresh even if cache exists'
+            "--force", action="store_true", help="Force regeneration"
         )
 
     def handle(self, *args, **options):
-        force = options.get('force', False)
-
-        self.stdout.write('Warming moderation dashboard cache...')
-
-        # Check if already cached
-        if not force and ModerationCacheService.is_cached():
-            self.stdout.write(
-                self.style.SUCCESS('Cache already warm - skipping (use --force to refresh)')
-            )
-            return
-
-        # Warm the cache
-        start_time = time.time()
-        ModerationCacheService.warm_dashboard_cache()
-        elapsed = time.time() - start_time
-
-        self.stdout.write(
-            self.style.SUCCESS(f'Cache warmed successfully in {elapsed:.2f}s')
-        )
+        # Warm the blog AI response cache; skip already-warm entries unless --force.
+        ...
 ```
 
 **Usage**:
-```bash
-# On deployment (post-deploy hook)
-python manage.py warm_moderation_cache
 
-# Force refresh
-python manage.py warm_moderation_cache --force
+```bash
+# Optional, post-deploy (NOT part of the Railway preDeployCommand)
+python manage.py warm_ai_cache
+
+# Force regeneration
+python manage.py warm_ai_cache --force
 ```
 
 ---
@@ -632,6 +636,7 @@ python manage.py warm_moderation_cache --force
 **Use Case**: Warm cache on first access, not on every deployment.
 
 **Implementation**:
+
 ```python
 @staticmethod
 def get_moderation_dashboard() -> Dict[str, Any]:
@@ -665,12 +670,14 @@ def get_moderation_dashboard() -> Dict[str, Any]:
 ### Blog Caching Performance
 
 **Measured Results** (production):
+
 - **Cache Hit Rate**: 40% (target: 35%+)
 - **Cached Response Time**: <50ms (target: <100ms)
 - **Uncached Response Time**: ~300ms (cold, 3-5 queries)
 - **TTL Strategy**: 24 hours (86400 seconds)
 
 **Why It Works**:
+
 - Blog content is relatively static (infrequent updates)
 - Aggressive signal-based invalidation ensures freshness
 - Dual-strategy invalidation handles all cache backends
@@ -680,12 +687,14 @@ def get_moderation_dashboard() -> Dict[str, Any]:
 ### Forum Caching Performance
 
 **Measured Results**:
+
 - **Cache Hit Rate**: 30% (target: >25%) - Lower due to user interactions
 - **Cached Response Time**: <50ms
 - **Uncached Response Time**: ~500ms (cold, 5-8 queries)
 - **TTL Strategy**: 1-6 hours - Shorter due to dynamic nature
 
 **Why Lower Hit Rate**:
+
 - Forum threads update more frequently (new posts, reactions)
 - User interactions (views, reactions) trigger invalidation
 - Higher query complexity (post counts, reaction aggregates)
@@ -695,12 +704,14 @@ def get_moderation_dashboard() -> Dict[str, Any]:
 ### Spam Detection Caching
 
 **Measured Results**:
+
 - **Cache Hit Rate**: 80% during spam attacks
 - **Cached Response Time**: <10ms
 - **Uncached Response Time**: ~150ms (duplicate checks, similarity)
 - **TTL Strategy**: 5 minutes
 
 **Why High Hit Rate**:
+
 - Spammers often retry same content
 - Short TTL prevents stale data
 - Targeted for attack scenarios
@@ -710,12 +721,14 @@ def get_moderation_dashboard() -> Dict[str, Any]:
 ### Trust Level Caching
 
 **Measured Results**:
+
 - **Cache Hit Rate**: 80% (target: >75%)
 - **Cached Response Time**: <10ms
 - **Uncached Response Time**: ~50ms (database query + calculation)
 - **TTL Strategy**: 1 hour
 
 **Why High Hit Rate**:
+
 - Trust levels change infrequently (automatic promotion daily)
 - Users perform multiple actions per session
 - Permissions checked on every request
@@ -727,6 +740,7 @@ def get_moderation_dashboard() -> Dict[str, Any]:
 ### Pitfall 1: Not Using Lazy Imports in Signals
 
 **Problem**:
+
 ```python
 # ❌ Circular import at module level
 from apps.blog.services import BlogCacheService
@@ -737,6 +751,7 @@ def invalidate_cache(sender, **kwargs):
 ```
 
 **Solution**:
+
 ```python
 # ✅ Lazy import inside signal handler
 @receiver(page_published)
@@ -750,6 +765,7 @@ def invalidate_cache(sender, **kwargs):
 ### Pitfall 2: Using hasattr() Instead of isinstance()
 
 **Problem**:
+
 ```python
 # ❌ BAD - hasattr matches multiple types
 if hasattr(instance, 'slug'):
@@ -757,6 +773,7 @@ if hasattr(instance, 'slug'):
 ```
 
 **Solution**:
+
 ```python
 # ✅ GOOD - isinstance checks exact type
 if isinstance(instance, BlogPostPage):
@@ -768,12 +785,14 @@ if isinstance(instance, BlogPostPage):
 ### Pitfall 3: Forgetting Tracked Keys
 
 **Problem**:
+
 ```python
 # ❌ No tracking - can't invalidate in development
 cache.set(cache_key, data, timeout)
 ```
 
 **Solution**:
+
 ```python
 # ✅ Track key for non-Redis backends
 cache.set(cache_key, data, timeout)
@@ -785,6 +804,7 @@ BlogCacheService._track_cache_key(cache_key)
 ### Pitfall 4: Filter Hash Without sort_keys
 
 **Problem**:
+
 ```python
 # ❌ Different hashes for same filters
 hash1 = hash(json.dumps({"a": 1, "b": 2}))
@@ -793,6 +813,7 @@ hash2 = hash(json.dumps({"b": 2, "a": 1}))
 ```
 
 **Solution**:
+
 ```python
 # ✅ Consistent hashes with sort_keys
 hash1 = hash(json.dumps({"a": 1, "b": 2}, sort_keys=True))
@@ -814,4 +835,3 @@ hash2 = hash(json.dumps({"b": 2, "a": 1}, sort_keys=True))
 **Pattern Count**: 15 caching patterns
 **Status**: ✅ Production-validated
 **Performance**: 30-80% cache hit rates, <50ms cached responses
-

--- a/backend/docs/patterns/architecture/caching.md
+++ b/backend/docs/patterns/architecture/caching.md
@@ -8,7 +8,16 @@
 - `TRUST_LEVEL_PATTERNS_CODIFIED.md` (trust level caching)
 - Forum caching patterns (Phase 4 implementation)
 
-**Status**: ✅ Production-Tested
+**Status**: ✅ Production-Tested (blog sections). ⚠️ Forum sections are historical.
+
+> ⚠️ **The FORUM caching sections in this doc are historical.** The **blog**
+> caching patterns are live. The **forum** sections — `ForumCacheService`
+> (`apps/forum/services/…`), `ModerationCacheService`, the moderation-dashboard
+> cache, `Post.flagged`, and the forum performance metrics — document the
+> **django-machina** forum, retired in PR #362. Those services and paths no longer
+> exist; the Wagtail-native `wagtail_forum` maintains denormalized counters in
+> `wagtail_forum/signals.py`, not these cache services. Treat every forum example
+> below as a pattern illustration only, not runnable code.
 
 ---
 
@@ -176,6 +185,9 @@ class BlogCacheService:
 ---
 
 ### Pattern: Forum Cache Service
+
+> **Retired (machina, PR #362).** `apps/forum/services/forum_cache_service.py` and
+> `ForumCacheService` no longer exist — pattern illustration only.
 
 **Location**: `apps/forum/services/forum_cache_service.py`
 
@@ -552,6 +564,9 @@ if isinstance(instance, BlogPostPage):  # Only BlogPostPage
 
 ### Pattern: Forum Post Invalidation
 
+> **Retired (machina, PR #362).** `ForumCacheService.invalidate_moderation_dashboard()`
+> and the `Post.flagged` field do not exist — pattern illustration only.
+
 **Complexity**: Posts affect multiple cache levels (thread, category, moderation dashboard).
 
 **Implementation**:
@@ -611,7 +626,7 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument(
-            "--force", action="store_true", help="Force regeneration"
+            "--force", action="store_true", help="Force cache regeneration even if already cached"
         )
 
     def handle(self, *args, **options):
@@ -632,6 +647,10 @@ python manage.py warm_ai_cache --force
 ---
 
 ### Pattern: Lazy Cache Warming
+
+> **Retired forum example (machina, PR #362).** The `get_moderation_dashboard()`
+> moderation-dashboard cache does not exist in `wagtail_forum` — the lazy-warming
+> pattern itself is valid, but this specific example is illustration only.
 
 **Use Case**: Warm cache on first access, not on every deployment.
 

--- a/docs/DEPLOYMENT_SECURITY_CHECKLIST.md
+++ b/docs/DEPLOYMENT_SECURITY_CHECKLIST.md
@@ -268,7 +268,9 @@ service firebase.storage {
 - [ ] **Verify cache warming** still works
 
   ```bash
-  python manage.py warm_moderation_cache
+  # Forum moderation cache retired with django-machina (PR #362) — no forum cache
+  # to warm. Only the blog AI cache is warmable (optional):
+  python manage.py warm_ai_cache --force
   ```
 
 - [ ] **Add performance test** with `assertNumQueries(2)`
@@ -460,10 +462,12 @@ service firebase.storage {
   ```
 
 - [ ] **Redis password** set (if production)
-- [ ] **Cache warming** runs on deployment
+- [ ] **Cache warming** (optional, manual — not part of the Railway deploy)
 
   ```bash
-  python manage.py warm_moderation_cache
+  # Forum moderation cache retired with django-machina (PR #362) — no forum cache
+  # to warm. Only the blog AI cache is warmable (optional):
+  python manage.py warm_ai_cache --force
   ```
 
 ### API Keys
@@ -569,7 +573,9 @@ service firebase.storage {
 - [ ] **Cache warmed**
 
   ```bash
-  python manage.py warm_moderation_cache
+  # Forum moderation cache retired with django-machina (PR #362) — no forum cache
+  # to warm. Only the blog AI cache is warmable (optional):
+  python manage.py warm_ai_cache --force
   ```
 
 - [ ] **Gunicorn/Daphne** configured with workers

--- a/todos/257-pending-p4-caching-md-forum-sections-rewrite.md
+++ b/todos/257-pending-p4-caching-md-forum-sections-rewrite.md
@@ -1,0 +1,86 @@
+---
+status: pending
+priority: p4
+issue_id: "257"
+tags: [docs, caching, forum, wagtail, cleanup]
+dependencies: []
+---
+
+# Rewrite caching.md forum sections to wagtail_forum reality (retired machina cache layer)
+
+## Context
+
+Surfaced by the PR #436 review. `backend/docs/patterns/architecture/caching.md`
+documents an entire **forum cache layer that no longer exists** — it belonged to
+the django-machina forum retired in PR #362 (rebuilt as the Wagtail-native
+`wagtail_forum`). PR #436 added a top-of-file banner and inline retired-markers so
+the doc is no longer self-contradictory, but the stale forum sections themselves
+were **not** rewritten (left as "pattern illustrations only"). This todo finishes
+that: replace them with the forum's actual caching reality, or delete them.
+
+## Problem
+
+`C = backend/docs/patterns/architecture/caching.md`
+
+These sections in `C` document retired `apps/forum/services/` code as if runnable
+(now banner-marked historical, but still misleading on close read):
+
+- **Pattern: Forum Cache Service** — full `ForumCacheService` class at
+  `apps/forum/services/forum_cache_service.py`. Path is empty; class undefined.
+- **Pattern: Forum Post Invalidation** — `ForumCacheService.invalidate_moderation_dashboard()`
+  - a guard on `Post.flagged` (no such field on `wagtail_forum.Post`).
+- **Pattern: Lazy Cache Warming** — `get_moderation_dashboard()` moderation-dashboard
+  cache; no equivalent in `wagtail_forum`.
+- **Forum Caching Performance** metrics section — measured numbers for the retired
+  forum cache; not representative of the current forum.
+- Various forum cache-key examples (`CACHE_PREFIX_FORUM_*`) — verify which constants
+  still exist.
+
+The live forum does NOT use a `ForumCacheService`. Its performance approach is
+denormalized counters recomputed in ONE UPDATE inside `wagtail_forum/signals.py`
+(see `_refresh_topic_counters`/`_refresh_board_counters`/`_refresh_profile`), not
+Redis-cached dashboards.
+
+## Recommended Action
+
+- For each forum section: either (a) DELETE it if it teaches nothing beyond the
+  dead service, or (b) REWRITE it to the `wagtail_forum` reality (denormalized
+  counters, `.public()`/visibility filtering, the `raw_data` StreamField
+  serialization N+1 guard) with real file references.
+- KEEP genuinely reusable generic patterns (e.g. Hierarchical Composite Keys,
+  SHA-256 filter hashing, Redis `delete_pattern` hasattr guard) but reground their
+  examples in live code (blog or the real forum), not `ForumCacheService`.
+- Once the sections reflect reality, drop the PR #436 banner/markers (their job is
+  done) or downgrade them to a one-line "forum caching lives in signals.py" pointer.
+- Decide whether the doc's blog-centric scope should absorb the forum content at
+  all, or whether forum caching deserves its own short section pointing at
+  `wagtail_forum/signals.py` and `docs/rules/caching.md`.
+
+## Technical Details
+
+- File: `backend/docs/patterns/architecture/caching.md` (docs only; no code/tests).
+- Cross-check every referenced symbol against the codebase before keeping it:
+  `apps/forum/` is empty; `ForumCacheService`/`ModerationCacheService` are undefined;
+  `Post` has no `flagged` field.
+- Reference for the live forum counter approach: `wagtail_forum/signals.py`,
+  `docs/rules/database.md` ("Denormalized counters: recount in ONE UPDATE").
+- Origin: PR #436 review (the warm_moderation_cache cleanup that exposed the wider rot).
+
+## Acceptance Criteria
+
+- [ ] No section in `caching.md` presents a non-existent service/path/field as live
+      (every referenced symbol verified to exist, or the section is deleted/marked
+      illustrative with a live alternative named).
+- [ ] Forum caching reality (denormalized counters in `signals.py`) is either
+      documented accurately or linked, not misrepresented as a `ForumCacheService`.
+- [ ] The PR #436 historical banner/markers are removed or reduced once the
+      underlying sections are accurate.
+- [ ] `markdownlint` passes (pre-commit gate).
+
+## Work Log
+
+### 2026-07-03 - Created
+
+- Filed from the PR #436 review. #436 stopped the doc contradicting itself
+  (banner + markers); this finishes the job by rewriting/removing the retired
+  forum cache sections.


### PR DESCRIPTION
`python manage.py warm_moderation_cache` is documented across several docs (including the auto-loaded `backend/CLAUDE.md`) as a post-deploy step, but the command **does not exist** — running it errors with `Unknown command`. It belonged to `apps.forum.services.ModerationCacheService` in the old django-machina forum, retired in PR #362 and rebuilt as the Wagtail-native `wagtail_forum`, which has no moderation-dashboard cache to warm. Surfaced when the command failed during the post-#435 deploy.

## Changes (active docs only)

- **`backend/CLAUDE.md`** — drop the two `warm_moderation_cache` lines; point to the real optional warm command (`warm_ai_cache --force`, the blog AI cache), noting the forum cache is gone.
- **`caching.md`** — the "Management Command Cache Warming" pattern's concrete example was the retired `ModerationCacheService`; marked it retired and repointed to the live `apps/blog/management/commands/warm_ai_cache.py`.
- **`DEPLOYMENT_SECURITY_CHECKLIST.md`** — replaced all 3 deploy-checklist commands with `warm_ai_cache`, and fixed the false "**Cache warming** runs on deployment" label (nothing auto-warms; Railway's `preDeployCommand` is `migrate` + `seed_default_forum`).

## Left intentionally untouched

- `docs/archive/**` and `docs/superpowers/**` — historical/read-only per repo convention.
- `backend/docs/patterns/domain/forum.md` — already documents `warm_moderation_cache` as retired (correct as-is).

Docs-only; no code or behavior change. `warm_ai_cache` verified to exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)