### PR TITLE
forum: preview + admin polish (todo 254 slice 4, audit M16/M20)

### DIFF
--- a/backend/docs/patterns/domain/forum.md
+++ b/backend/docs/patterns/domain/forum.md
@@ -51,3 +51,23 @@ The forum is a reusable, Wagtail-native package — no django-machina, no
 - **Visibility**: filter page querysets with `.live().public()`; gate child-object
   queries via the visible-board set (`PageViewRestriction` is not auto-enforced in
   custom views/APIs).
+
+## Moderation permission scope is global, deliberately (audit M19)
+
+Moderation is one flat `"Forum Moderators"` group (`apps/forum_host/bootstrap.py`)
+with `change_topic`/`change_post` etc. — there is no per-board moderator concept.
+This is a **deliberate decision, not an oversight**:
+
+- `Topic`/`Post` are snippets, not Pages — Wagtail's `GroupPagePermission` (which
+  `ForumBoard`, itself a Page, could otherwise use) has no snippet analog. A
+  board-scoped check would mean a new group↔board mapping model consulted from
+  every permission check site (`Post.edit_block`/`delete_block`,
+  `_edit_is_trusted`'s `acting_as_moderator`, the bulk-unpublish action's
+  `check_perm`, the SnippetViewSet permission gate) — high blast radius through
+  security-critical code.
+  - `seed_default_forum` creates exactly one board. There is no product signal
+    (no second board, no request for delegated moderators) that justifies that
+    blast radius today (YAGNI, root `CLAUDE.md`).
+- **Revisit trigger**: when a second board ships AND it needs a moderator distinct
+  from the global group, design the group↔board mapping then, against a real
+  requirement instead of a speculative one.

--- a/backend/packages/wagtail_forum/wagtail_forum/models/posts.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/models/posts.py
@@ -4,7 +4,13 @@ from django.db import models
 from django.db.models import Q
 from wagtail.admin.panels import FieldPanel
 from wagtail.fields import StreamField
-from wagtail.models import DraftStateMixin, LockableMixin, RevisionMixin, WorkflowMixin
+from wagtail.models import (
+    DraftStateMixin,
+    LockableMixin,
+    PreviewableMixin,
+    RevisionMixin,
+    WorkflowMixin,
+)
 from wagtail.search import index
 
 from ..blocks import ForumBodyBlock
@@ -21,6 +27,7 @@ class Post(
     DraftStateMixin,
     LockableMixin,
     RevisionMixin,
+    PreviewableMixin,
     index.Indexed,
     models.Model,
 ):
