### PR TITLE
security-scan: bump Django to 6.0.7, soupsieve to 2.8.4

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -37,7 +37,7 @@ decorator==5.2.1
 defusedxml==0.7.1
 distro==1.9.0
 dj-database-url==3.1.2
-Django==6.0.6
+Django==6.0.7
 django-ai-core==0.1.5
 django-allauth==65.16.1
 django-appconf==1.2.0
@@ -188,7 +188,7 @@ setuptools==80.9.0
 shellingham==1.5.4
 six==1.17.0
 sniffio==1.3.1
-soupsieve==2.8
+soupsieve==2.8.4
 sqlite-fts4==1.0.3
 sqlite-migrate==0.1b0
 sqlite-utils==3.38


### PR DESCRIPTION
## Summary
pip-audit's Backend Python Security Scan is failing on every PR (first seen on #438) after new upstream advisories were published against pinned deps:

| Package | Pinned | Advisories | Fixed in |
|---------|--------|-----------|----------|
| Django | 6.0.6 | PYSEC-2026-2090, PYSEC-2026-2091, PYSEC-2026-2092 | 6.0.7 |
| soupsieve | 2.8 | CVE-2026-49476, CVE-2026-49477 | 2.8.4 |

Both are patch releases within the pinned minor.

## Verification
- `wagtail_forum` + `forum_host` suites: 208/208 green locally on the new pins (fresh test DB, `--create-db`)
- Full backend suite run in progress locally; this PR's CI runs it on the new pins regardless

## Notes
Unblocks the Backend Python Security Scan for all open PRs once merged (they pick it up via the merge ref on re-run / update-branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)