### PR TITLE
docs: codify distilled session learnings (Railway builder, emulator tests, spectacular)

### DIFF
--- a/backend/docs/deployment/railway.md
+++ b/backend/docs/deployment/railway.md
@@ -13,7 +13,52 @@ so cross-site cookie auth must be configured (see env vars below).
 3. **Add PostgreSQL** and **Add Redis** (New → Database). Railway exposes
    `DATABASE_URL` and `REDIS_URL` — reference them from the web service (see below).
 4. Set the **environment variables** (Settings → Variables).
-5. Deploy. The start command runs migrations + `collectstatic`, then `gunicorn`.
+5. Deploy. The Docker build bakes `collectstatic`; `preDeployCommand` runs
+   migrations + the forum seed; the start command is gunicorn-only (see below).
+
+## How a deploy works (DOCKERFILE builder — todo 241)
+
+`backend/railway.json` sets `"builder": "DOCKERFILE"`, so Railway builds
+`backend/Dockerfile` instead of auto-generating one. Deploys auto-trigger from
+GitHub `main` (Railway's GitHub connection — no Actions workflow, no staging
+environment): **merging to `main` IS deploying**. Each piece below was placed
+where it is for a reason — moving it breaks prod in a way local testing won't
+show:
+
+- **Why not Nixpacks/Railpack**: Nixpacks generates a Dockerfile with
+  `ARG`+`ENV` lines for every service variable, baking secrets into image
+  layers (BuildKit's `SecretsUsedInArgOrEnv` lint flagged 9). Railpack copies
+  only `requirements.txt` before `pip install`, which breaks the editable
+  `-e ./packages/wagtail_forum` requirement. The hand-written Dockerfile
+  declares NO `ARG`s and `COPY . .`s before installing — see its header
+  comments.
+- **Python version** is pinned by `backend/.python-version` (canonical) and
+  must stay in sync with the Dockerfile's `FROM python:3.13-slim`.
+- **`collectstatic` runs at BUILD time** (a `RUN` step), never at container
+  start: on the slim runtime image the filesystem copies ~3 s/file (262 files
+  ≈ 13 min), which eats the whole healthcheck window so gunicorn never starts.
+  Build infra does it in ~1.5 s. It also can't move to `preDeployCommand` —
+  that container's filesystem is separate from the serving container, so its
+  output never reaches gunicorn. (Django 6 note: `STATICFILES_STORAGE` in
+  settings.py is deprecated-and-ignored — removed in Django 5.1, superseded by
+  `STORAGES` — so collectstatic is plain file copying, no manifest; the
+  setting is vestigial.)
+- **Migrations run in `preDeployCommand`** (`migrate --noinput` +
+  `seed_default_forum`). If it fails, Railway halts the deploy and the
+  previous deployment keeps serving — zero-downtime failure, unlike a
+  migration wedged inside the start command.
+- **`startCommand` is wrapped in `sh -c`**: with a DOCKERFILE builder the
+  command is exec'd with no shell, so a bare `$PORT` reaches gunicorn as the
+  literal string `$PORT` ("Error: '$PORT' is not a valid port number"). The
+  old Nixpacks command only worked because `collectstatic && gunicorn` forced
+  a shell via `&&`.
+- **The healthcheck is load-bearing**: Railway marks a deploy SUCCESS when the
+  container *starts*, not when it serves. `healthcheckPath` makes Railway wait
+  for a 200 before swapping traffic; on timeout (300 s) the old deployment
+  stays live. Railway probes with `Host: healthcheck.railway.app` over plain
+  HTTP, so settings.py appends that host to `ALLOWED_HOSTS` and exempts the
+  health path from the SSL redirect (`SECURE_REDIRECT_EXEMPT`) — removing
+  either fails every future deploy at the healthcheck.
 
 ## Required environment variables (web service)
 

--- a/docs/LEARNINGS.md
+++ b/docs/LEARNINGS.md
@@ -687,3 +687,46 @@ the operation's own `save_revision` (e.g. monkeypatch `save_revision` to run the
 real one then delete the row), not before — otherwise you test a different failure
 (full_clean on a dangling revision FK) than the one you intend (the lock re-fetch's
 `DoesNotExist`). **Agent**: wagtail-reviewer.
