### PR TITLE
forum: scope image blocks to allowed uploader (todo 254 slice 5, audit L21)

### DIFF
--- a/backend/docs/patterns/domain/forum.md
+++ b/backend/docs/patterns/domain/forum.md
@@ -71,3 +71,40 @@ This is a **deliberate decision, not an oversight**:
 - **Revisit trigger**: when a second board ships AND it needs a moderator distinct
   from the global group, design the group↔board mapping then, against a real
   requirement instead of a speculative one.
+
+## Image blocks are scoped to an allowed-uploader set, not just collection membership (audit L21)
+
+The forum image collection (`collections.get_forum_image_collection()`) is a
+single shared collection across every member — collection-membership alone
+(audit L5's IDOR-by-reference fix) stops a body from referencing an image
+outside the forum entirely, but does **not** stop one member from embedding
+another member's upload, since Wagtail's own `Image.uploaded_by_user` was
+recorded at upload time but never checked.
+
+`api/sanitize.py::validate_forum_body(value, allowed_uploader_ids)` now takes
+a required second argument: the set of user ids (a `None` member is legal —
+see below) whose uploads may be referenced. The three write serializers
+(`_ForumBodyContract` in `api/serializers.py`) compute this per request:
+
+- **Create** (`TopicCreateSerializer`/`ReplyCreateSerializer`): just the
+  acting `request.user` — no post exists yet.
+- **Edit** (`PostEditSerializer`): `request.user` **plus** the post's
+  pre-existing `author_id` (passed via `context={"existing_author_id": ...}`
+  at the view call site). PATCH resends the *entire* body — a moderator
+  editing someone else's post while keeping the author's existing image
+  blocks must not have them rejected just because the editor changed.
+
+**`None` is a legal member of `allowed_uploader_ids`**, and it is handled with
+an explicit `Q(uploaded_by_user_id__isnull=True)` branch, *not*
+`uploaded_by_user_id__in={..., None}` — SQL's `IN (NULL)` is never true, even
+for a row whose value actually is `NULL` (caught by a test before this ever
+reached review). `None` matters because Wagtail's `Image.uploaded_by_user` and
+`Post.author` both go `SET_NULL` together on account deletion — a deleted
+author's pre-existing images grandfather in automatically without any special
+casing, since `existing_author_id` is already `None` in that case.
+
+The moderator-edit carve-out is intentionally narrow: it grandfathers the
+POST's existing author, not "any image a privileged user chooses" — a
+moderator cannot smuggle in a *different*, unrelated member's image while
+editing someone else's post (pinned by
+`test_moderator_edit_cannot_smuggle_in_a_different_members_image`).

--- a/backend/packages/wagtail_forum/wagtail_forum/api/sanitize.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/api/sanitize.py
@@ -14,6 +14,7 @@ cost and storage in check.
 import json
 
 import nh3
+from django.db.models import Q
 from rest_framework import serializers
 from wagtail.blocks import ChooserBlock, RichTextBlock, StructBlock
 from wagtail.images import get_image_model
@@ -45,13 +46,23 @@ def sanitize_rich_text(html):
     )
 
 
-def validate_forum_body(value):
+def validate_forum_body(value, allowed_uploader_ids):
     """Validate + sanitize a forum post body (raw StreamField list-of-dicts).
 
     1. Reject an oversized body (block count / total size) — bounds parse cost.
     2. Reject a structurally malformed body (``to_python`` dry-run) — 400, not 500.
     3. Sanitize each rich-text ("paragraph") block's HTML, stripping scripts,
        event-handler attributes, and disallowed tags/schemes.
+
+    ``allowed_uploader_ids`` bounds which images an ``image`` block may
+    reference: an image must live in the forum collection (audit L5 IDOR-by-
+    reference) AND have been uploaded by one of these user ids (audit L21 —
+    collection membership alone lets any member embed any other member's
+    upload by guessing/observing its PK). Pass a set; ``None`` is a valid
+    member for an account-deleted author's grandfathered images — Wagtail's
+    ``Image.uploaded_by_user`` and ``Post.author`` both go ``SET_NULL`` on
+    account deletion in the same operation, so a deleted author's pre-existing
+    uploads carry ``uploaded_by_user_id=None`` right alongside the post.
 
     Returns the cleaned value so the caller stores the safe version.
     """
