### PR TITLE
docs: codify findings from todo 254 slice 5 (audit L21)

### DIFF
--- a/docs/LEARNINGS.md
+++ b/docs/LEARNINGS.md
@@ -789,3 +789,53 @@ review; escalated to HIGH after both halves reproduced empirically. **Fix**:
 **Pattern**: `backend/docs/patterns/architecture/viewsets.md`. **Trigger**:
 `drf-package-views-pin-filter-backends`.
 **Agent**: django-drf-reviewer — package generics views must pin `filter_backends`.
+
+## Django/DRF (2026-07-12 additions)
+
+### [2026-07-12] `field__in={..., None}` silently matches nothing for the None member (todo 254 slice 5, audit L21)
+
+**Mistake**: closing a cross-user image-reuse IDOR (audit L21) required an
+`allowed_uploader_ids` set that legitimately includes `None` (an
+account-deleted author's images grandfather in, since Wagtail's
+`Image.uploaded_by_user` and `Post.author` both go `SET_NULL` together on
+account deletion). The first implementation filtered directly with
+`uploaded_by_user_id__in=allowed_uploader_ids`. A dedicated test for the
+`None`-grandfather case failed: SQL's `IN (NULL)` evaluates to unknown, not
+true, for ANY row — including one whose value actually is `NULL`. Django's
+ORM passes `None` through to the `IN (...)` list literally; it does not
+special-case it the way `field=None` (which Django DOES rewrite to
+`IS NULL`) does.
+**Fix**: split the set — `Q(field__in=non_null_values) | Q(field__isnull=True)`,
+OR'd in only when `None` is actually a member. See
+`backend/packages/wagtail_forum/wagtail_forum/api/sanitize.py::validate_forum_body`.
+**Rule**: `docs/rules/database.md`. **Pattern**:
+`backend/docs/patterns/domain/forum.md` → "Image blocks are scoped to an
+allowed-uploader set".
+**Agent**: django-drf-reviewer — flag `__in=` filters where the RHS set/list
+may contain `None`.
+
+## Tooling / Agents (2026-07-12 additions)
+
+### [2026-07-12] Edit-time import strip recurs when an import lands before its first usage
+
+**Mistake**: added `from django.db.models import Q` to `sanitize.py` in one
+Edit call, then used `Q(...)` in a *later* Edit call. The PostToolUse
+formatter hook runs between edits and reformats/lints the file as it stands
+at that moment — with no usage yet, it silently removed the "unused" import.
+The next edit then referenced `Q` without it being defined, surfacing as
+`NameError: name 'Q' is not defined` only when tests ran. This is the same
+class of bug already logged for Dart/Flutter (`project_dart_edittime_import_
+strip` memory, hit 2026-06-23) — confirmed here to also apply on the Python
+side within a single session, not just across sessions.
+**Fix**: re-added the import in the SAME Edit call as its first usage; the
+formatter had nothing to strip once the usage was already present.
+**Rule**: added to `docs/rules/_discipline.md` (auto-injected before every
+edit): add a new import in the same edit as its first usage, never a prior
+one.
+**Trigger**: none registered — the actual failure mode (an import added
+ahead of a *future* edit that hasn't happened yet) has no textual signature
+capturable from a single edit's diff; a trigger matching "any new import" on
+every Python/Dart file would be pure noise. Left as prose in
+`docs/rules/_discipline.md` + this entry.
+**Agent**: (process — no diff-reviewable signature; same as the worktree
+PYTHONPATH entry above).

--- a/docs/rules/_discipline.md
+++ b/docs/rules/_discipline.md
@@ -4,3 +4,7 @@
 - Simplicity first. Write the minimum code that solves the problem. No speculative abstractions. No flexibility nobody asked for. The test: would a senior engineer call this overcomplicated.
 - Surgical changes. Touch only what the task requires. Do not improve neighboring code. Do not refactor what is not broken. Every changed line should trace back to the request.
 - Goal-driven execution. Turn vague instructions into verifiable targets before writing a line. "Add validation" becomes "write tests for invalid inputs, then make them pass."
+- Add a new import in the SAME edit as its first usage, not a prior one. The
+  formatter runs between edits and strips an import that's unused at that
+  moment — adding it ahead of the code that uses it gets it silently deleted,
+  surfacing later as `NameError`/`undefined_identifier`.

--- a/docs/rules/database.md
+++ b/docs/rules/database.md
@@ -44,6 +44,11 @@ Compact checklist auto-injected before edits. Long-form:
   read-modify-write `save()` can. And preserve every invariant other code relies
   on (e.g. a cursor-pagination "never NULL" ordering field needs `Coalesce` to a
   fallback in EVERY writer).
+- **`field__in={..., None}` never matches a NULL column value.** SQL's
+  `IN (NULL)` evaluates to unknown, not true, even for a row whose value
+  actually is `NULL`. When `None` is a legitimate member of an `__in` set
+  (e.g. grandfathering a nullable FK), split it out:
+  `Q(field__in=non_null_values) | Q(field__isnull=True)`.
 - **After `select_for_update().get(pk=…)`, mutate the LOCKED instance, never an
   earlier unlocked read.** `save()`/`unpublish()`/`publish()` on the pre-lock
   object writes fields back as they were at the stale read, clobbering a

--- a/docs/rules/security.md
+++ b/docs/rules/security.md
@@ -37,6 +37,14 @@ Compact checklist auto-injected before edits. Long-form: `backend/docs/patterns/
   the email, the downstream user lookup MUST treat a missing email as a hard
   stop. Canonical: `backend/docs/patterns/security/authentication.md` → "Trust
   only provider-verified emails".
+- **A shared resource container (collection/bucket/folder) is not an ownership
+  check.** Validating that a referenced object lives in the right *container*
+  (e.g. an upload collection) closes an existence-guessing IDOR but does not
+  stop one user from referencing another user's object BY ID within that same
+  container. If the object records an owner/uploader, check it explicitly —
+  don't assume container membership implies ownership. Canonical:
+  `backend/docs/patterns/domain/forum.md` → "Image blocks are scoped to an
+  allowed-uploader set" (audit L21).
 - **Gate the drf-spectacular schema/docs endpoints.** `SpectacularAPIView`,
   `SpectacularSwaggerView`, and `SpectacularRedocView` default to
   `SERVE_PERMISSIONS = [AllowAny]`, so the full OpenAPI schema (every path,

--- a/todos/254-in_progress-p1-forum-moderation-safety-admin.md
+++ b/todos/254-in_progress-p1-forum-moderation-safety-admin.md
@@ -328,6 +328,21 @@ Path shorthand: `W` = `backend/packages/wagtail_forum/wagtail_forum`, `H` = `bac
   `Image.uploaded_by_user` already existed).
 - Todo 254 acceptance criteria are now all met (C1/H16/M16/M19/M20/L21) —
   epic complete pending final review + archival.