+
+## Railway Dockerfile-builder migration (todo 241, 2026-07-01)
+
+### [2026-07-01] Nixpacks baked secrets into image layers; the DOCKERFILE rebuild took four prod-only fixes to go live
+
+**Mistake**: The legacy `NIXPACKS` builder generates a Dockerfile with `ARG`+`ENV`
+lines for EVERY service variable, so all 9 secret-named vars (SECRET_KEY, API
+keys, …) were baked into image layers (BuildKit's `SecretsUsedInArgOrEnv` lint;
+Railway docs confirm sealed variables still inject into Nixpacks builds).
+Switching to a hand-written Dockerfile (zero `ARG`s; `COPY . .` before
+`pip install` so the editable `wagtail_forum` package resolves) fixed the leak
+but surfaced four failures observable ONLY in prod, each caught by a guarded
+deploy:
+
+1. **No healthcheck = blind traffic swap.** Railway marks a deploy SUCCESS when
+   the container *starts*, not when it serves. `healthcheckPath` in
+   `railway.json` makes Railway hold traffic until a 200 (old deploy keeps
+   serving on timeout) — every later fix was diagnosed through it.
+2. **`collectstatic` at container start**: on the `python:3.13-slim` runtime
+   filesystem ~3 s/file × 262 files ≈ 13 min — ate the 300 s healthcheck window
+   so gunicorn never started. Baked into the Docker build (build infra: ~1.5 s).
+   It can't go in `preDeployCommand` either — that container's filesystem is
+   separate from the serving one. (Same debugging confirmed Django 6 IGNORES the
+   deprecated `STATICFILES_STORAGE` setting — removed in 5.1, superseded by
+   `STORAGES` — so settings.py:388 is vestigial and collectstatic emits no
+   manifest.)
+3. **`$PORT` unexpanded**: a DOCKERFILE `startCommand` is exec'd with NO shell,
+   so gunicorn received the literal string `$PORT`. Fix: wrap in `sh -c '…'`.
+   (The Nixpacks-era command only worked because `collectstatic && gunicorn`
+   forced a shell via `&&`.)
+4. **Healthcheck host/scheme rejected**: Railway probes with
+   `Host: healthcheck.railway.app` over plain HTTP → Django 400 `DisallowedHost`,
+   then `SECURE_SSL_REDIRECT` 301'd the probe. settings.py now appends that host
+   to `ALLOWED_HOSTS` and lists the health path in `SECURE_REDIRECT_EXEMPT`.
+
+**Rule**: On Railway always set `healthcheckPath` (SUCCESS ≠ serving). Migrations
+belong in `preDeployCommand` (failure = old deploy stays live); `collectstatic`
+belongs in the image build (never the start path, never pre-deploy — separate
+filesystem); `sh -c`-wrap any `startCommand` that references `$VARS`; keep
+`healthcheck.railway.app` + the SSL-exempt health path in settings. Deploys
+auto-trigger from `main` (no staging) — merging IS deploying. Operational detail:
+`backend/docs/deployment/railway.md` + `backend/Dockerfile` header comments.
+**Agent**: (process/deployment — codified in railway.md; no diff-reviewable signature)

--- a/docs/rules/api.md
+++ b/docs/rules/api.md
@@ -37,3 +37,18 @@ Compact checklist auto-injected before edits. Long-form:
   request host). Clients fetch them verbatim — do NOT re-prefix the API base
   (double-prefixing 404s). The page-fetch helper must accept either a relative
   path (first page) or an absolute cursor URL (subsequent pages).
+- **Never name a custom OpenAPI auth scheme `cookieAuth`** — drf-spectacular's
+  built-in SessionAuthentication scheme already claims that name (the
+  `sessionid` cookie); a second identity under it triggers "2 components with
+  identical names … different identities" and an incorrect schema. Name it for
+  the actual cookie (`jwtCookieAuth` for `access_token`) — see
+  `apps/users/schema.py`.
+- **drf-spectacular pre/post-processing hooks must not share module-global
+  state.** Two concurrent `SpectacularAPIView` regenerations interleave
+  `.clear()`/`.add()` with iteration → silently missing schema entries or "Set
+  changed size during iteration". Keep cross-hook state in `threading.local()`
+  (reference: `plant_community_backend/api_schema.py`), import
+  `django.conf.settings` inside the hook body (a top-level import added before
+  its first use gets stripped by the formatter), and derive the path prefix
+  from `SPECTACULAR_SETTINGS["SCHEMA_PATH_PREFIX"]` rather than re-hardcoding
+  a regex that can drift.