@@ -117,17 +128,30 @@ def validate_forum_body(value):
             )
 
     # Image blocks ARE allowed, but only when every referenced PK is an image in
-    # the forum collection — the to_python dry-run never resolves chooser PKs, so
-    # an unchecked id is an IDOR-by-reference (audit L5). One bulk query.
+    # the forum collection AND uploaded by an allowed user — the to_python
+    # dry-run never resolves chooser PKs, so an unchecked id is an IDOR-by-
+    # reference (audit L5); collection membership alone is not enough to stop
+    # cross-member reuse (audit L21). One bulk query.
     image_ids = [
         block["value"]
         for block in value
         if isinstance(block, dict) and block.get("type") in image_types
     ]
     if image_ids:
+        # `uploaded_by_user_id__in={..., None}` would silently match nothing for
+        # the None member — SQL's `IN (NULL)` is never true, even for a NULL
+        # column value. isnull=True is the only correct way to include it.
+        uploader_ids = {uid for uid in allowed_uploader_ids if uid is not None}
+        uploader_match = Q(uploaded_by_user_id__in=uploader_ids)
+        if None in allowed_uploader_ids:
+            uploader_match |= Q(uploaded_by_user_id__isnull=True)
         valid_ids = set(
             get_image_model()
-            .objects.filter(id__in=image_ids, collection=get_forum_image_collection())
+            .objects.filter(
+                uploader_match,
+                id__in=image_ids,
+                collection=get_forum_image_collection(),
+            )
             .values_list("id", flat=True)
         )
         if any(image_id not in valid_ids for image_id in image_ids):

--- a/backend/packages/wagtail_forum/wagtail_forum/api/serializers.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/api/serializers.py
@@ -325,7 +325,20 @@ class _ForumBodyContract(serializers.Serializer):
     body = serializers.JSONField()
 
     def validate_body(self, value):
-        return validate_forum_body(value)
+        return validate_forum_body(value, self._allowed_uploader_ids())
+
+    def _allowed_uploader_ids(self):
+        # An image block may reference: (a) something the acting request user
+        # uploaded, and (b) on edit, whatever the post's PRE-EXISTING author
+        # already uploaded — PATCH resends the whole body, so a moderator
+        # editing someone else's post must not have the original author's
+        # existing image blocks rejected out from under them (audit L21).
+        # `existing_author_id` is only set by the edit call site.
+        request = self.context.get("request")
+        ids = {request.user.pk} if request else set()
+        if "existing_author_id" in self.context:
+            ids.add(self.context["existing_author_id"])
+        return ids
 
 
 class TopicCreateSerializer(_ForumBodyContract):

--- a/backend/packages/wagtail_forum/wagtail_forum/api/views.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/api/views.py
@@ -197,7 +197,9 @@ class TopicListView(generics.ListAPIView):
         if replayed is not None:
             return replayed
 
-        serializer = TopicCreateSerializer(data=request.data)
+        serializer = TopicCreateSerializer(
+            data=request.data, context={"request": request}
+        )
         serializer.is_valid(raise_exception=True)
         board = _get_board(slug)
 
@@ -387,7 +389,9 @@ class PostListView(generics.ListAPIView):
         )
         if topic.is_closed or topic.locked:
             raise Conflict("Topic is closed to replies.")
-        serializer = ReplyCreateSerializer(data=request.data)
+        serializer = ReplyCreateSerializer(
+            data=request.data, context={"request": request}
+        )
         serializer.is_valid(raise_exception=True)
 
         reserve(cache_key)  # 409 if a same-key twin is mid-flight (atomic add)
@@ -462,7 +466,10 @@ class PostWriteView(APIView):
     def patch(self, request, post_id):
         post = self._get_editable(request, post_id)
         self._enforce_writable(post.edit_block(request.user))
