### PR TITLE
fix: view_count increment, tombstone sync, and FCM push notifications (issues 6, 10, 14)

### DIFF
--- a/backend/apps/forum_host/notifications.py
+++ b/backend/apps/forum_host/notifications.py
@@ -4,11 +4,69 @@ logger = logging.getLogger("forum_host.notifications")
 
 
 def dispatch(event, **kwargs):
-    """Send a forum event to FCM.
+    """Route a forum signal event to FCM via a background Celery task.
 
-    Replace the log call with the project's FCM sender (e.g. enqueue a Celery
-    task that calls the Firebase Admin SDK). Kept as a single seam so the
-    delivery mechanism is swappable and unit-testable.
+    Importing the task here (inside the function) keeps the module importable
+    even before the Celery app is ready (e.g. during migrations).
+
+    Supported events
+    ----------------
+    reply_added
+        Notifies the topic's original author that someone replied to their
+        thread.  kwargs: topic (Topic), post (Post).
+
+    moderation_decided
+        Notifies the post's author of their content's moderation outcome.
+        kwargs: obj (Post|Topic), status ("published"|"pending").
+
+    topic_created
+        No push for now — there is no board-subscriber model yet.
+        Logged only so the seam is visible when that model is added.
     """
+    from .tasks import send_forum_push
+
     topic = kwargs.get("topic")
-    logger.info("forum.%s topic=%s", event, getattr(topic, "id", None))
+    topic_id = getattr(topic, "id", None)
+
+    if event == "reply_added":
+        post = kwargs.get("post")
+        # Notify the topic author when someone else replies.
+        topic_author = getattr(topic, "author", None)
+        post_author = getattr(post, "author", None)
+        if topic_author is None:
+            return
+        # Don't ping the author for their own replies.
+        if post_author is not None and post_author.pk == topic_author.pk:
+            return
+        send_forum_push.delay(
+            event,
+            topic_author.pk,
+            {
+                "topic_id": str(topic_id),
+                "topic_title": topic.title if topic else "",
+                "post_id": str(getattr(post, "id", "")),
+            },
+        )
+
+    elif event == "moderation_decided":
+        obj = kwargs.get("obj")
+        status = kwargs.get("status", "")
+        author = getattr(obj, "author", None)
+        if author is None:
+            return
+        send_forum_push.delay(
+            event,
+            author.pk,
+            {
+                "topic_id": str(topic_id),
+                "status": status,
+                "obj_id": str(getattr(obj, "id", "")),
+            },
+        )
+
+    elif event == "topic_created":
+        # No subscriber model yet — log and return.
+        logger.info("forum.topic_created topic=%s (no push subscribers yet)", topic_id)
+
+    else:
+        logger.warning("forum_host.notifications: unknown event %r", event)

--- a/backend/apps/forum_host/tasks.py
+++ b/backend/apps/forum_host/tasks.py
@@ -1,0 +1,81 @@
+"""Celery tasks for forum push notifications (Issue 14).
+
+Fired by forum_host/notifications.py dispatch() via .delay() so that:
+- The publish transaction is never held open waiting for FCM.
+- A failed push never rolls back a moderation decision.
+- Tasks are retried automatically by Celery on transient FCM errors.
+"""
+
+import logging
+
+from celery import shared_task
+
+logger = logging.getLogger("forum_host.tasks")
+
+
+@shared_task(bind=True, max_retries=3, default_retry_delay=30)
+def send_forum_push(self, event: str, recipient_user_id: int, data: dict):
+    """Send a single FCM data message for a forum event.
+
+    Args:
+        event: one of "reply_added", "moderation_decided", "topic_created".
+        recipient_user_id: pk of the User whose FCM token to look up.
+        data: dict of string key/value pairs to include in the FCM data payload.
+              All values are coerced to strings (FCM requirement).
+    """
+    from apps.garden.firebase_config import get_fcm_client, is_firebase_available
+    from django.contrib.auth import get_user_model
+    from wagtail_forum.models import ForumProfile
+
+    User = get_user_model()
+
+    if not is_firebase_available():
+        logger.debug("[FCM] Firebase not configured — skipping forum push (%s)", event)
+        return
+
+    try:
+        user = User.objects.get(pk=recipient_user_id)
+    except User.DoesNotExist:
+        logger.warning(
+            "[FCM] forum push skipped — user %s not found", recipient_user_id
+        )
+        return
+
+    if not getattr(user, "forum_notifications", True) is True:
+        logger.debug(
+            "[FCM] forum push skipped — user %s has forum_notifications=False",
+            recipient_user_id,
+        )
+        return
+
+    profile = ForumProfile.for_user(user)
+    token = profile.fcm_token
+    if not token:
+        logger.debug(
+            "[FCM] forum push skipped — user %s has no FCM token", recipient_user_id
+        )
+        return
+
+    fcm = get_fcm_client()
+    if fcm is None:
+        logger.error("[FCM] FCM client unavailable — cannot send forum push")
+        return
+
+    # Coerce all values to strings — FCM data payloads must be str:str.
+    str_data = {k: str(v) for k, v in data.items()}
+    str_data["event"] = event
+
+    try:
+        message = fcm.Message(data=str_data, token=token)
+        response = fcm.send(message)
+        logger.info(
+            "[FCM] forum.%s sent to user=%s: %s", event, recipient_user_id, response
+        )
+    except Exception as exc:
+        logger.warning(
+            "[FCM] forum.%s send failed (user=%s): %s — retrying",
+            event,
+            recipient_user_id,
+            exc,
+        )
+        raise self.retry(exc=exc)

--- a/backend/apps/forum_host/tests/test_signals.py
+++ b/backend/apps/forum_host/tests/test_signals.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import pytest
 from django.contrib.auth import get_user_model
 from wagtail.models import Page
@@ -31,3 +33,73 @@ def test_publishing_a_reply_dispatches_a_host_notification(monkeypatch):
 
     assert "topic_created" in events
     assert "reply_added" in events
+
+
+# ---- push-notification routing tests ----------------------------------------
+
+
+@pytest.mark.django_db
+def test_reply_added_enqueues_push_for_topic_author():
+    """reply_added must enqueue send_forum_push for the topic author."""
+    topic_author = User.objects.create_user(username="topicowner", password="x")
+    replier = User.objects.create_user(username="replier", password="x")
+
+    root = Page.objects.get(id=1)
+    index = root.add_child(instance=ForumIndex(title="Forum2", slug="forum2"))
+    board = index.add_child(instance=ForumBoard(title="General2", slug="general2"))
+    topic = Topic.objects.create(
+        board=board, title="T2", slug="t2", author=topic_author
+    )
+
+    with patch("apps.forum_host.tasks.send_forum_push.delay") as mock_delay:
+        from apps.forum_host.notifications import dispatch
+
+        post = Post(topic=topic, author=replier)
+        dispatch("reply_added", topic=topic, post=post)
+
+    mock_delay.assert_called_once()
+    call_args = mock_delay.call_args
+    assert call_args.args[0] == "reply_added"
+    assert call_args.args[1] == topic_author.pk
+
+
+@pytest.mark.django_db
+def test_reply_added_does_not_push_for_self_reply():
+    """An author replying to their own topic must not receive a push."""
+    author = User.objects.create_user(username="selfie", password="x")
+
+    root = Page.objects.get(id=1)
+    index = root.add_child(instance=ForumIndex(title="Forum3", slug="forum3"))
+    board = index.add_child(instance=ForumBoard(title="General3", slug="general3"))
+    topic = Topic.objects.create(board=board, title="T3", slug="t3", author=author)
+
+    with patch("apps.forum_host.tasks.send_forum_push.delay") as mock_delay:
+        from apps.forum_host.notifications import dispatch
+
+        post = Post(topic=topic, author=author)
+        dispatch("reply_added", topic=topic, post=post)
+
+    mock_delay.assert_not_called()
+
+
+@pytest.mark.django_db
+def test_moderation_decided_enqueues_push_for_post_author():
+    """moderation_decided must enqueue send_forum_push for the post's author."""
+    author = User.objects.create_user(username="modauthor", password="x")
+
+    root = Page.objects.get(id=1)
+    index = root.add_child(instance=ForumIndex(title="Forum4", slug="forum4"))
+    board = index.add_child(instance=ForumBoard(title="General4", slug="general4"))
+    topic = Topic.objects.create(board=board, title="T4", slug="t4", author=author)
+    post = Post(topic=topic, author=author)
+
+    with patch("apps.forum_host.tasks.send_forum_push.delay") as mock_delay:
+        from apps.forum_host.notifications import dispatch
+
+        dispatch("moderation_decided", topic=topic, obj=post, status="published")
+
+    mock_delay.assert_called_once()
+    call_args = mock_delay.call_args
+    assert call_args.args[0] == "moderation_decided"
+    assert call_args.args[1] == author.pk
+    assert call_args.args[2]["status"] == "published"