--- a/docs/rules/flutter.md
+++ b/docs/rules/flutter.md
@@ -23,3 +23,16 @@ Compact checklist auto-injected before edits. Long-form:
   (`_$xHash`), so *any* edit (even deleting an unrelated method) makes it stale. CI's
   "Ensure generated code is committed" gate (`build_runner` + `git diff
   --exit-code`) blocks the merge; local `flutter analyze`/`test` will NOT catch it.
+- **Firebase-emulator integration tests** (`integration_test/`): adopt the
+  native `[DEFAULT]` app — `Firebase.initializeApp()` with NO options (passing
+  options throws `[core/duplicate-app]`) and run the emulator with the same
+  `--project` as the native `projectId`. Gate on
+  `String.fromEnvironment('FIRESTORE_EMULATOR_HOST')` — `Platform.environment`
+  is invisible on-device; an unset define is a clean skip. Mount the service
+  provider BEFORE `useFirestoreEmulator()` (its `build()` assigns
+  `_firestore.settings`, which would clobber the emulator host and send traffic
+  to prod). Give `testWidgets` an overall `timeout:` — per-step `.timeout()`s
+  don't cover init/sign-in, so an unreachable emulator hangs forever. Reference:
+  `integration_test/firestore_emulator_roundtrip_test.dart` +
+  `scripts/run_firestore_emulator_test.sh`; details in
+  `docs/FIRESTORE_PATTERNS.md` Pattern 10.

--- a/docs/rules/forum.md
+++ b/docs/rules/forum.md
@@ -25,3 +25,10 @@ Compact checklist auto-injected before edits to the forum code. Long-form:
   `class Ratelimited(PermissionDenied): pass` with no `.rate` attribute. Use the
   `apps/core/ratelimit.py` wrapper that catches `Ratelimited` and re-raises `RatelimitedWithRate(rate)`
   so the exception handler can derive the real `Retry-After` window instead of hardcoding a constant.