-        serializer = PostEditSerializer(data=request.data)
+        serializer = PostEditSerializer(
+            data=request.data,
+            context={"request": request, "existing_author_id": post.author_id},
+        )
         serializer.is_valid(raise_exception=True)
         post.body = ForumBodyBlock().to_python(serializer.validated_data["body"])
         # submit_edit_for_moderation owns the persistence contract: a pre-revision

--- a/backend/packages/wagtail_forum/wagtail_forum/tests/api/test_post_edit_delete.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/tests/api/test_post_edit_delete.py
@@ -261,6 +261,71 @@ def test_moderator_edit_author_deleted_post_persists():
     assert fresh.live and "[redacted]" in fresh.body[0].value.source
 
 
+def test_moderator_edit_keeps_original_authors_existing_image():
+    """audit L21: an image block must be uploaded by an allowed user, but a
+    moderator resending the AUTHOR's pre-existing image (PATCH replaces the
+    whole body) must not have it rejected just because the editor changed —
+    allowed_uploader_ids includes the post's existing author, not just the
+    acting request user."""
+    from wagtail.images import get_image_model
+    from wagtail.images.tests.utils import get_test_image_file
+    from wagtail_forum.collections import get_forum_image_collection
+
+    board = _board()
+    author = _member("ada")
+    image = get_image_model().objects.create(
+        title="seedling",
+        file=get_test_image_file(),
+        collection=get_forum_image_collection(),
+        uploaded_by_user=author,
+    )
+    _topic, _opening, reply = _topic_with_reply(board, author)
+    mod = _moderator("mod")
+    client = APIClient()
+    client.force_authenticate(mod)
+    resp = client.patch(
+        f"/forum/posts/{reply.id}/",
+        {
+            "body": [
+                {"type": "paragraph", "value": "<p>mod note</p>"},
+                {"type": "image", "value": image.id},
+            ]
+        },
+        format="json",
+    )
+    assert resp.status_code == 200
+    assert resp.data["moderation_status"] == "published"
+
+
+def test_moderator_edit_cannot_smuggle_in_a_different_members_image():
+    """audit L21: the moderator-edit carve-out grandfathers the POST's existing
+    author, not an arbitrary third member's upload — a moderator adding a
+    stranger's image while editing someone else's post is still rejected."""
+    from wagtail.images import get_image_model
+    from wagtail.images.tests.utils import get_test_image_file
+    from wagtail_forum.collections import get_forum_image_collection
+
+    board = _board()
+    author = _member("ada")
+    stranger = _member("carol")
+    image = get_image_model().objects.create(
+        title="private",
+        file=get_test_image_file(),
+        collection=get_forum_image_collection(),
+        uploaded_by_user=stranger,
+    )
+    _topic, _opening, reply = _topic_with_reply(board, author)
+    mod = _moderator("mod")
+    client = APIClient()
+    client.force_authenticate(mod)
+    resp = client.patch(
+        f"/forum/posts/{reply.id}/",
+        {"body": [{"type": "image", "value": image.id}]},
+        format="json",
+    )
+    assert resp.status_code == 400
+
+
 def test_edit_save_revision_failure_is_not_fake_pending(monkeypatch):
     """A failure BEFORE the revision is saved must surface as an error, not a
     fake 200 'pending' (finding #3) — nothing was persisted, so the old body

--- a/backend/packages/wagtail_forum/wagtail_forum/tests/api/test_post_image_upload.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/tests/api/test_post_image_upload.py
@@ -188,3 +188,41 @@ def test_image_round_trips_through_create_and_read():
     assert blocks["image"]["id"] == image_id
     assert blocks["image"]["url"].startswith("http://testserver")
     assert blocks["image"]["width"] > 0 and blocks["image"]["height"] > 0
+
+
+@pytest.mark.django_db
+def test_image_uploaded_by_another_member_cannot_be_referenced():
+    """audit L21: the forum image collection is shared, so collection
+    membership alone (audit L5) does not stop one member from embedding
+    another member's upload by PK. A different member's post referencing it
+    must be rejected."""
+    from wagtail.models import Page
+    from wagtail_forum.models import ForumBoard, ForumIndex, ForumProfile, Topic
+    from wagtail_forum.workflow import ensure_default_workflow
+
+    ensure_default_workflow()
+    root = Page.objects.get(id=1)
+    index = root.add_child(instance=ForumIndex(title="Forum", slug="forum"))
+    board = index.add_child(instance=ForumBoard(title="General", slug="general"))
+    uploader = User.objects.create_user(username="uploader")
+    ForumProfile.for_user(uploader)
+    intruder = User.objects.create_user(username="intruder")
+    ForumProfile.for_user(intruder)
+    topic = Topic.objects.create(
+        board=board, title="T", slug="t", author=uploader, live=True
+    )
+
+    uploader_client = APIClient()
+    uploader_client.force_authenticate(uploader)
+    upload = uploader_client.post(URL, {"image": _upload()}, format="multipart")
+    assert upload.status_code == 201
+    image_id = upload.data["id"]
+
+    intruder_client = APIClient()
+    intruder_client.force_authenticate(intruder)
+    reply = intruder_client.post(
+        f"/forum/topics/{topic.id}/posts/",
+        {"body": [{"type": "image", "value": image_id}]},
+        format="json",
+    )
+    assert reply.status_code == 400

--- a/backend/packages/wagtail_forum/wagtail_forum/tests/test_blocks.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/tests/test_blocks.py
@@ -21,7 +21,9 @@ def test_body_block_rejects_unknown_block_type():
     from wagtail_forum.api.sanitize import validate_forum_body
 
     with pytest.raises(ValidationError):
-        validate_forum_body([{"type": "raw_html", "value": "<script>x</script>"}])
+        validate_forum_body(
+            [{"type": "raw_html", "value": "<script>x</script>"}], set()
+        )
 
 
 @pytest.mark.django_db
@@ -32,13 +34,61 @@ def test_image_block_with_nonexistent_id_is_rejected():
     from wagtail_forum.api.sanitize import validate_forum_body
 
     with pytest.raises(ValidationError):
-        validate_forum_body([{"type": "image", "value": 12345}])
+        validate_forum_body([{"type": "image", "value": 12345}], {1})
 
 
 @pytest.mark.django_db
-def test_image_block_in_forum_collection_is_accepted():
+def test_image_block_in_forum_collection_uploaded_by_allowed_user_is_accepted():
     # PR-3 relaxes the blanket chooser rejection: an image that lives in the
-    # forum collection round-trips through body validation unchanged.
+    # forum collection AND was uploaded by an allowed user (audit L21) round-
+    # trips through body validation unchanged.
+    from django.contrib.auth import get_user_model
+    from wagtail.images import get_image_model
+    from wagtail.images.tests.utils import get_test_image_file
+    from wagtail_forum.api.sanitize import validate_forum_body
+    from wagtail_forum.collections import get_forum_image_collection
+
+    uploader = get_user_model().objects.create_user(username="uploader")
+    image = get_image_model().objects.create(
+        title="seedling",
+        file=get_test_image_file(),
+        collection=get_forum_image_collection(),
+        uploaded_by_user=uploader,
+    )
+    cleaned = validate_forum_body([{"type": "image", "value": image.id}], {uploader.pk})
+    assert cleaned == [{"type": "image", "value": image.id}]
+
+
+@pytest.mark.django_db
+def test_image_block_uploaded_by_a_different_member_is_rejected():
+    # audit L21: collection membership alone is not enough — an image another
+    # member uploaded (not in allowed_uploader_ids) must not be referenceable
+    # even though it lives in the shared forum collection.
+    from django.contrib.auth import get_user_model
+    from rest_framework.serializers import ValidationError
+    from wagtail.images import get_image_model
+    from wagtail.images.tests.utils import get_test_image_file
+    from wagtail_forum.api.sanitize import validate_forum_body
+    from wagtail_forum.collections import get_forum_image_collection
+
+    uploader = get_user_model().objects.create_user(username="uploader")
+    other = get_user_model().objects.create_user(username="other")
+    image = get_image_model().objects.create(
+        title="seedling",
+        file=get_test_image_file(),
+        collection=get_forum_image_collection(),
+        uploaded_by_user=uploader,
+    )
+    with pytest.raises(ValidationError):
+        validate_forum_body([{"type": "image", "value": image.id}], {other.pk})
+
+
+@pytest.mark.django_db
+def test_image_block_with_null_uploader_matches_none_in_allowed_ids():
+    # Grandfathers an account-deleted author's pre-existing images: Wagtail's
+    # Image.uploaded_by_user and Post.author both go SET_NULL together on
+    # account deletion, so None is a legitimate member of allowed_uploader_ids
+    # (wired by the edit call site's existing_author_id).
     from wagtail.images import get_image_model
     from wagtail.images.tests.utils import get_test_image_file
     from wagtail_forum.api.sanitize import validate_forum_body
@@ -48,27 +98,34 @@ def test_image_block_in_forum_collection_is_accepted():
         title="seedling",
         file=get_test_image_file(),
         collection=get_forum_image_collection(),
+        uploaded_by_user=None,
     )
-    cleaned = validate_forum_body([{"type": "image", "value": image.id}])
+    cleaned = validate_forum_body([{"type": "image", "value": image.id}], {None})
     assert cleaned == [{"type": "image", "value": image.id}]
 
 
 @pytest.mark.django_db
 def test_image_block_outside_forum_collection_is_rejected():
     # Guessing a restricted asset's id is the exact IDOR the membership check
-    # closes: an image in any other collection must not be referenceable.
+    # closes: an image in any other collection must not be referenceable, even
+    # when its uploader is in allowed_uploader_ids.
+    from django.contrib.auth import get_user_model
     from rest_framework.serializers import ValidationError
     from wagtail.images import get_image_model
     from wagtail.images.tests.utils import get_test_image_file
     from wagtail.models import Collection
     from wagtail_forum.api.sanitize import validate_forum_body
 
+    uploader = get_user_model().objects.create_user(username="uploader")
     other = Collection.get_first_root_node().add_child(name="Private")
     image = get_image_model().objects.create(
-        title="secret", file=get_test_image_file(), collection=other
+        title="secret",
+        file=get_test_image_file(),
+        collection=other,
+        uploaded_by_user=uploader,
     )
     with pytest.raises(ValidationError):
-        validate_forum_body([{"type": "image", "value": image.id}])
+        validate_forum_body([{"type": "image", "value": image.id}], {uploader.pk})
 
 
 def test_oversized_body_chars_rejected():
@@ -78,7 +135,7 @@ def test_oversized_body_chars_rejected():
 
     huge = [{"type": "paragraph", "value": "<p>" + "x" * MAX_BODY_CHARS + "</p>"}]
     with pytest.raises(ValidationError):
-        validate_forum_body(huge)
+        validate_forum_body(huge, set())
 
 
 def test_non_string_block_values_are_rejected_not_500():
@@ -101,4 +158,4 @@ def test_non_string_block_values_are_rejected_not_500():
         [{"type": "image", "value": True}],
     ):
         with pytest.raises(ValidationError):
-            validate_forum_body(bad)
+            validate_forum_body(bad, set())

--- a/todos/254-in_progress-p1-forum-moderation-safety-admin.md
+++ b/todos/254-in_progress-p1-forum-moderation-safety-admin.md
@@ -69,10 +69,17 @@ Path shorthand: `W` = `backend/packages/wagtail_forum/wagtail_forum`, `H` = `bac
   invisible in global admin search; blog registers one), `search_fields`
   missing on Post/Profile viewsets, no bulk actions for spam-wave cleanup
   (`W/wagtail_hooks.py:12,21-45`).
-- **L21** — Product/privacy note: cross-user image reuse is by-design
-  (collection-scoped, sequential integer PKs — any member can embed another
-  member's uploaded image); deliberate per docstring — needs a roadmap-owner
-  decision, not a code fix (`W/api/sanitize.py:122-137`).
+- **L21** — Product/privacy note: cross-user image reuse was possible
+  (collection-scoped, sequential integer PKs — any member could embed another
+  member's uploaded image); a side effect of the L5 collection-membership
+  check, not an independently deliberate feature — needed a roadmap-owner
+  decision, not a unilateral code fix (`W/api/sanitize.py:122-137`).
+  **Decision (2026-07-12, Slice 5):** scope to uploader — closed in code, not
+  just documented. `validate_forum_body` now takes a required
+  `allowed_uploader_ids` set (request user, plus the post's existing author on
+  edit so a moderator resending the body doesn't lose the author's images).
+  See `backend/docs/patterns/domain/forum.md`'s "Image blocks are scoped to an
+  allowed-uploader set" section.
 
 ## Recommended Action
 
@@ -90,7 +97,8 @@ Path shorthand: `W` = `backend/packages/wagtail_forum/wagtail_forum`, `H` = `bac
 4. **M16 preview** (PreviewableMixin + preview template), **M19 board-scoped
    checks**, **M20 polish** (search area, search_fields, bulk actions).
 5. **L21**: record the image-reuse stance (accept + document, or scope
-   collections per-user) — decision, then docs.
+   collections per-user) — decision, then docs. Decided: scope to uploader
+   (Slice 5) — see finding correction above.
 
 ## Technical Details
 
@@ -129,7 +137,9 @@ Path shorthand: `W` = `backend/packages/wagtail_forum/wagtail_forum`, `H` = `bac
       see the M19 finding correction below and
       `backend/docs/patterns/domain/forum.md`'s "Moderation permission scope
       is global, deliberately" section (Slice 4).
-- [ ] L21 image-reuse stance recorded (docs or code change)
+- [x] L21 image-reuse stance recorded (docs or code change) — scoped to
+      uploader in code (`validate_forum_body`'s `allowed_uploader_ids`), not
+      just documented; see `backend/docs/patterns/domain/forum.md` (Slice 5).
 
 ## Work Log
 
@@ -268,6 +278,56 @@ Path shorthand: `W` = `backend/packages/wagtail_forum/wagtail_forum`, `H` = `bac
   test so the confirmation-page render is covered there too, not just in the
   permission-denial test that happened to catch it. 256 forum+forum_host
   tests passing after this fix.
+
+### 2026-07-12 - Slice 5 (L21 image-reuse stance) shipped
+
+- **Decision**: asked the user to choose between "accept + document" and
+  "scope to uploader" (the todo's own two options), with the corrected cost
+  (cheap — `Image.uploaded_by_user` is already recorded at upload time,
+  `W/api/views.py:585` — no migration, no collection restructure) and the
+  concrete harm (a member's photo reusable by a stranger in a hostile/
+  unrelated post; a takedown of one shared image silently breaks rendering
+  in every other post referencing it). User chose **scope to uploader**.
+- **Implementation**: `validate_forum_body(value, allowed_uploader_ids)` gained
+  a required second parameter — an image block's referenced PK must now be in
+  the forum collection (L5, unchanged) AND uploaded by an allowed user id
+  (L21, new). `_ForumBodyContract._allowed_uploader_ids()` (api/serializers.py)
+  computes the set per request: `{request.user.pk}` on create, plus the post's
+  pre-existing `author_id` on edit (threaded via
+  `context={"existing_author_id": post.author_id}` at the `PostWriteView.patch`
+  call site) — a moderator resending an author's whole body (PATCH replaces it
+  entirely) must not lose the author's existing images just because the editor
+  changed. `None` is a legal set member: Wagtail's `Image.uploaded_by_user` and
+  `Post.author` both go `SET_NULL` together on account deletion, so a deleted
+  author's images grandfather in for free.
+- **Real bug caught by a test, not review**: the first cut used
+  `uploaded_by_user_id__in=allowed_uploader_ids` directly. A dedicated test for
+  the `None`-grandfather case (`test_image_block_with_null_uploader_matches_
+  none_in_allowed_ids`) failed — SQL's `IN (NULL)` is never true, even for a
+  row whose value actually is `NULL`. Fixed with an explicit
+  `Q(uploaded_by_user_id__isnull=True)` branch OR'd in only when `None` is in
+  the set. Without that test this would have shipped silently broken: any
+  moderator edit of a deleted-account author's post that had an existing image
+  would have had the image rejected on every subsequent edit.
+  - Also hit the project's known edit-time import-strip gotcha twice
+    (`project_dart_edittime_import_strip` memory) — adding the `django.db.models.Q`
+    import in a separate edit before its first usage let the formatter strip it
+    as unused; fixed by re-adding it in the same edit as the usage.
+- **Tests**: `test_blocks.py` — 4 new/rewritten unit tests on
+  `validate_forum_body` directly (accepted-by-allowed-uploader, rejected-by-
+  different-uploader, `None`-grandfather accepted, collection-rejection now
+  uploader-agnostic). `tests/api/test_post_image_upload.py` — one new
+  end-to-end test proving a second member's API POST referencing the first
+  member's uploaded image id 400s. `tests/api/test_post_edit_delete.py` — two
+  new tests: a moderator's edit keeps the author's pre-existing image (no
+  regression from the fix), and a moderator cannot smuggle in a *third*,
+  unrelated member's image while editing someone else's post (the carve-out
+  is narrow — grandfathered author only, not "any privileged edit").
+  261 forum+forum_host tests passing (was 256). `manage.py check` and
+  `makemigrations --check --dry-run` both clean (no model field changed —
+  `Image.uploaded_by_user` already existed).
+- Todo 254 acceptance criteria are now all met (C1/H16/M16/M19/M20/L21) —
+  epic complete pending final review + archival.
 
 ## Notes
 


### PR DESCRIPTION
## Summary

Closes todo 254's final finding (L21). The forum's inline image collection is shared across all members; body validation only checked that a referenced image PK lived in that collection (audit L5's IDOR fix), never who uploaded it — so any member could embed any other member's uploaded photo by PK.

Presented the todo's own two options to the user (accept + document vs. scope to uploader), with the corrected cost (cheap — `Image.uploaded_by_user` was already recorded at upload time, no migration needed) and the concrete harm (cross-context photo reuse; a moderation takedown of one shared image silently breaking every other post referencing it). **User chose scope to uploader.**

- `validate_forum_body(value, allowed_uploader_ids)` — new required parameter. An image block must be in the forum collection (L5, unchanged) **and** uploaded by an allowed user id (L21, new).
- `_ForumBodyContract._allowed_uploader_ids()` computes the set per request: `{request.user.pk}` on create; plus the post's pre-existing `author_id` on edit (a moderator resending the whole body via PATCH must not lose the original author's existing images just because the editor changed).
- `None` is a legal set member — Wagtail's `Image.uploaded_by_user` and `Post.author` both go `SET_NULL` together on account deletion, so a deleted author's images grandfather in automatically.
- Pattern doc updated: `backend/docs/patterns/domain/forum.md`.

## Bug caught by a test before it shipped

The first cut used `uploaded_by_user_id__in=allowed_uploader_ids` directly. A dedicated test for the `None`-grandfather case failed: SQL's `IN (NULL)` is never true, even for a row whose value actually is `NULL`. Fixed with an explicit `Q(uploaded_by_user_id__isnull=True)` branch, OR'd in only when `None` is in the set. Without that test, this would have shipped silently broken — any moderator editing a deleted-account author's post that had an existing image would have had it rejected on every subsequent edit.

## Test plan

- [x] `test_blocks.py` — 4 new/rewritten unit tests directly on `validate_forum_body` (accepted-by-allowed-uploader, rejected-by-different-uploader, `None`-grandfather accepted, collection-rejection now uploader-agnostic)
- [x] `tests/api/test_post_image_upload.py` — end-to-end: a second member's API POST referencing the first member's uploaded image id 400s
- [x] `tests/api/test_post_edit_delete.py` — moderator edit keeps the author's pre-existing image (no regression); moderator cannot smuggle in a *third*, unrelated member's image while editing someone else's post
- [x] 261 forum+forum_host tests passing (was 256)
- [x] `manage.py check` clean; `makemigrations --check --dry-run` clean (no model field changed)
- [x] kimi-review: no CRITICAL/WARNING findings

Todo 254's acceptance criteria are now all met (C1/H16/M16/M19/M20/L21) — epic complete pending this review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)