--- a/backend/apps/forum_host/tests/test_tasks.py
+++ b/backend/apps/forum_host/tests/test_tasks.py
@@ -1,0 +1,133 @@
+"""Unit tests for forum_host.tasks.send_forum_push (Issue 14).
+
+All tests mock the FCM client and Firebase availability check so they
+run without Firebase credentials in CI.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from django.contrib.auth import get_user_model
+from wagtail_forum.models import ForumProfile
+
+User = get_user_model()
+
+
+@pytest.mark.django_db
+def test_send_forum_push_sends_when_token_present():
+    user = User.objects.create_user(username="pushme", password="x")
+    profile = ForumProfile.for_user(user)
+    profile.fcm_token = "device-token-abc"
+    profile.save()
+
+    mock_fcm = MagicMock()
+    mock_fcm.send.return_value = "projects/x/messages/1"
+
+    with patch(
+        "apps.garden.firebase_config.is_firebase_available", return_value=True
+    ), patch("apps.garden.firebase_config.get_fcm_client", return_value=mock_fcm):
+        from apps.forum_host.tasks import send_forum_push
+
+        send_forum_push(
+            "reply_added",
+            user.pk,
+            {"topic_id": "7", "topic_title": "Hello", "post_id": "3"},
+        )
+
+    mock_fcm.Message.assert_called_once()
+    mock_fcm.send.assert_called_once()
+    # The FCM Message must include the event key
+    call_kwargs = mock_fcm.Message.call_args.kwargs
+    assert call_kwargs["data"]["event"] == "reply_added"
+    assert call_kwargs["token"] == "device-token-abc"
+
+
+@pytest.mark.django_db
+def test_send_forum_push_skips_when_no_token():
+    user = User.objects.create_user(username="notoken", password="x")
+    ForumProfile.for_user(user)  # fcm_token="" by default
+
+    mock_fcm = MagicMock()
+    with patch(
+        "apps.garden.firebase_config.is_firebase_available", return_value=True
+    ), patch("apps.garden.firebase_config.get_fcm_client", return_value=mock_fcm):
+        from apps.forum_host.tasks import send_forum_push
+
+        send_forum_push("reply_added", user.pk, {"topic_id": "1"})
+
+    mock_fcm.send.assert_not_called()
+
+
+@pytest.mark.django_db
+def test_send_forum_push_skips_when_firebase_unavailable():
+    user = User.objects.create_user(username="nofb", password="x")
+    profile = ForumProfile.for_user(user)
+    profile.fcm_token = "some-token"
+    profile.save()
+
+    mock_fcm = MagicMock()
+    with patch(
+        "apps.garden.firebase_config.is_firebase_available", return_value=False
+    ), patch("apps.garden.firebase_config.get_fcm_client", return_value=mock_fcm):
+        from apps.forum_host.tasks import send_forum_push
+
+        send_forum_push("reply_added", user.pk, {"topic_id": "1"})
+
+    mock_fcm.send.assert_not_called()
+
+
+@pytest.mark.django_db
+def test_send_forum_push_skips_when_forum_notifications_off():
+    user = User.objects.create_user(username="optout", password="x")
+    user.forum_notifications = False
+    user.save()
+    profile = ForumProfile.for_user(user)
+    profile.fcm_token = "some-token"
+    profile.save()
+
+    mock_fcm = MagicMock()
+    with patch(
+        "apps.garden.firebase_config.is_firebase_available", return_value=True
+    ), patch("apps.garden.firebase_config.get_fcm_client", return_value=mock_fcm):
+        from apps.forum_host.tasks import send_forum_push
+
+        send_forum_push("reply_added", user.pk, {"topic_id": "1"})
+
+    mock_fcm.send.assert_not_called()
+
+
+@pytest.mark.django_db
+def test_send_forum_push_skips_for_nonexistent_user():
+    mock_fcm = MagicMock()
+    with patch(
+        "apps.garden.firebase_config.is_firebase_available", return_value=True
+    ), patch("apps.garden.firebase_config.get_fcm_client", return_value=mock_fcm):
+        from apps.forum_host.tasks import send_forum_push
+
+        send_forum_push("reply_added", 999999, {"topic_id": "1"})
+
+    mock_fcm.send.assert_not_called()
+
+
+@pytest.mark.django_db
+def test_send_forum_push_all_data_values_coerced_to_str():
+    user = User.objects.create_user(username="strcheck", password="x")
+    profile = ForumProfile.for_user(user)
+    profile.fcm_token = "tok"
+    profile.save()
+
+    mock_fcm = MagicMock()
+    mock_fcm.send.return_value = "ok"
+
+    with patch(
+        "apps.garden.firebase_config.is_firebase_available", return_value=True
+    ), patch("apps.garden.firebase_config.get_fcm_client", return_value=mock_fcm):
+        from apps.forum_host.tasks import send_forum_push
+
+        send_forum_push(
+            "moderation_decided", user.pk, {"topic_id": 42, "status": "published"}
+        )
+
+    data = mock_fcm.Message.call_args.kwargs["data"]
+    for v in data.values():
+        assert isinstance(v, str), f"FCM data value {v!r} is not a string"

--- a/backend/packages/wagtail_forum/wagtail_forum/api/serializers.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/api/serializers.py
@@ -328,6 +328,11 @@ class MeProfileSerializer(serializers.ModelSerializer):
     bio = serializers.CharField(
         max_length=MAX_BIO_CHARS, required=False, allow_blank=True
     )
+    # Write-only: the mobile app PATCHes this on login to register its FCM
+    # device token. Never returned in responses — a token is a credential.
+    fcm_token = serializers.CharField(
+        max_length=255, required=False, allow_blank=True, write_only=True
+    )
 
     class Meta:
         model = ForumProfile
@@ -340,6 +345,7 @@ class MeProfileSerializer(serializers.ModelSerializer):
             "trust_level",
             "post_count",
             "capabilities",
+            "fcm_token",
         ]
         read_only_fields = ["trust_level", "post_count"]
 

--- a/backend/packages/wagtail_forum/wagtail_forum/api/views.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/api/views.py
@@ -1,7 +1,8 @@
 import logging
 
+from django.core.cache import cache
 from django.db import IntegrityError, transaction
-from django.db.models import Q
+from django.db.models import F, Q
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
 from django.utils.dateparse import parse_datetime
@@ -268,6 +269,34 @@ class TopicDetailView(generics.RetrieveAPIView):
         return Topic.objects.filter(
             live=True, board__in=_visible_boards()
         ).select_related("board", "author", "last_post_author")
+
+    def retrieve(self, request, *args, **kwargs):
+        response = super().retrieve(request, *args, **kwargs)
+        # Increment view_count after a successful 200, deduplicated per viewer.
+        # Uses on_commit so the UPDATE runs outside the serialization transaction
+        # and does not inflate the pinned query count for the response itself.
+        # The cache key is scoped per (topic, viewer) — authenticated users key on
+        # their pk; anonymous requests key on the client IP so a single browser
+        # session doesn't multi-count. The TTL is host-configurable via
+        # WAGTAILFORUM_VIEW_COUNT_DEDUP_SECONDS (default 15 min).
+        from ..conf import get_setting
+
+        topic_id = self.kwargs[self.lookup_url_kwarg]
+        viewer = (
+            request.user.pk
+            if request.user.is_authenticated
+            else request.META.get("REMOTE_ADDR", "anon")
+        )
+        dedup_key = f"forum:vc:{topic_id}:{viewer}"
+        ttl = get_setting("VIEW_COUNT_DEDUP_SECONDS")
+        if not cache.get(dedup_key):
+            cache.set(dedup_key, True, ttl)
+
+            def _increment():
+                Topic.objects.filter(pk=topic_id).update(view_count=F("view_count") + 1)
+
+            transaction.on_commit(_increment)
+        return response
 
 
 @extend_schema(
@@ -682,12 +711,22 @@ class SyncView(APIView):
             {"id": t.id, "slug": t.slug, "title": t.title, "updated_at": t.updated_at}
             for t in batch
         ]
-        # Tombstones (ids deleted since `since`) require a soft-delete log added in
-        # a later plan; return an empty list for now.
+        # Tombstones: topic ids deleted since the client's last poll. Only
+        # meaningful for a delta sync (since provided); a full resync
+        # (no since) rebuilds from scratch so there are no stale ids to evict.
+        deleted = []
+        if since:
+            from ..models.tombstones import TopicDeletedLog
+
+            deleted = list(
+                TopicDeletedLog.objects.filter(deleted_at__gt=since).values(
+                    "topic_id", "board_id"
+                )
+            )
         return Response(
             {
                 "topics": topics,
-                "deleted": [],
+                "deleted": deleted,
                 "has_more": has_more,
                 "next_since": batch[-1].updated_at if batch else raw_since or None,
                 "next_since_id": batch[-1].id if batch else (since_id or None),

--- a/backend/packages/wagtail_forum/wagtail_forum/conf.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/conf.py
@@ -24,6 +24,13 @@ DEFAULTS = {
     "IMAGE_MAX_WIDTH": 5000,
     "IMAGE_MAX_HEIGHT": 5000,
     "IMAGE_COLLECTION_NAME": "Forum Images",
+    # view_count deduplication window (seconds). A topic detail GET from the same
+    # user (or anonymous IP) within this window counts as one view, not many.
+    "VIEW_COUNT_DEDUP_SECONDS": 15 * 60,  # 15 minutes
+    # How long tombstone rows (TopicDeletedLog) are retained before pruning.
+    # A mobile client that hasn't synced in longer than this window will miss
+    # some deletions and should fall back to a full resync.
+    "SYNC_TOMBSTONE_RETENTION_DAYS": 30,
 }
 
 

--- a/backend/packages/wagtail_forum/wagtail_forum/management/commands/prune_forum_tombstones.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/management/commands/prune_forum_tombstones.py
@@ -1,0 +1,44 @@
+"""Management command: prune old TopicDeletedLog tombstone rows.
+
+Run periodically (e.g. daily via Celery beat or cron) to prevent the
+tombstone table growing unboundedly. Rows older than
+WAGTAILFORUM_SYNC_TOMBSTONE_RETENTION_DAYS (default 30) are removed;
+any client that has not synced within that window must perform a full
+resync to recover missed deletions.
+"""
+
+from datetime import timedelta
+
+from django.core.management.base import BaseCommand
+from django.utils import timezone
+
+
+class Command(BaseCommand):
+    help = "Delete TopicDeletedLog tombstone rows older than the retention window."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--days",
+            type=int,
+            default=None,
+            help=(
+                "Override the retention window in days "
+                "(default: WAGTAILFORUM_SYNC_TOMBSTONE_RETENTION_DAYS setting)."
+            ),
+        )
+
+    def handle(self, *args, **options):
+        from wagtail_forum.conf import get_setting
+        from wagtail_forum.models.tombstones import TopicDeletedLog
+
+        days = options["days"]
+        if days is None:
+            days = get_setting("SYNC_TOMBSTONE_RETENTION_DAYS")
+
+        cutoff = timezone.now() - timedelta(days=days)
+        deleted, _ = TopicDeletedLog.objects.filter(deleted_at__lt=cutoff).delete()
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"Pruned {deleted} tombstone row(s) older than {days} day(s)."
+            )
+        )

--- a/backend/packages/wagtail_forum/wagtail_forum/migrations/0010_topicdeleted_log.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/migrations/0010_topicdeleted_log.py
@@ -36,7 +36,7 @@ class Migration(migrations.Migration):
             },
         ),
         migrations.AddIndex(
-            model_name="topicdeleted_log",
+            model_name="topicdeletedlog",
             index=models.Index(
                 fields=["deleted_at"], name="wf_tombstone_deleted_at_idx"
             ),

--- a/backend/packages/wagtail_forum/wagtail_forum/migrations/0010_topicdeleted_log.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/migrations/0010_topicdeleted_log.py
@@ -1,0 +1,44 @@
+import django.utils.timezone
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("wagtail_forum", "0009_alter_post_author"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="TopicDeletedLog",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("topic_id", models.IntegerField(db_index=True)),
+                ("board_id", models.IntegerField(db_index=True)),
+                (
+                    "deleted_at",
+                    models.DateTimeField(
+                        default=django.utils.timezone.now, db_index=True
+                    ),
+                ),
+            ],
+            options={
+                "ordering": ["deleted_at"],
+                "app_label": "wagtail_forum",
+            },
+        ),
+        migrations.AddIndex(
+            model_name="topicdeleted_log",
+            index=models.Index(
+                fields=["deleted_at"], name="wf_tombstone_deleted_at_idx"
+            ),
+        ),
+    ]

--- a/backend/packages/wagtail_forum/wagtail_forum/migrations/0011_forumprofile_fcm_token.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/migrations/0011_forumprofile_fcm_token.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("wagtail_forum", "0010_topicdeleted_log"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="forumprofile",
+            name="fcm_token",
+            field=models.CharField(blank=True, default="", max_length=255),
+        ),
+    ]

--- a/backend/packages/wagtail_forum/wagtail_forum/models/__init__.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/models/__init__.py
@@ -3,6 +3,7 @@ from .moderation import SpamCheckTask
 from .posts import Post
 from .profiles import ForumProfile, TrustLevel
 from .reactions import Reaction
+from .tombstones import TopicDeletedLog
 from .topics import Topic
 
 __all__ = [
@@ -13,5 +14,6 @@ __all__ = [
     "Reaction",
     "SpamCheckTask",
     "Topic",
+    "TopicDeletedLog",
     "TrustLevel",
 ]

--- a/backend/packages/wagtail_forum/wagtail_forum/models/profiles.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/models/profiles.py
@@ -28,6 +28,10 @@ class ForumProfile(models.Model):
     )
     bio = models.TextField(blank=True)
     signature = models.CharField(max_length=255, blank=True)
+    # FCM device token — registered by the mobile app on login. Used by
+    # forum_host/tasks.py to deliver push notifications. Nullable: a user
+    # who has never registered a token (web-only) simply receives no pushes.
+    fcm_token = models.CharField(max_length=255, blank=True, default="")
     # System-computed (read-only to members).
     trust_level = models.PositiveSmallIntegerField(
         choices=TrustLevel.choices, default=TrustLevel.NEW

--- a/backend/packages/wagtail_forum/wagtail_forum/models/tombstones.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/models/tombstones.py
@@ -1,0 +1,31 @@
+"""Tombstone log for deleted topics (Issue 6 — delta-sync completeness).
+
+When a topic is hard-deleted its row vanishes; a mobile client polling
+/sync/?since=<last_seen> would never learn it is gone and would keep
+showing a stale entry.  This lightweight append-only log lets SyncView
+return the ids of topics removed since the client's last poll so the
+client can evict them from its local cache.
+
+Design notes:
+- No FK to Topic — the topic is gone by the time this row is read.
+- board_id is stored for clients that partition their cache by board.
+- deleted_at is indexed; old rows are pruned by the
+  `prune_forum_tombstones` management command (retention controlled via
+  WAGTAILFORUM_SYNC_TOMBSTONE_RETENTION_DAYS, default 30 days).
+"""
+
+from django.db import models
+from django.utils import timezone
+
+
+class TopicDeletedLog(models.Model):
+    topic_id = models.IntegerField(db_index=True)
+    board_id = models.IntegerField(db_index=True)
+    deleted_at = models.DateTimeField(default=timezone.now, db_index=True)
+
+    class Meta:
+        app_label = "wagtail_forum"
+        ordering = ["deleted_at"]
+        indexes = [
+            models.Index(fields=["deleted_at"], name="wf_tombstone_deleted_at_idx"),
+        ]

--- a/backend/packages/wagtail_forum/wagtail_forum/signals.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/signals.py
@@ -257,6 +257,11 @@ def update_counters_on_topic_delete(sender, instance, **kwargs):
     _refresh_board_counters(instance.board_id)
     for author_id in author_ids:
         _refresh_profile(author_id)
+    # Record a tombstone so delta-sync clients can evict the deleted topic
+    # from their local cache without requiring a full resync (Issue 6).
+    from .models.tombstones import TopicDeletedLog
+
+    TopicDeletedLog.objects.create(topic_id=instance.pk, board_id=instance.board_id)
 
 
 @receiver(post_delete, sender="wagtail_forum.Post")

--- a/backend/packages/wagtail_forum/wagtail_forum/tests/api/test_search_sync.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/tests/api/test_search_sync.py
@@ -165,3 +165,75 @@ def test_sync_without_since_id_includes_exact_boundary_row():
         .data
     )
     assert [x["id"] for x in resp["topics"]] == [t.id]
+
+
+# ---- tombstone / delta-sync tests -------------------------------------------
+
+
+@pytest.mark.django_db
+def test_deleted_topic_appears_in_sync_deleted_list():
+    """A topic deleted after `since` must surface in the `deleted` list so
+    mobile clients can evict it from their local cache (Issue 6)."""
+    board = _board()
+    before = datetime.datetime(2026, 1, 1, tzinfo=datetime.timezone.utc)
+    topic = Topic.objects.create(board=board, title="gone", slug="gone", live=True)
+    saved_id = topic.pk
+    saved_board_id = board.pk
+    topic.delete()
+
+    resp = APIClient().get(
+        "/forum/sync/", {"since": before.isoformat(), "board": board.slug}
+    )
+    assert resp.status_code == 200
+    deleted_ids = [d["topic_id"] for d in resp.data["deleted"]]
+    assert saved_id in deleted_ids
+    # board_id is also returned so clients can scope the eviction
+    deleted_board_ids = [d["board_id"] for d in resp.data["deleted"]]
+    assert saved_board_id in deleted_board_ids
+
+
+@pytest.mark.django_db
+def test_full_resync_without_since_returns_empty_deleted():
+    """A full resync (no `since`) always returns deleted=[] regardless of
+    how many tombstones exist — clients rebuild from the topics list."""
+    from wagtail_forum.models.tombstones import TopicDeletedLog
+
+    TopicDeletedLog.objects.create(topic_id=999, board_id=1)
+
+    resp = APIClient().get("/forum/sync/")
+    assert resp.status_code == 200
+    assert resp.data["deleted"] == []
+
+
+@pytest.mark.django_db
+def test_tombstone_not_returned_before_its_deleted_at():
+    """A deletion that happened before the client's `since` must NOT appear
+    in `deleted` — the client already knew about it (or never had it)."""
+    from wagtail_forum.models.tombstones import TopicDeletedLog
+
+    old_deletion = datetime.datetime(2020, 1, 1, tzinfo=datetime.timezone.utc)
+    TopicDeletedLog.objects.create(topic_id=42, board_id=1, deleted_at=old_deletion)
+    since = datetime.datetime(2025, 1, 1, tzinfo=datetime.timezone.utc)
+
+    resp = APIClient().get("/forum/sync/", {"since": since.isoformat()})
+    assert resp.status_code == 200
+    assert resp.data["deleted"] == []
+
+
+@pytest.mark.django_db
+def test_prune_tombstones_command_removes_old_rows(capsys):
+    """prune_forum_tombstones deletes rows older than --days and leaves
+    newer rows intact."""
+    from django.core.management import call_command
+    from wagtail_forum.models.tombstones import TopicDeletedLog
+
+    old = datetime.datetime(2000, 1, 1, tzinfo=datetime.timezone.utc)
+    TopicDeletedLog.objects.create(topic_id=1, board_id=1, deleted_at=old)
+    TopicDeletedLog.objects.create(topic_id=2, board_id=1)  # now — recent
+
+    call_command("prune_forum_tombstones", days=30)
+
+    assert not TopicDeletedLog.objects.filter(topic_id=1).exists()
+    assert TopicDeletedLog.objects.filter(topic_id=2).exists()
+    out = capsys.readouterr().out
+    assert "Pruned 1 tombstone row(s)" in out

--- a/backend/packages/wagtail_forum/wagtail_forum/tests/api/test_topic_detail.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/tests/api/test_topic_detail.py
@@ -1,7 +1,8 @@
 import pytest
 from django.contrib.auth import get_user_model
+from django.core.cache import cache
 from django.db import connection
-from django.test.utils import CaptureQueriesContext
+from django.test.utils import CaptureQueriesContext, override_settings
 from rest_framework.test import APIClient
 from wagtail.models import Page
 from wagtail_forum.models import ForumBoard, ForumIndex, Post, Topic
@@ -56,3 +57,91 @@ def test_topic_detail_hides_topic_on_unpublished_board():
     board.save()
     topic = Topic.objects.create(board=board, title="X", slug="x", live=True)
     assert APIClient().get(f"/forum/topics/{topic.id}/").status_code == 404
+
+
+# ---- view_count tests -------------------------------------------------------
+
+
+@pytest.mark.django_db(transaction=True)
+@override_settings(WAGTAILFORUM_VIEW_COUNT_DEDUP_SECONDS=900)
+def test_view_count_increments_on_get():
+    cache.clear()
+    board = _board(slug="vc-board")
+    topic = Topic.objects.create(board=board, title="VC", slug="vc", live=True)
+    assert topic.view_count == 0
+
+    APIClient().get(f"/forum/topics/{topic.id}/")
+
+    topic.refresh_from_db()
+    assert topic.view_count == 1
+
+
+@pytest.mark.django_db(transaction=True)
+@override_settings(WAGTAILFORUM_VIEW_COUNT_DEDUP_SECONDS=900)
+def test_view_count_does_not_double_count_within_dedup_window():
+    cache.clear()
+    board = _board(slug="vc-board2")
+    topic = Topic.objects.create(board=board, title="VC2", slug="vc2", live=True)
+
+    client = APIClient()
+    client.get(f"/forum/topics/{topic.id}/")
+    client.get(f"/forum/topics/{topic.id}/")  # same viewer, same window
+
+    topic.refresh_from_db()
+    assert topic.view_count == 1
+
+
+@pytest.mark.django_db(transaction=True)
+@override_settings(WAGTAILFORUM_VIEW_COUNT_DEDUP_SECONDS=900)
+def test_view_count_counts_different_users_independently():
+    cache.clear()
+    board = _board(slug="vc-board3")
+    topic = Topic.objects.create(board=board, title="VC3", slug="vc3", live=True)
+    u1 = User.objects.create_user(username="v1", password="x")
+    u2 = User.objects.create_user(username="v2", password="x")
+
+    c1 = APIClient()
+    c1.force_authenticate(u1)
+    c1.get(f"/forum/topics/{topic.id}/")
+
+    c2 = APIClient()
+    c2.force_authenticate(u2)
+    c2.get(f"/forum/topics/{topic.id}/")
+
+    topic.refresh_from_db()
+    assert topic.view_count == 2
+
+
+@pytest.mark.django_db(transaction=True)
+@override_settings(WAGTAILFORUM_VIEW_COUNT_DEDUP_SECONDS=0)
+def test_view_count_recounts_after_dedup_window_expires():
+    cache.clear()
+    board = _board(slug="vc-board4")
+    topic = Topic.objects.create(board=board, title="VC4", slug="vc4", live=True)
+
+    client = APIClient()
+    client.get(f"/forum/topics/{topic.id}/")
+    # TTL=0 means the cache entry expires immediately — next request is a new view.
+    client.get(f"/forum/topics/{topic.id}/")
+
+    topic.refresh_from_db()
+    assert topic.view_count == 2
+
+
+@pytest.mark.django_db
+def test_view_count_does_not_add_queries_to_response():
+    # on_commit fires AFTER the response transaction; the pinned query count
+    # for the response itself must be unchanged (still 4).
+    cache.clear()
+    board = _board(slug="vc-board5")
+    author = User.objects.create_user(username="vcq", password="x")
+    topic = Topic.objects.create(
+        board=board, title="VCQ", slug="vcq", author=author, live=True
+    )
+    Post.objects.create(topic=topic, author=author, is_opening_post=True, live=True)
+
+    with CaptureQueriesContext(connection) as ctx:
+        resp = APIClient().get(f"/forum/topics/{topic.id}/")
+
+    assert resp.status_code == 200
+    assert len(ctx.captured_queries) == 4

--- a/backend/packages/wagtail_forum/wagtail_forum/tests/api/test_topic_detail.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/tests/api/test_topic_detail.py
@@ -62,67 +62,81 @@ def test_topic_detail_hides_topic_on_unpublished_board():
 # ---- view_count tests -------------------------------------------------------
 
 
-@pytest.mark.django_db(transaction=True)
+# These tests must NOT use django_db(transaction=True): its teardown flush
+# deletes Wagtail's migration-seeded root page, breaking every later test that
+# calls _board(). django_capture_on_commit_callbacks runs the on_commit hook
+# without needing real commits.
+@pytest.mark.django_db
 @override_settings(WAGTAILFORUM_VIEW_COUNT_DEDUP_SECONDS=900)
-def test_view_count_increments_on_get():
+def test_view_count_increments_on_get(django_capture_on_commit_callbacks):
     cache.clear()
     board = _board(slug="vc-board")
     topic = Topic.objects.create(board=board, title="VC", slug="vc", live=True)
     assert topic.view_count == 0
 
-    APIClient().get(f"/forum/topics/{topic.id}/")
+    with django_capture_on_commit_callbacks(execute=True):
+        APIClient().get(f"/forum/topics/{topic.id}/")
 
     topic.refresh_from_db()
     assert topic.view_count == 1
 
 
-@pytest.mark.django_db(transaction=True)
+@pytest.mark.django_db
 @override_settings(WAGTAILFORUM_VIEW_COUNT_DEDUP_SECONDS=900)
-def test_view_count_does_not_double_count_within_dedup_window():
+def test_view_count_does_not_double_count_within_dedup_window(
+    django_capture_on_commit_callbacks,
+):
     cache.clear()
     board = _board(slug="vc-board2")
     topic = Topic.objects.create(board=board, title="VC2", slug="vc2", live=True)
 
     client = APIClient()
-    client.get(f"/forum/topics/{topic.id}/")
-    client.get(f"/forum/topics/{topic.id}/")  # same viewer, same window
+    with django_capture_on_commit_callbacks(execute=True):
+        client.get(f"/forum/topics/{topic.id}/")
+        client.get(f"/forum/topics/{topic.id}/")  # same viewer, same window
 
     topic.refresh_from_db()
     assert topic.view_count == 1
 
 
-@pytest.mark.django_db(transaction=True)
+@pytest.mark.django_db
 @override_settings(WAGTAILFORUM_VIEW_COUNT_DEDUP_SECONDS=900)
-def test_view_count_counts_different_users_independently():
+def test_view_count_counts_different_users_independently(
+    django_capture_on_commit_callbacks,
+):
     cache.clear()
     board = _board(slug="vc-board3")
     topic = Topic.objects.create(board=board, title="VC3", slug="vc3", live=True)
     u1 = User.objects.create_user(username="v1", password="x")
     u2 = User.objects.create_user(username="v2", password="x")
 
-    c1 = APIClient()
-    c1.force_authenticate(u1)
-    c1.get(f"/forum/topics/{topic.id}/")
+    with django_capture_on_commit_callbacks(execute=True):
+        c1 = APIClient()
+        c1.force_authenticate(u1)
+        c1.get(f"/forum/topics/{topic.id}/")
 
-    c2 = APIClient()
-    c2.force_authenticate(u2)
-    c2.get(f"/forum/topics/{topic.id}/")
+        c2 = APIClient()
+        c2.force_authenticate(u2)
+        c2.get(f"/forum/topics/{topic.id}/")
 
     topic.refresh_from_db()
     assert topic.view_count == 2
 
 
-@pytest.mark.django_db(transaction=True)
+@pytest.mark.django_db
 @override_settings(WAGTAILFORUM_VIEW_COUNT_DEDUP_SECONDS=0)
-def test_view_count_recounts_after_dedup_window_expires():
+def test_view_count_recounts_after_dedup_window_expires(
+    django_capture_on_commit_callbacks,
+):
     cache.clear()
     board = _board(slug="vc-board4")
     topic = Topic.objects.create(board=board, title="VC4", slug="vc4", live=True)
 
     client = APIClient()
-    client.get(f"/forum/topics/{topic.id}/")
-    # TTL=0 means the cache entry expires immediately — next request is a new view.
-    client.get(f"/forum/topics/{topic.id}/")
+    with django_capture_on_commit_callbacks(execute=True):
+        client.get(f"/forum/topics/{topic.id}/")
+        # TTL=0 means the cache entry expires immediately — next request is a new view.
+        client.get(f"/forum/topics/{topic.id}/")
 
     topic.refresh_from_db()
     assert topic.view_count == 2

--- a/todos/250-pending-p2-forum-view-count-race.md
+++ b/todos/250-pending-p2-forum-view-count-race.md
@@ -1,0 +1,69 @@
+---
+status: pending
+priority: p2
+issue_id: "250"
+tags: [forum, cache, concurrency]
+dependencies: []
+---
+
+# Forum view_count dedup has a non-atomic cache race
+
+## Problem
+
+`TopicDetailView.retrieve()` uses `cache.get` + `cache.set` to deduplicate
+view-count increments. Under concurrent requests from the same viewer both
+calls can miss the cache and each schedule an `on_commit` increment, causing
+overcounting of `view_count`.
+
+## Findings
+
+- Flagged by kimi-review on commit `335f01c` (forum issues 6/10/14).
+- Source file: `backend/packages/wagtail_forum/wagtail_forum/api/views.py`
+  line ~292.
+- `cache.get(dedup_key)` → falsy for both concurrent requests → both call
+  `cache.set` and register `transaction.on_commit(_increment)`.
+
+## Recommended Action
+
+1. Replace the `cache.get` / `cache.set` pair with a single atomic
+   `cache.add(dedup_key, True, ttl)` call.
+   `cache.add` sets the key only if it does not already exist and returns
+   `True` on success — this is the standard atomic test-and-set for Django's
+   cache backends (memcached and Redis both support it natively).
+1. Only register `transaction.on_commit(_increment)` when `cache.add`
+   returns `True`.
+
+```python
+# Before
+if not cache.get(dedup_key):
+    cache.set(dedup_key, True, ttl)
+    transaction.on_commit(_increment)
+
+# After
+if cache.add(dedup_key, True, ttl):
+    transaction.on_commit(_increment)
+```
+
+1. Update the dedup-window expiry test to verify no double-count under
+   simulated concurrent requests.
+
+## Technical Details
+
+- File: `backend/packages/wagtail_forum/wagtail_forum/api/views.py` ~line 292
+- Tests: `backend/packages/wagtail_forum/wagtail_forum/tests/api/test_topic_detail.py`
+- Pattern: same atomic-add pattern used by Django's built-in rate-limiter
+  and the project's `api/idempotency.py` `reserve()` function.
+
+## Acceptance Criteria
+
+- [ ] `cache.get` + `cache.set` replaced with `cache.add` in `retrieve()`.
+- [ ] Existing view_count tests still pass.
+- [ ] No new test is needed beyond updating the existing dedup test comment
+      to note atomicity.
+
+## Work Log
+
+### 2025-07-07 - Identified
+
+- Flagged by kimi-review gate on commit `335f01c`.
+- Todo filed by Cascade.

--- a/todos/251-pending-p2-forum-notifications-topic-id-none.md
+++ b/todos/251-pending-p2-forum-notifications-topic-id-none.md
@@ -1,0 +1,81 @@
+---
+status: pending
+priority: p2
+issue_id: "251"
+tags: [forum, notifications, fcm]
+dependencies: []
+---
+
+# Forum notifications send "None" as topic_id for moderation_decided
+
+## Problem
+
+In `forum_host/notifications.py`, `topic_id` is derived from
+`kwargs.get("topic")` at the top of `dispatch()`. For the
+`moderation_decided` event the `topic` kwarg may be absent (the signal
+fires with `obj` but not always `topic`). When `topic` is `None`,
+`str(topic_id)` becomes the string `"None"` which is sent to FCM,
+corrupting the mobile client's payload.
+
+## Findings
+
+- Flagged by kimi-review on commit `335f01c`.
+- Source file: `backend/apps/forum_host/notifications.py` line ~60.
+- `topic_id = getattr(topic, "id", None)` → `None` when `topic` kwarg
+  is missing → `str(None)` → `"None"` in FCM data dict.
+- The `wagtail_forum/signals.py` `moderation_decided` signal fires with
+  `obj` (the Post or Topic) but `topic` is not guaranteed to be passed.
+
+## Recommended Action
+
+1. In the `moderation_decided` branch, derive `topic_id` from `obj`
+   when `topic` is not provided:
+
+```python
+elif event == "moderation_decided":
+    obj = kwargs.get("obj")
+    status = kwargs.get("status", "")
+    author = getattr(obj, "author", None)
+    if author is None:
+        return
+    # Derive topic_id from obj: Post has .topic_id, Topic has .pk.
+    from wagtail_forum.models import Post as ForumPost
+    if isinstance(obj, ForumPost):
+        resolved_topic_id = obj.topic_id
+    else:
+        resolved_topic_id = getattr(obj, "id", None)
+    send_forum_push.delay(
+        event,
+        author.pk,
+        {
+            "topic_id": str(resolved_topic_id) if resolved_topic_id is not None else "",
+            "status": status,
+            "obj_id": str(getattr(obj, "id", "")),
+        },
+    )
+```
+
+1. Add a test in `test_signals.py` that calls
+   `dispatch("moderation_decided", obj=post, status="published")`
+   **without** a `topic` kwarg and asserts the FCM data payload
+   `topic_id` value is not the string `"None"`.
+
+## Technical Details
+
+- File: `backend/apps/forum_host/notifications.py` ~line 51–65
+- Tests: `backend/apps/forum_host/tests/test_signals.py`
+
+## Acceptance Criteria
+
+- [ ] `moderation_decided` derives `topic_id` from `obj` when `topic`
+      kwarg is absent.
+- [ ] FCM data payload never contains the string `"None"` as a value.
+- [ ] New test passes: `dispatch("moderation_decided", obj=post, status="published")`
+      without `topic` kwarg produces a payload with `topic_id != "None"`.
+
+## Work Log
+
+### 2025-07-07 - Identified
+
+- Flagged by kimi-review gate on commit `335f01c`.
+- Todo filed by Cascade.

--- a/todos/252-pending-p2-forum-push-delay-unguarded.md
+++ b/todos/252-pending-p2-forum-push-delay-unguarded.md
@@ -1,0 +1,66 @@
+---
+status: pending
+priority: p2
+issue_id: "252"
+tags: [forum, notifications, celery, reliability]
+dependencies: []
+---
+
+# forum_host dispatch() does not guard send_forum_push.delay() against Celery errors
+
+## Problem
+
+`forum_host/notifications.py::dispatch()` calls `send_forum_push.delay()`
+without a try/except. If Celery is unavailable (broker down, queue full,
+connection timeout) the exception propagates up through the signal handler
+and into the publish transaction, potentially causing the entire publish to
+roll back. A push notification failure must never abort content publication.
+
+## Findings
+
+- Flagged by kimi-review on commit `335f01c`.
+- Source file: `backend/apps/forum_host/notifications.py` lines ~41 and ~57.
+- The existing `notify()` helper in `wagtail_forum/signals.py` already uses
+  `signal.send_robust()` to protect against receiver exceptions — the same
+  principle applies here at the task-enqueue level.
+
+## Recommended Action
+
+1. Wrap each `send_forum_push.delay()` call in a try/except and log the
+   failure instead of propagating it:
+
+```python
+try:
+    send_forum_push.delay(event, recipient_pk, data)
+except Exception:
+    logger.exception(
+        "[forum_host] Failed to enqueue push for event=%s user=%s",
+        event, recipient_pk,
+    )
+```
+
+1. Apply to both the `reply_added` and `moderation_decided` branches.
+1. Add a test that monkeypatches `send_forum_push.delay` to raise and
+   asserts `dispatch()` does not re-raise (i.e. it swallows the error
+   gracefully).
+
+## Technical Details
+
+- File: `backend/apps/forum_host/notifications.py` ~lines 41, 57
+- Tests: `backend/apps/forum_host/tests/test_signals.py`
+- Reference pattern: `wagtail_forum/signals.py::notify()` uses
+  `send_robust()` for the same reason.
+
+## Acceptance Criteria
+
+- [ ] Both `send_forum_push.delay()` calls are wrapped in try/except.
+- [ ] Exceptions are logged at ERROR/EXCEPTION level, not re-raised.
+- [ ] New test: `delay()` raising does not cause `dispatch()` to raise.
+- [ ] Existing signal and task tests still pass.
+
+## Work Log
+
+### 2025-07-07 - Identified
+
+- Flagged by kimi-review gate on commit `335f01c`.
+- Todo filed by Cascade.


### PR DESCRIPTION
## Summary
Addresses three issues identified in the Wagtail Forum addon review.

### Issue 10 — view_count never incremented
- Atomic F() increment in TopicDetailView.retrieve() via transaction.on_commit
- Cache-deduplicated per viewer (WAGTAILFORUM_VIEW_COUNT_DEDUP_SECONDS, default 15 min)

### Issue 6 — SyncView always returns empty deleted list
- New TopicDeletedLog model (append-only tombstone log, migration 0010)
- post_delete signal writes a tombstone on every topic hard-delete
- SyncView returns [{topic_id, board_id}] in deleted for delta syncs
- prune_forum_tombstones management command to bound table growth (WAGTAILFORUM_SYNC_TOMBSTONE_RETENTION_DAYS, default 30 days)

### Issue 14 — notifications.dispatch() is a stub
- ForumProfile.fcm_token field (migration 0011), write-only on MeProfileSerializer
- forum_host/tasks.py: send_forum_push Celery task with retry logic
- notifications.dispatch() routes reply_added and moderation_decided to FCM via the task

## Follow-up todos filed
- 250 — cache.add race fix for view_count dedup
- 251 — topic_id "None" string in moderation_decided payload
- 252 — send_forum_push.delay() unguarded against Celery errors