+- **The frozen-topic guard is deliberately symmetric**: PATCH and DELETE are both
+  blocked (409) on a closed/locked topic **including for moderators** — a product
+  decision for mirror-PATCH predictability, not a bug; a moderator reopens the
+  topic to remove content. Don't add a moderator bypass without a new product
+  decision. (The earlier "reply_count desync" justification was wrong —
+  `unpublish()`'s recount is state-independent.) Policy is single-sourced in
+  `Post.edit_block`/`delete_block` (`wagtail_forum/models/posts.py`).

--- a/docs/rules/testing.md
+++ b/docs/rules/testing.md
@@ -76,3 +76,16 @@ Compact checklist auto-injected before edits.
   controls share a label.** `{ name: /sign in/i }` matches both `"Sign in"` and
   `"Sign in with Google"` → "Found multiple elements". Use an exact string
   (`{ name: 'Sign in' }`) once a page has both.
+- **Pin a `swagger_fake_view` guard with a direct `view.get_queryset()` unit
+  test.** Schema-content tests can't detect the guard's removal —
+  drf-spectacular resolves the model from `serializer_class` and never calls
+  `get_queryset`. Instantiate the view, set `view.swagger_fake_view = True`,
+  call `get_queryset()` with no request/kwargs wired: it only survives if the
+  guard short-circuits (guard missing → `KeyError` on `self.kwargs` → red).
+  See `wagtail_forum/tests/api/test_schema.py`.
+- **"Comment out `permission_classes`" can be a NO-OP mutation.** With
+  `DEFAULT_PERMISSION_CLASSES = IsAuthenticatedOrReadOnly`, a view with its
+  `permission_classes` removed still blocks anonymous writes — the 401 test
+  keeps passing and proves nothing. To verify an auth test is non-vacuous,
+  mutate to `permission_classes = [AllowAny]`, and check the DRF default
+  before trusting any mutation-based verification.

--- a/plant_community_mobile/docs/FIRESTORE_PATTERNS.md
+++ b/plant_community_mobile/docs/FIRESTORE_PATTERNS.md
@@ -44,12 +44,14 @@ class FirestoreService extends _$FirestoreService {
 ### Key Points
 
 **DO**:
+
 - ✅ Enable `persistenceEnabled: true` for offline support
 - ✅ Use `CACHE_SIZE_UNLIMITED` for mobile apps (no storage constraints)
 - ✅ Initialize settings in service build() method
 - ✅ Log initialization for debugging
 
 **DON'T**:
+
 - ❌ Disable offline persistence (breaks offline functionality)
 - ❌ Set cache size too small (<40MB) - causes data eviction
 - ❌ Re-initialize settings multiple times
@@ -106,12 +108,14 @@ match /users/{userId}/{document=**} {
 ### Key Points
 
 **DO**:
+
 - ✅ Always use `/users/{userId}/...` structure
 - ✅ Get userId from Firebase Auth (`FirebaseAuth.instance.currentUser?.uid`)
 - ✅ Enforce same rules in client and security rules
 - ✅ Test with multiple users to verify isolation
 
 **DON'T**:
+
 - ❌ Use global collections for user data
 - ❌ Hardcode user IDs
 - ❌ Trust client-side auth checks only
@@ -194,6 +198,7 @@ ref.watch(plantsStreamProvider(userId)).when(
 ### Key Points
 
 **DO**:
+
 - ✅ Handle parsing errors for each document
 - ✅ Use `.handleError()` to catch stream errors
 - ✅ Log errors for debugging
@@ -201,6 +206,7 @@ ref.watch(plantsStreamProvider(userId)).when(
 - ✅ Use Riverpod's `.when()` for loading/error states
 
 **DON'T**:
+
 - ❌ Let stream errors crash the app
 - ❌ Assume all documents are valid
 - ❌ Ignore malformed data
@@ -265,12 +271,14 @@ Future<Plant?> getPlant(String userId, String plantId) async {
 ### Key Points
 
 **DO**:
+
 - ✅ Check `snapshot.metadata.isFromCache` to identify source
 - ✅ Log cache hits for performance debugging
 - ✅ Use `kDebugMode` to disable logs in production
 - ✅ Include operation type in log prefix (`[FIRESTORE]`)
 
 **DON'T**:
+
 - ❌ Leave debug logs enabled in production
 - ❌ Log sensitive user data
 - ❌ Spam logs with every document
@@ -354,6 +362,7 @@ class Plant {
 ### Key Points
 
 **DO**:
+
 - ✅ Use explicit type casts (`as String`, `as List<dynamic>`)
 - ✅ Handle null values with `?` operator
 - ✅ Store timestamps as ISO 8601 strings
@@ -361,6 +370,7 @@ class Plant {
 - ✅ Validate all required fields are present
 
 **DON'T**:
+
 - ❌ Use dynamic types without validation
 - ❌ Store DateTime as milliseconds (harder to query)
 - ❌ Assume lists are already typed
@@ -442,12 +452,14 @@ ref.watch(plantsStreamProvider(userId)).when(
 ### Key Points
 
 **DO**:
+
 - ✅ Show success feedback immediately
 - ✅ Trust Firestore's offline queue
 - ✅ Use streams for real-time updates
 - ✅ Handle errors gracefully
 
 **DON'T**:
+
 - ❌ Wait for server confirmation to update UI
 - ❌ Show loading spinner for writes (instant on cache)
 - ❌ Manually track pending writes
@@ -503,12 +515,14 @@ Future<void> clearAllPlants(String userId) async {
 ### Key Points
 
 **DO**:
+
 - ✅ Use batches for multiple related operations
 - ✅ Batch up to 500 operations (Firestore limit)
 - ✅ Commit batch to execute atomically
 - ✅ Log operation count for debugging
 
 **DON'T**:
+
 - ❌ Use batches for single operations (overhead)
 - ❌ Exceed 500 operations per batch
 - ❌ Mix batch and non-batch operations
@@ -590,12 +604,14 @@ try {
 ### Key Points
 
 **DO**:
+
 - ✅ Create domain-specific exception classes
 - ✅ Include operation context in message
 - ✅ Preserve original error details for debugging
 - ✅ Use custom exceptions in catch blocks
 
 **DON'T**:
+
 - ❌ Let generic Firebase exceptions reach UI
 - ❌ Lose original error information
 - ❌ Show technical error codes to users
@@ -668,12 +684,14 @@ class PlantsList extends ConsumerWidget {
 ### Key Points
 
 **DO**:
+
 - ✅ Use Riverpod providers for stream lifecycle
 - ✅ Pass userId as provider parameter
 - ✅ Use `.when()` for loading/error states
 - ✅ Let Riverpod handle disposal
 
 **DON'T**:
+
 - ❌ Manually manage stream subscriptions
 - ❌ Create StreamControllers in services
 - ❌ Forget to cancel subscriptions (memory leak)
@@ -757,12 +775,14 @@ void main() {
 ### Key Points
 
 **DO**:
+
 - ✅ Use emulator for all integration tests
 - ✅ Clear data between tests (isolation)
 - ✅ Test offline scenarios (disconnect emulator)
 - ✅ Verify security rules in emulator
 
 **DON'T**:
+
 - ❌ Test against production Firestore
 - ❌ Skip emulator setup (costs money, slow)
 - ❌ Share test data between tests
@@ -774,6 +794,39 @@ void main() {
 - Free (no Firestore costs)
 - Isolated test environment
 - Offline testing support
+
+### Hard-won specifics for ON-DEVICE emulator tests (2026-07)
+
+The generic setup above works host-side. For a real `integration_test/` run on
+a device/simulator, five specifics matter — reference implementation:
+`integration_test/firestore_emulator_roundtrip_test.dart` +
+`scripts/run_firestore_emulator_test.sh`:
+
+1. **Adopt the native `[DEFAULT]` app.** iOS/Android auto-configure it from the
+   bundled `GoogleService-Info.plist` / `google-services.json`. Call
+   `Firebase.initializeApp()` with **no options** — passing options collides
+   with the native app (`[core/duplicate-app]`). Run the emulator with the same
+   project id (`firebase emulators:exec --project plant-community-prod`) so the
+   redirected traffic lands in the right namespace and prod is never touched.
+2. **Mount the service before connecting the emulator.**
+   `FirestoreService.build()` assigns
+   `_firestore.settings = Settings(persistenceEnabled: true)` with no host — if
+   it runs after `useFirestoreEmulator()`, that assignment clobbers the
+   emulator host and traffic goes to prod. Read/listen the provider first, then
+   call `useFirestoreEmulator`.
+3. **Gate with `String.fromEnvironment`, not `Platform.environment`.** The test
+   executes ON the device, where the host shell's environment is invisible;
+   `--dart-define` values are compiled in. An unset define ⇒ clean skip, so
+   plain `flutter test` (which never scans `integration_test/`) and define-less
+   device runs both stay green.
+4. **Forward the env vars `emulators:exec` injects.** It exports
+   `FIRESTORE_EMULATOR_HOST` / `FIREBASE_AUTH_EMULATOR_HOST` matching the ports
+   in `firebase.json` — pass those straight through as `--dart-define`s instead
+   of hardcoding ports, so `firebase.json` stays the single source of truth.
+5. **Overall `timeout:` on `testWidgets`.** Per-step `.timeout()`s don't cover
+   `initializeApp` / `signInAnonymously` / `enableNetwork`, so an unreachable
+   emulator hangs the run forever without one. The round-trip test uses
+   `Timeout(Duration(minutes: 2))`.
 
 ---
 
@@ -899,10 +952,10 @@ Before deploying Firestore to production:
 
 ## References
 
-- **Firestore Documentation**: https://firebase.google.com/docs/firestore
-- **Offline Persistence**: https://firebase.google.com/docs/firestore/manage-data/enable-offline
-- **Security Rules**: https://firebase.google.com/docs/firestore/security/get-started
-- **Riverpod**: https://riverpod.dev/docs/introduction/getting_started
+- **Firestore Documentation**: <https://firebase.google.com/docs/firestore>
+- **Offline Persistence**: <https://firebase.google.com/docs/firestore/manage-data/enable-offline>
+- **Security Rules**: <https://firebase.google.com/docs/firestore/security/get-started>
+- **Riverpod**: <https://riverpod.dev/docs/introduction/getting_started>
 
 ---
 


### PR DESCRIPTION
## Summary

Triage of `distilled-learnings-from-claude-sessions-2026-07-10.md` — 34 learnings distilled from June 25 – July 8 session transcripts (OCRecipes episodic-distillation experiment), routed per the codify skill's destination tables. **~24 items were already codified** (the Wagtail edit-moderation cluster, SERVE_PERMISSIONS gate + import-time binding, OAuth/ITP risk, strict assertions, force_login/detect-secrets, WorkflowState wedge/cancel, select_for_update rules, trigger regex); this PR routes the 10 that weren't. The source file is deleted after this lands (it was intentionally untracked and self-instructed "triage then delete").

## Changes

- **`backend/docs/deployment/railway.md`** — the biggest gap: the doc still described the pre-todo-241 world ("start command runs migrations + collectstatic"). New "How a deploy works" section documents the DOCKERFILE builder reality: Nixpacks secret-baking rationale, build-time `collectstatic` (slim-image ~3 s/file), `preDeployCommand` migrations (fail = old deploy stays live; separate filesystem), `sh -c` for `$PORT`, healthcheck semantics (SUCCESS ≠ serving) + `healthcheck.railway.app` host, `.python-version`, deploys-auto-trigger-from-`main`.
- **`docs/LEARNINGS.md`** — dated entry for the todo-241 migration (the four prod-only fixes never got one) incl. the Django 6 `STATICFILES_STORAGE`-is-ignored fact (settings.py:388 is vestigial).
- **`docs/rules/testing.md`** — pin `swagger_fake_view` guards via a direct `view.get_queryset()` unit test (schema tests can't detect removal); "comment out `permission_classes`" is a NO-OP mutation under `DEFAULT_PERMISSION_CLASSES=IsAuthenticatedOrReadOnly`.
- **`docs/rules/api.md`** — never name a custom OpenAPI auth scheme `cookieAuth` (built-in collision); drf-spectacular hooks keep shared state in `threading.local()` (ref: `plant_community_backend/api_schema.py`).
- **`docs/rules/flutter.md` + `plant_community_mobile/docs/FIRESTORE_PATTERNS.md`** — the five on-device Firebase-emulator integration-test gotchas, anchored to the real reference implementation (`integration_test/firestore_emulator_roundtrip_test.dart` + runner script): native `[DEFAULT]` app adoption, provider-mount-before-`useFirestoreEmulator`, `String.fromEnvironment` gating, `emulators:exec` env-var forwarding, overall `testWidgets` timeout. (The distillation file guessed these belonged to `~/projects/flutter` — they belong here; verified against this repo's test.)
- **`docs/rules/forum.md`** — frozen-topic guard symmetry (PATCH = DELETE, no moderator bypass) recorded as a deliberate product decision so it isn't "rediscovered" as a bug.

`FIRESTORE_PATTERNS.md` also carries markdownlint's whole-file blank-line normalization (auto-fix on first commit attempt). Its remaining MD024 duplicate-heading warnings are the file's pre-existing per-pattern section structure — committed with `SKIP=markdownlint`, matching the documented precedent.

## Verification

- Every claim was verified against the current code before writing: `railway.json`/`Dockerfile`/settings.py:115,388,993 for the Railway section; `users/schema.py`, `api_schema.py:81`, `wagtail_forum/tests/api/test_schema.py` for the DRF bullets; the integration test (provider-mount ordering comment, `Timeout(Duration(minutes: 2))` at line 196) and runner script for the emulator items; `posts.py`/`views.py:488` for the frozen-topic policy.
- Docs-only diff; kimi-review gate passed (no CRITICAL/WARNING).

🤖 Generated with [Claude Code](https://claude.com/claude-code)