+- PR #445 merged (`dec46f0`, all 18 CI checks green). Post-merge `/codify`
+  pass ran a fresh kimi-review on the merged diff (`2dca465..dec46f0`) —
+  flagged one WARNING: `_allowed_uploader_ids()` doesn't itself guard
+  `request.user` being anonymous. Verified against the call graph, not
+  applied: all three call sites (`TopicListView.post`/`PostListView.post` via
+  `IsAuthenticatedOrReadOnly` on write, `PostWriteView.patch` via
+  `IsAuthenticated`) already guarantee `request.user.is_authenticated` before
+  the serializer runs — DRF's permission check runs in `dispatch()`, before
+  the view method body. Even if reached anonymous, `AnonymousUser.pk` is
+  `None`, not a crash, and degrades fail-closed (rejects all real image refs,
+  doesn't open one). No fix; not a reachable gap. Codified two reusable
+  gotchas from this slice into `docs/rules/{database,security}.md`,
+  `docs/rules/_discipline.md`, and `docs/LEARNINGS.md` (Django/DRF + Tooling
+  sections, both dated 2026-07-12) — see those for detail rather than
+  duplicating here.
 
 ## Notes
 


### PR DESCRIPTION
## Summary

Post-merge `/codify` pass on PR #445 (todo 254 slice 5, L21 image-uploader scoping). Two reusable gotchas surfaced during that work that weren't yet in project docs:

- **Django `field__in={..., None}` never matches a NULL column value** — SQL's `IN (NULL)` is never true, even for a row whose value actually is `NULL`. Caught by a dedicated test before it shipped in #445; now a rule in `docs/rules/database.md` + a full `docs/LEARNINGS.md` entry.
- **Shared-container membership ≠ ownership** — the general IDOR lesson behind L21 (checking an image lives in the right *collection* doesn't stop cross-user reuse *within* it). New rule in `docs/rules/security.md`, canonical worked example already in `backend/docs/patterns/domain/forum.md`.
- Re-hit the already-known edit-time import-strip gotcha a second time this session (previously only logged as Dart-specific in memory) — confirmed it applies on the Python side too. Added to `docs/rules/_discipline.md` (auto-injected before every edit) since it has no regex-matchable signature for a write-time trigger.

Also appends a work-log addendum to `todos/254-...md` documenting a post-merge kimi-review WARNING (anonymous-user guard on `_allowed_uploader_ids`) that was verified against the actual call graph and correctly not fixed — all three write endpoints already require `IsAuthenticated` before that code runs, and even if reached anonymous it degrades fail-closed (rejects references, doesn't open one).

No `triggers.json` entry for either gotcha — evaluated per the codify skill's Step 5b and consciously skipped: neither has a textual signature precise enough to avoid false positives.

## Test plan

- [x] Docs-only change, no code touched
- [x] kimi-review: no CRITICAL/WARNING findings on the staged diff
- [x] Markdown lint passed (pre-commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)