@@ -103,6 +110,14 @@ class Post(
 
     def __str__(self):
         return f"Post #{self.pk} in {self.topic_id}"
+
+    def get_preview_template(self, request, mode_name):
+        """Lets a moderator preview a NEEDS_CHANGES post's rendered body from
+        the snippet edit view (audit M16) — the workflow "Awaiting my review"
+        dashboard never surfaces SpamCheckTask items (see wagtail_hooks.py's
+        `_pending_moderation_count` docstring), so the edit view opened from
+        the live=False filtered list is the reachable path this serves."""
+        return "wagtail_forum/admin/post_preview.html"
 
     def edit_block(self, user):
         """Why ``user`` may not edit (PATCH) this post, or ``None`` if they may.

--- a/backend/packages/wagtail_forum/wagtail_forum/templates/wagtail_forum/admin/bulk_actions/confirm_bulk_unpublish.html
+++ b/backend/packages/wagtail_forum/wagtail_forum/templates/wagtail_forum/admin/bulk_actions/confirm_bulk_unpublish.html
@@ -1,5 +1,5 @@
 {% extends 'wagtailadmin/bulk_actions/confirmation/base.html' %}
-{% load i18n %}
+{% load i18n wagtailadmin_tags %}
 
 {% block titletag %}
     {% if items|length == 1 %}

--- a/backend/packages/wagtail_forum/wagtail_forum/templates/wagtail_forum/admin/bulk_actions/confirm_bulk_unpublish.html
+++ b/backend/packages/wagtail_forum/wagtail_forum/templates/wagtail_forum/admin/bulk_actions/confirm_bulk_unpublish.html
@@ -1,0 +1,57 @@
+{% extends 'wagtailadmin/bulk_actions/confirmation/base.html' %}
+{% load i18n %}
+
+{% block titletag %}
+    {% if items|length == 1 %}
+        {% blocktrans trimmed with snippet_type_name=model_opts.verbose_name %}Unpublish {{ snippet_type_name }}{% endblocktrans %} - {{ items.0.item }}
+    {% else %}
+        {{ items|length|intcomma }} {{ model_opts.verbose_name_plural|capfirst }}
+    {% endif %}
+{% endblock %}
+
+{% block header %}
+    {% trans "Unpublish " as unpublish_str %}
+    {% if items|length == 1 %}
+        {% include "wagtailadmin/shared/header.html" with title=unpublish_str subtitle=items.0.item icon=header_icon only %}
+    {% else %}
+        {% include "wagtailadmin/shared/header.html" with title=unpublish_str subtitle=model_opts.verbose_name_plural|capfirst icon=header_icon only %}
+    {% endif %}
+{% endblock header %}
+
+{% block items_with_access %}
+    {% if items %}
+        {% if items|length == 1 %}
+            <p>{% blocktrans trimmed with snippet_type_name=model_opts.verbose_name %}Are you sure you want to unpublish this {{ snippet_type_name }}?{% endblocktrans %}</p>
+        {% else %}
+            <p>{% blocktrans trimmed with snippet_type_name=model_opts.verbose_name_plural count=items|length|intcomma %}Are you sure you want to unpublish {{ count }} {{ snippet_type_name }}?{% endblocktrans %}</p>
+            <ul>
+                {% for snippet in items %}
+                    <li><a href="{{ snippet.edit_url }}" target="_blank" rel="noreferrer">{{ snippet.item }}</a></li>
+                {% endfor %}
+            </ul>
+        {% endif %}
+    {% endif %}
+{% endblock items_with_access %}
+
+{% block items_with_no_access %}
+    {% if items_with_no_access|length == 1 %}
+        {% blocktrans with snippet_type_name=model_opts.verbose_name trimmed asvar no_access_msg %}
+            You don't have permission to unpublish this {{ snippet_type_name }}
+        {% endblocktrans %}
+    {% else %}
+        {% blocktrans with snippet_plural_name=model_opts.verbose_name_plural trimmed asvar no_access_msg %}
+            You don't have permission to unpublish these {{ snippet_plural_name }}
+        {% endblocktrans %}
+    {% endif %}
+    {% include 'wagtailsnippets/bulk_actions/list_items_with_no_access.html' with items=items_with_no_access no_access_msg=no_access_msg %}
+{% endblock items_with_no_access %}
+
+{% block form_section %}
+    {% if items %}
+        {% trans 'Yes, unpublish' as action_button_text %}
+        {% trans "No, don't unpublish" as no_action_button_text %}
+        {% include 'wagtailadmin/bulk_actions/confirmation/form.html' with action_button_class="serious" %}
+    {% else %}
+        {% include 'wagtailadmin/bulk_actions/confirmation/go_back.html' %}
+    {% endif %}
+{% endblock form_section %}

--- a/backend/packages/wagtail_forum/wagtail_forum/templates/wagtail_forum/admin/post_preview.html
+++ b/backend/packages/wagtail_forum/wagtail_forum/templates/wagtail_forum/admin/post_preview.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+{# Moderator preview of a Post's rendered body (audit M16) — reached from the #}
+{# snippet edit view's preview pane, not a public-facing page: Post has no #}
+{# front-end route of its own (the React SPA owns that), so this exists only #}
+{# to let a moderator see what a NEEDS_CHANGES post's body actually renders to. #}
+{% load wagtailcore_tags wagtailuserbar %}
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Preview: post in {{ object.topic.title }}</title>
+  </head>
+  <body>
+    <main>
+      <p>
+        <strong>{{ object.author|default:"[deleted user]" }}</strong>
+        in <em>{{ object.topic.title }}</em>
+        &mdash; {{ object.created_at }}
+      </p>
+      {% include_block object.body %}
+    </main>
+    {% wagtailuserbar %}
+  </body>
+</html>

--- a/backend/packages/wagtail_forum/wagtail_forum/tests/test_admin.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/tests/test_admin.py
@@ -252,6 +252,16 @@ def test_bulk_unpublish_action_unpublishes_selected_posts(client):
         args=("wagtail_forum", "post", "unpublish"),
     )
     query = "&".join(f"id={p.pk}" for p in posts)
+
+    # A real moderator always sees the GET confirmation page before POSTing
+    # (the snippet list's "Unpublish" button). Check it too, not just the
+    # POST — it renders a distinct template block (titletag) that a POST-only
+    # test never touches (kimi-review follow-up: this caught a real
+    # {% load %} bug, a missing wagtailadmin_tags for the intcomma filter,
+    # that 500'd this exact page for every user, privileged or not).
+    confirm_resp = client.get(f"{url}?{query}")
+    assert confirm_resp.status_code == 200
+
     resp = client.post(f"{url}?{query}", data={})
 
     assert resp.status_code == 302
@@ -302,6 +312,15 @@ def test_bulk_unpublish_action_blocks_user_without_change_permission(client):
     client.force_login(staff)
 
     url = reverse("wagtail_bulk_action", args=("wagtail_forum", "post", "unpublish"))
+
+    # GET the confirmation page first: proves check_perm was actually reached
+    # and returned False for THIS object (not just "nothing happened", which
+    # a negative-only assertion after POST can't distinguish from a broken
+    # request that never dispatched at all — kimi-review follow-up).
+    confirm_resp = client.get(f"{url}?id={post.pk}")
+    assert confirm_resp.status_code == 200
+    assert b"You don't have permission to unpublish this post" in confirm_resp.content
+
     client.post(f"{url}?id={post.pk}", data={})
 
     post.refresh_from_db()

--- a/backend/packages/wagtail_forum/wagtail_forum/tests/test_admin.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/tests/test_admin.py
@@ -258,3 +258,51 @@ def test_bulk_unpublish_action_unpublishes_selected_posts(client):
     for p in posts:
         p.refresh_from_db()
         assert p.live is False
+
+
+@pytest.mark.django_db
+def test_bulk_unpublish_action_blocks_user_without_change_permission(client):
+    # check_perm gates on wagtail_forum.change_post — a staff user who can
+    # reach /cms/ (access_admin) but lacks that specific permission must not
+    # be able to unpublish via this action (kimi-review follow-up: the
+    # golden-path test alone never proved check_perm actually blocks anyone).
+    from django.contrib.auth.models import Permission
+    from django.urls import reverse
+    from wagtail.models import Page
+    from wagtail_forum.models import ForumBoard, ForumIndex, ForumProfile, Post, Topic
+
+    author = User.objects.create_user(username="perm_test_author")
+    ForumProfile.for_user(author)
+    root = Page.objects.get(id=1)
+    index = root.add_child(instance=ForumIndex(title="PermForum", slug="permforum"))
+    board = index.add_child(
+        instance=ForumBoard(title="PermGeneral", slug="permgeneral")
+    )
+    topic = Topic.objects.create(
+        board=board, title="PermT", slug="permt", author=author
+    )
+    post = Post(
+        topic=topic,
+        author=author,
+        is_opening_post=True,
+        body=[{"type": "paragraph", "value": "<p>should stay live</p>"}],
+    )
+    post.save()
+    post.save_revision().publish()
+
+    # access_admin alone (no wagtail_forum.change_post) mirrors that
+    # forum_host/bootstrap.py's own "Forum Moderators" group needs BOTH —
+    # access_admin just to reach /cms/, change_post to actually moderate.
+    staff = User.objects.create_user(username="no_change_perm", is_staff=True)
+    staff.user_permissions.add(
+        Permission.objects.get(
+            content_type__app_label="wagtailadmin", codename="access_admin"
+        )
+    )
+    client.force_login(staff)
+
+    url = reverse("wagtail_bulk_action", args=("wagtail_forum", "post", "unpublish"))
+    client.post(f"{url}?id={post.pk}", data={})
+
+    post.refresh_from_db()
+    assert post.live is True

--- a/backend/packages/wagtail_forum/wagtail_forum/tests/test_admin.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/tests/test_admin.py
@@ -81,3 +81,180 @@ def test_moderation_summary_item_counts_spam_rejected_post(client):
 
     assert resp.status_code == 200
     assert b"1 Forum post awaiting moderation" in resp.content
+
+
+@pytest.mark.django_db
+def test_forum_search_area_appears_on_admin_pages_search(client):
+    # register_admin_search_area hooks render on Wagtail's global Pages search
+    # page (wagtailadmin/pages/search_results.html), not on /cms/ itself —
+    # SnippetViewSet listings default show_other_searches=False so they don't
+    # render it either (audit M20).
+    from django.urls import reverse
+
+    admin = User.objects.create_superuser(username="root", email="r@x.io")
+    client.force_login(admin)
+
+    resp = client.get(reverse("wagtailadmin_pages:search"), {"q": "anything"})
+
+    assert resp.status_code == 200
+    assert b"Forum" in resp.content
+
+
+@pytest.mark.django_db
+def test_post_search_fields_finds_live_post_by_body_text(client):
+    from wagtail.models import Page
+    from wagtail_forum.models import ForumBoard, ForumIndex, ForumProfile, Post, Topic
+
+    author = User.objects.create_user(username="searchable_author")
+    ForumProfile.for_user(author)
+    root = Page.objects.get(id=1)
+    index = root.add_child(instance=ForumIndex(title="SForum", slug="sforum"))
+    board = index.add_child(instance=ForumBoard(title="SGeneral", slug="sgeneral"))
+    topic = Topic.objects.create(board=board, title="ST", slug="st", author=author)
+    post = Post(
+        topic=topic,
+        author=author,
+        is_opening_post=True,
+        body=[{"type": "paragraph", "value": "<p>photosynthesis basics</p>"}],
+    )
+    post.save()
+    post.save_revision().publish()
+
+    admin = User.objects.create_superuser(username="root3", email="r3@x.io")
+    client.force_login(admin)
+
+    resp = client.get("/cms/snippets/wagtail_forum/post/?q=photosynthesis")
+
+    assert resp.status_code == 200
+    assert str(post.pk).encode() in resp.content
+
+
+@pytest.mark.django_db
+def test_forum_profile_search_fields_finds_profile_by_username(client):
+    from wagtail_forum.models import ForumProfile
+
+    user = User.objects.create_user(username="findme_by_search")
+    ForumProfile.for_user(user)
+
+    admin = User.objects.create_superuser(username="root4", email="r4@x.io")
+    client.force_login(admin)
+
+    resp = client.get("/cms/snippets/wagtail_forum/forumprofile/?q=findme_by_search")
+
+    assert resp.status_code == 200
+    assert b"findme_by_search" in resp.content
+
+
+@pytest.mark.django_db
+def test_post_preview_renders_pending_revision_body():
+    # make_preview_request() is what Wagtail's own moderation UI calls to
+    # preview a pending revision (PreviewableMixin docstring: "Used for
+    # previewing / moderation") — this is the actual M16 code path, not just
+    # the edit page wiring (see test_post_edit_view_reachable_with_preview_
+    # enabled for that).
+    from wagtail.models import Page
+    from wagtail_forum.models import ForumBoard, ForumIndex, ForumProfile, Post, Topic
+    from wagtail_forum.workflow import ensure_default_workflow, submit_for_moderation
+
+    ensure_default_workflow()
+    author = User.objects.create_user(username="pending_author")
+    ForumProfile.for_user(author)  # trust NEW -- screened, not autopublished
+
+    root = Page.objects.get(id=1)
+    index = root.add_child(instance=ForumIndex(title="PForum", slug="pforum"))
+    board = index.add_child(instance=ForumBoard(title="PGeneral", slug="pgeneral"))
+    topic = Topic.objects.create(board=board, title="PT", slug="pt", author=author)
+    spam = "http://a.com http://b.com http://c.com http://d.com http://e.com"
+    post = Post(
+        topic=topic,
+        author=author,
+        is_opening_post=True,
+        body=[{"type": "paragraph", "value": f"<p>{spam}</p>"}],
+    )
+    post.save()
+    status = submit_for_moderation(post, author)
+    assert status == "pending"  # sanity: really rejected, not published
+
+    revision_obj = post.get_latest_revision_as_object()
+    response = revision_obj.make_preview_request()
+
+    assert response.status_code == 200
+    assert b"a.com" in response.content
+
+
+@pytest.mark.django_db
+def test_post_edit_view_reachable_with_preview_enabled(client):
+    # PreviewableMixin wiring (SnippetViewSet.preview_enabled auto-detection)
+    # doesn't break the ordinary snippet edit page (audit M16).
+    from django.urls import reverse
+    from wagtail.models import Page
+    from wagtail_forum.models import ForumBoard, ForumIndex, ForumProfile, Post, Topic
+
+    author = User.objects.create_user(username="edit_view_author")
+    ForumProfile.for_user(author)
+    root = Page.objects.get(id=1)
+    index = root.add_child(instance=ForumIndex(title="EForum", slug="eforum"))
+    board = index.add_child(instance=ForumBoard(title="EGeneral", slug="egeneral"))
+    topic = Topic.objects.create(board=board, title="ET", slug="et", author=author)
+    post = Post(
+        topic=topic,
+        author=author,
+        is_opening_post=True,
+        body=[{"type": "paragraph", "value": "<p>hello</p>"}],
+    )
+    post.save()
+    post.save_revision().publish()
+
+    admin = User.objects.create_superuser(username="root5", email="r5@x.io")
+    client.force_login(admin)
+
+    from wagtail_forum.models import Post as PostModel
+
+    url = reverse(PostModel.snippet_viewset.get_url_name("edit"), args=(post.pk,))
+    resp = client.get(url)
+
+    assert resp.status_code == 200
+
+
+@pytest.mark.django_db
+def test_bulk_unpublish_action_unpublishes_selected_posts(client):
+    # Spam-wave cleanup (audit M20): reuses the same UnpublishAction(...)
+    # .execute(skip_permission_checks=True) mechanism as the single-object
+    # DELETE view, attributed to the acting moderator.
+    from django.urls import reverse
+    from wagtail.models import Page
+    from wagtail_forum.models import ForumBoard, ForumIndex, ForumProfile, Post, Topic
+
+    author = User.objects.create_user(username="bulk_target_author")
+    ForumProfile.for_user(author)
+    root = Page.objects.get(id=1)
+    index = root.add_child(instance=ForumIndex(title="BForum", slug="bforum"))
+    board = index.add_child(instance=ForumBoard(title="BGeneral", slug="bgeneral"))
+    topic = Topic.objects.create(board=board, title="BT", slug="bt", author=author)
+
+    posts = []
+    for i in range(2):
+        p = Post(
+            topic=topic,
+            author=author,
+            is_opening_post=(i == 0),
+            body=[{"type": "paragraph", "value": f"<p>spam {i}</p>"}],
+        )
+        p.save()
+        p.save_revision().publish()
+        posts.append(p)
+
+    admin = User.objects.create_superuser(username="root6", email="r6@x.io")
+    client.force_login(admin)
+
+    url = reverse(
+        "wagtail_bulk_action",
+        args=("wagtail_forum", "post", "unpublish"),
+    )
+    query = "&".join(f"id={p.pk}" for p in posts)
+    resp = client.post(f"{url}?{query}", data={})
+
+    assert resp.status_code == 302
+    for p in posts:
+        p.refresh_from_db()
+        assert p.live is False

--- a/backend/packages/wagtail_forum/wagtail_forum/wagtail_hooks.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/wagtail_hooks.py
@@ -1,8 +1,14 @@
 from django.contrib.contenttypes.models import ContentType
+from django.utils.translation import gettext_lazy as _
+from django.utils.translation import ngettext
 from wagtail import hooks
+from wagtail.actions.unpublish import UnpublishAction
+from wagtail.admin.search import SearchArea
 from wagtail.admin.site_summary import SummaryItem
 from wagtail.models import WorkflowState
+from wagtail.snippets.bulk_actions.snippet_bulk_action import SnippetBulkAction
 from wagtail.snippets.models import register_snippet
+from wagtail.snippets.permissions import get_permission_name
 from wagtail.snippets.views.snippets import SnippetViewSet, SnippetViewSetGroup
 
 from .models import ForumProfile, Post, Report, Topic
@@ -29,6 +35,11 @@ class PostViewSet(SnippetViewSet):
     menu_label = "Posts"
     list_display = ["__str__", "topic", "author", "live"]
     list_filter = ["live"]
+    # Post is index.Indexed with one SearchField ("body"); this list is passed
+    # through to the search backend as the `fields` filter, not a separate ORM
+    # icontains mechanism (audit M20; wagtail/admin/views/generic/base.py
+    # search_queryset()).
+    search_fields = ["body"]
 
     def get_queryset(self, request):
         qs = super().get_queryset(request)
@@ -43,6 +54,9 @@ class ForumProfileViewSet(SnippetViewSet):
     menu_label = "Profiles"
     list_display = ["__str__", "trust_level", "post_count"]
     list_filter = ["trust_level"]
+    # ForumProfile is a plain model (not index.Indexed), so this list drives a
+    # direct ORM icontains filter, not the search backend (audit M20).
+    search_fields = ["user__username"]
 
     def get_queryset(self, request):
         # __str__ falls back to user.get_username() — N+1 without this.
@@ -124,3 +138,70 @@ def add_forum_moderation_summary_item(request, items):
         return  # graceful degradation if forum models aren't ready
     if count > 0:
         items.append(ForumModerationSummaryItem(request, count))
+
+
+@hooks.register("register_admin_search_area")
+def register_forum_search_area():
+    """Makes the forum visible in Wagtail's global admin search picker (audit
+    M20) — mirrors the blog's register_blog_search (apps/blog/wagtail_hooks.py).
+    SearchArea is a plain positional-args class (confirmed via
+    wagtail.admin.search.SearchArea) — not the Component-style trap
+    ForumModerationSummaryItem's docstring above warns about."""
+    return SearchArea(
+        "Forum",
+        "/cms/snippets/wagtail_forum/topic/",
+        name="forum",
+        icon_name="group",
+        order=300,
+    )
+
+
+class ForumUnpublishBulkAction(SnippetBulkAction):
+    """Bulk-unpublish selected Topics/Posts from the admin snippet list, for
+    spam-wave cleanup (audit M20). Reuses the same UnpublishAction(...).execute(
+    skip_permission_checks=True) call the single-object DELETE view and the
+    report auto-hide threshold use (api/views.py, models/reports.py) — one
+    unpublish mechanism, so the `unpublished` signal's counter/trust recount
+    fires identically regardless of which path triggered it.
+    """
+
+    models = [Post, Topic]
+    display_name = _("Unpublish")
+    action_type = "unpublish"
+    aria_label = _("Unpublish selected forum items")
+    template_name = "wagtail_forum/admin/bulk_actions/confirm_bulk_unpublish.html"
+    action_priority = 40
+    classes = {"serious"}
+
+    def check_perm(self, obj):
+        # Snippet permissions aren't per-object, so (like the built-in
+        # DeleteBulkAction) check once per model per request rather than once
+        # per selected row.
+        if getattr(self, "_can_change", None) is None:
+            self._can_change = self.request.user.has_perm(
+                get_permission_name("change", self.model)
+            )
+        return self._can_change
+
+    def get_execution_context(self):
+        # SnippetBulkAction.get_execution_context() supplies {"self": self}
+        # only — no user — so a copy-paste of the Page bulk-unpublish action
+        # would silently attribute every take-down to the system instead of
+        # the acting moderator (audit M20 follow-up).
+        return {**super().get_execution_context(), "user": self.request.user}
+
+    @classmethod
+    def execute_action(cls, objects, user=None, **kwargs):
+        for obj in objects:
+            UnpublishAction(obj, user=user).execute(skip_permission_checks=True)
+        return len(objects), 0
+
+    def get_success_message(self, num_parent_objects, num_child_objects):
+        return ngettext(
+            "%(count)d item has been unpublished",
+            "%(count)d items have been unpublished",
+            num_parent_objects,
+        ) % {"count": num_parent_objects}
+
+
+hooks.register("register_bulk_action", ForumUnpublishBulkAction)

--- a/todos/254-in_progress-p1-forum-moderation-safety-admin.md
+++ b/todos/254-in_progress-p1-forum-moderation-safety-admin.md
@@ -58,6 +58,13 @@ Path shorthand: `W` = `backend/packages/wagtail_forum/wagtail_forum`, `H` = `bac
   required shape is a custom board-scoped permission check (group↔board mapping
   consulted via `post.topic.board_id`) (`W/models/posts.py:107-143`,
   `H/bootstrap.py:20-46`).
+  **Decision (2026-07-12, Slice 4):** stays global-only, deliberately — one
+  seed board exists, no product signal calls for delegated per-board
+  moderators, and the retrofit is high-blast-radius (a new mapping model
+  consulted from every permission-check site: `edit_block`/`delete_block`,
+  `_edit_is_trusted`, the bulk-unpublish action, the SnippetViewSet gate) for
+  zero current benefit (YAGNI). Rationale + revisit trigger recorded in
+  `backend/docs/patterns/domain/forum.md`.
 - **M20** — Admin polish cluster: no `register_admin_search_area` (forum
   invisible in global admin search; blog registers one), `search_fields`
   missing on Post/Profile viewsets, no bulk actions for spam-wave cleanup
@@ -113,9 +120,15 @@ Path shorthand: `W` = `backend/packages/wagtail_forum/wagtail_forum`, `H` = `bac
       automated/synchronous with no persistent state for a human to act on;
       building `get_task_states_user_can_moderate` for it would be dead code.
 - [x] Wagtail homepage shows an awaiting-moderation count for forum content
-- [ ] A moderator can preview a pending revision's rendered body
-- [ ] Board-scoped moderation is possible, or global-only is explicitly
-      documented with rationale (M19 decision recorded)
+- [x] A moderator can preview a pending revision's rendered body — Post gained
+      `PreviewableMixin` + a preview template; verified via
+      `make_preview_request()` (the same call Wagtail's own moderation UI
+      uses) rendering a real NEEDS_CHANGES post's body (Slice 4).
+- [x] Board-scoped moderation is possible, or global-only is explicitly
+      documented with rationale (M19 decision recorded) — decided global-only;
+      see the M19 finding correction below and
+      `backend/docs/patterns/domain/forum.md`'s "Moderation permission scope
+      is global, deliberately" section (Slice 4).
 - [ ] L21 image-reuse stance recorded (docs or code change)
 
 ## Work Log
@@ -184,6 +197,77 @@ Path shorthand: `W` = `backend/packages/wagtail_forum/wagtail_forum`, `H` = `bac
   assertion and docstring so it's a documented scope limit, not a silent gap.
 - Remaining slices (M16 preview, M19 board-scoped mod, M20 admin polish,
   L21 image-reuse stance) not started.
+
+### 2026-07-12 - Slice 4 (M16 preview, M19 decision, M20 admin polish) shipped
+
+- **M16**: `Post` gained `PreviewableMixin` (Topic deliberately excluded — it
+  has no body, so a preview surface would be near-empty; the AC only asks for
+  "a pending revision's rendered body", which only Post has) + a minimal
+  preview template rendering the StreamField body via `{% include_block %}`.
+  `PreviewableMixin` is fieldless (`makemigrations --check` confirmed no
+  migration). Verified two ways: `make_preview_request()` on a real
+  spam-rejected post's latest revision (the exact call Wagtail's own
+  moderation UI makes — its own docstring says "Used for previewing /
+  moderation") renders the body; the ordinary snippet edit view still 200s
+  with the mixin wired in. Deliberately did NOT try to drive
+  `PreviewOnEditView`'s GET/POST HTTP flow directly — a bare GET with no
+  prior form POST hits Wagtail's own "stale preview" error response (its
+  `FormState` mechanism, unrelated to this fix), so it would have tested
+  Wagtail's framework code, not the template/mixin wiring this slice added.
+  Branch `feat/forum-moderation-slice4-preview-admin`, cut fresh off
+  `origin/main` (learned from Slice 2's branch-staleness bug — verified with
+  `git log origin/main` before cutting, not repeated here).
+- **M19**: decided global-only, documented (see finding correction above and
+  `backend/docs/patterns/domain/forum.md`) rather than building a board-scoped
+  permission retrofit with no current product signal.
+- **M20**: `register_admin_search_area` hook ("Forum" → the Topic listing,
+  same `SearchArea` positional-args class the blog already uses safely — NOT
+  the `SummaryItem` Component trap from Slice 2); `search_fields` added to
+  `PostViewSet` (`["body"]`) and `ForumProfileViewSet` (`["user__username"]`);
+  a `ForumUnpublishBulkAction` (spam-wave cleanup) reusing the same
+  `UnpublishAction(...).execute(skip_permission_checks=True)` mechanism as the
+  single-object DELETE view and the report auto-hide threshold, so the
+  `unpublished` signal's counter/trust recount fires identically regardless of
+  which path triggered it.
+  - Research-before-coding surfaced two non-obvious API facts (read directly
+    from the installed Wagtail 7.4.2 source, not assumed): (1) a SnippetViewSet's
+    own `search_fields` list is passed to the search BACKEND as a `fields`
+    filter when the model is `index.Indexed` (Post's case) — it is only a
+    plain ORM `icontains` filter for a non-indexed model (ForumProfile's
+    case). Both viewsets' `search_fields` were tested against a real row, not
+    just asserted as present (the SummaryItem lesson generalized). (2) the
+    base `SnippetBulkAction.get_execution_context()` supplies `{"self": self}`
+    only, no `user` — copying the Wagtail core Page bulk-unpublish action's
+    shape verbatim would have silently attributed every take-down to the
+    system instead of the acting moderator; caught before writing the code
+    (advisor flagged it), not after.
+- 209 backend forum-package tests (was 203) + 46 forum_host tests passing.
+  `manage.py check` and `makemigrations --check --dry-run` both clean.
+- kimi-review (1 pass) flagged `check_perm`'s single `_can_change` cache
+  attribute as unsafe across `ForumUnpublishBulkAction`'s two `models`
+  (Post/Topic) — verified against `BulkAction.__init__`/the dispatcher
+  (`admin/views/bulk_action/dispatcher.py`) and found FALSE: one dispatched
+  instance is always bound to exactly one model (the URL encodes a single
+  `model_name`), so `self.model` never changes mid-instance — the same
+  single-cache-var shape the core `DeleteBulkAction.check_perm` already uses.
+  No fix applied (kimi's own pipeline had already tagged the finding
+  "unverified against code"). The finding's test-coverage half had a real
+  kernel though: nothing proved `check_perm` actually blocks a non-privileged
+  user — added `test_bulk_unpublish_action_blocks_user_without_change_permission`
+  (a staff user with `access_admin` but not `change_post` cannot unpublish).
+  210 tests passing after this follow-up.
+- Writing that permission test (a GET to the confirmation page, not just a
+  POST) caught a REAL bug the golden-path POST-only test had never exercised:
+  `confirm_bulk_unpublish.html` only `{% load i18n %}`, but its `titletag`
+  block uses `intcomma` — which lives in `wagtailadmin_tags`
+  (`wagtail.admin.templatetags.wagtailadmin_tags`), not `humanize` or
+  `wagtailusers_tags`. Every GET to the confirmation page 500'd, for ANY
+  user, privileged or not — the exact real-world flow a moderator uses
+  (click "Unpublish" -> see confirm page -> click "Yes"). Fixed the
+  `{% load %}` line; also added a GET-then-POST check to the golden-path
+  test so the confirmation-page render is covered there too, not just in the
+  permission-denial test that happened to catch it. 256 forum+forum_host
+  tests passing after this fix.
 
 ## Notes
 


### PR DESCRIPTION
## Summary

Slice 4 of the forum-moderation epic (todo 254) — the third shipped slice, covering M16 and M20 from the 2026-07-11 forum-modernization audit. M19 was resolved as a documented decision rather than a code change (see below).

- **M16 (preview)**: `Post` gained Wagtail's `PreviewableMixin` + a minimal preview template rendering the StreamField body, so a moderator can preview a pending/`NEEDS_CHANGES` post's rendered content from the snippet edit view — the actual reachable moderation path (Slice 2 already proved the workflow "Awaiting my review" dashboard never surfaces `SpamCheckTask` items). Topic was deliberately excluded — no body field, so a preview surface would be near-empty; the AC only requires "a pending revision's rendered body."
- **M19 (board-scoped moderation)**: decided **global-only, documented**, not implemented. `Topic`/`Post` are snippets with no `GroupSnippetPermission` analog; a board-scoped retrofit means a new group↔board mapping consulted from every permission-check site in the package — high blast radius for zero current product signal (one seed board, no request for delegated moderators). Rationale + revisit trigger recorded in `backend/docs/patterns/domain/forum.md`.
- **M20 (admin polish)**: `register_admin_search_area` hook (forum now appears in Wagtail's global admin search); `search_fields` on `PostViewSet`/`ForumProfileViewSet`; a `ForumUnpublishBulkAction` for spam-wave cleanup, reusing the exact `UnpublishAction(...).execute(skip_permission_checks=True)` mechanism the single-object DELETE view and report auto-hide threshold already use.

## Notable fixes found while testing this slice

- A real bug: `confirm_bulk_unpublish.html` was missing `{% load wagtailadmin_tags %}` (only had `i18n`), so its `titletag` block's `intcomma` filter 500'd the confirmation page for **any** user — privileged or not. Caught by writing a permission-denial test that used GET instead of POST-only; fixed, and the golden-path test now covers the GET confirmation step too (a POST-only test had never rendered this template at all).
- A kimi-review finding (cached `_can_change` unsafe across the action's two `models`) was verified **false** against the actual dispatcher — one bulk-action instance is always bound to a single model (the URL encodes one `model_name`), mirroring the core `DeleteBulkAction`'s own single-cache-var pattern. No fix applied; the test-coverage half of the finding had a real kernel though (nothing proved `check_perm` actually blocks anyone), so that test was added instead.

## Test plan

- [x] `manage.py check` clean
- [x] `makemigrations --check --dry-run` clean (`PreviewableMixin` is fieldless)
- [x] 256 backend tests passing (`packages/wagtail_forum/` + `apps/forum_host/`), up from 249 pre-slice
- [x] kimi-review clean on all 4 commits (CRITICAL/WARNING tiers)
- [x] PR diff reviewed in full before requesting merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)