### PR TITLE
todos: archive todo 254 (forum moderation epic) + file test-gap follow-up

### DIFF
--- a/docs/audits/2026-07-11-forum-modernization.md
+++ b/docs/audits/2026-07-11-forum-modernization.md
@@ -287,7 +287,7 @@ Deferred findings converted to todos (Review Doc Tracking convention — the
 `completing-todos` skill checks these off on archive). The 15 `verified` and
 1 `false-positive` findings were closed in this audit and have no todo.
 
-- [ ] #C1 report-flag-mechanism → todo 254
+- [x] #C1 report-flag-mechanism → todo 254 (completed 2026-07-13)
 - [ ] #C2 notifications-delivery-channel → todo 253
 - [ ] #H1 orphaned-email-notifications → todo 253
 - [ ] #H2 push-event-coverage → todo 253
@@ -303,7 +303,7 @@ Deferred findings converted to todos (Review Doc Tracking convention — the
 - [ ] #H13 llm-spam-prescreen → todo 255
 - [ ] #H14 ai-thread-summarization → todo 255
 - [ ] #H15 semantic-similar-topics → todo 255
-- [ ] #H16 admin-moderation-queue → todo 254
+- [x] #H16 admin-moderation-queue → todo 254 (completed 2026-07-13)
 - [ ] #H18 error-retry-affordance → todo 259
 - [ ] #H21 tombstone-prune-scheduling → todo 261
 - [ ] #H26 author-shape-inconsistency → todo 257
@@ -321,11 +321,11 @@ Deferred findings converted to todos (Review Doc Tracking convention — the
 - [ ] #M12 semantic-search-upgrade → todo 255
 - [ ] #M13 rag-plant-care → todo 255
 - [ ] #M14 ai-composer-assist → todo 255
-- [ ] #M16 preview-support → todo 254
+- [x] #M16 preview-support → todo 254 (completed 2026-07-13)
 - [ ] #M17 i18n → todo 262
 - [ ] #M18 package-readme → todo 262
-- [ ] #M19 per-board-moderation → todo 254
-- [ ] #M20 admin-polish-cluster → todo 254
+- [x] #M19 per-board-moderation → todo 254 (completed 2026-07-13)
+- [x] #M20 admin-polish-cluster → todo 254 (completed 2026-07-13)
 - [ ] #M22 fetch-race-guards → todo 259
 - [ ] #M23 reacted-state → todo 257
 - [ ] #M24 native-dialogs → todo 259
@@ -362,7 +362,7 @@ Deferred findings converted to todos (Review Doc Tracking convention — the
 - [ ] #L18 write-path-query-profiling → todo 258
 - [ ] #L19 location-header-201 → todo 258
 - [ ] #L20 versioning-comment → todo 258
-- [ ] #L21 image-reuse-privacy-decision → todo 254
+- [x] #L21 image-reuse-privacy-decision → todo 254 (completed 2026-07-13)
 
 ## Phase 6 code review (2026-07-11)
 

--- a/todos/265-pending-p3-forum-moderation-test-gaps.md
+++ b/todos/265-pending-p3-forum-moderation-test-gaps.md
@@ -1,0 +1,104 @@
+---
+status: pending
+priority: p3
+issue_id: "265"
+tags: [forum, testing, moderation]
+dependencies: []
+---
+
+# Forum moderation test-coverage gaps: bulk-unpublish attribution, report 401
+
+## Problem
+
+A retrospective `code-review-orchestrator` pass on the merged todo-254
+moderation epic (run during its archival) surfaced two test-coverage gaps.
+Neither is a live defect — both confirmed the underlying code is already
+correct — but two security/attribution-relevant behaviors ship with no
+regression test pinning them.
+
+## Findings
+
+- **HIGH** (cross-cutting-reviewer) —
+  `test_bulk_unpublish_action_unpublishes_selected_posts`
+  (`backend/packages/wagtail_forum/wagtail_forum/tests/test_admin.py:270`)
+  only asserts `post.live is False`; it never asserts the acting moderator
+  lands in `ModelLogEntry`. `ForumUnpublishBulkAction.get_execution_context()`
+  (`wagtail_hooks.py`) overrides `user=self.request.user` specifically to
+  avoid attributing takedowns to "the system" instead of the acting
+  moderator (per its own docstring, added in todo-254 Slice 4) — but that
+  override has no regression test.
+  `tests/test_actor_attribution.py` is the established pattern for this bug
+  class (audit finding M15: API-driven publish/unpublish must attribute the
+  acting user) and was never extended to the new bulk-unpublish path.
+- **MEDIUM** (cross-cutting-reviewer) — no test asserts that an
+  unauthenticated `POST /forum/posts/<id>/reports/` returns 401
+  (`backend/packages/wagtail_forum/wagtail_forum/tests/api/test_reports.py:38`),
+  unlike every other unsafe-write endpoint in the suite (topic create, reply
+  create, reaction toggle, post edit/delete, image upload all have this
+  case). `PostReportView` is the one new unsafe-write handler todo-254 added
+  and the one missing this coverage.
+
+## Recommended Action
+
+1. Add an attribution assertion to (or alongside)
+   `test_bulk_unpublish_action_unpublishes_selected_posts`: after the bulk
+   action runs, fetch the `ModelLogEntry` for one unpublished post
+   (`action="wagtail.unpublish"`, latest by timestamp) and assert
+   `.user == admin`. Mirror
+   `test_actor_attribution.py::test_api_delete_unpublish_logs_acting_user`.
+2. Add an unauthenticated-401 case for the report endpoint in
+   `test_reports.py` (or extend
+   `test_topic_create.py::test_unauthenticated_writes_are_rejected`'s
+   pattern to include it).
+3. Per `docs/rules/testing.md`'s non-vacuous-mutation rule, verify each new
+   test actually catches the regression it claims to: for the 401 test,
+   mutate `PostReportView.permission_classes` to `AllowAny` (not delete it —
+   `IsAuthenticatedOrReadOnly` is the DRF default and would mask a deleted
+   `permission_classes`, producing a false-pass); for the attribution test,
+   temporarily drop the `get_execution_context()` override and confirm the
+   test fails.
+
+## Technical Details
+
+- `backend/packages/wagtail_forum/wagtail_forum/wagtail_hooks.py` —
+  `ForumUnpublishBulkAction.get_execution_context()`
+- `backend/packages/wagtail_forum/wagtail_forum/tests/test_admin.py:270`
+- `backend/packages/wagtail_forum/wagtail_forum/tests/test_actor_attribution.py`
+  — pattern to mirror
+- `backend/packages/wagtail_forum/wagtail_forum/api/views.py` —
+  `PostReportView`
+- `backend/packages/wagtail_forum/wagtail_forum/tests/api/test_reports.py:38`
+- `docs/rules/testing.md` — non-vacuous mutation-check rule
+
+## Acceptance Criteria
+
+- [ ] A test asserts the acting moderator (not `None`/system) is attributed
+      in `ModelLogEntry` after `ForumUnpublishBulkAction` runs
+- [ ] A test asserts unauthenticated `POST` to the report endpoint returns
+      401
+- [ ] Both new tests are non-vacuous: the mutations described in
+      Recommended Action step 3 make them fail
+- [ ] Full `wagtail_forum` + `forum_host` suite green
+
+## Work Log
+
+### 2026-07-13 - Created from todo-254 retrospective review
+
+- Filed from a `code-review-orchestrator` retrospective checklist pass
+  (cross-cutting-reviewer) dispatched against the merged todo-254 epic diff
+  during its archival. 4 reviewers, 9 total findings; these 2 (HIGH +
+  MEDIUM) were the only genuinely new and actionable ones — the rest were
+  pre-existing-pattern repeats or already in pending todo 259's scope. Full
+  review context lives in
+  `todos/archive/254-completed-p1-forum-moderation-safety-admin.md`'s Work
+  Log.
+
+## Notes
+
+p3 — both are coverage gaps on already-verified-correct, merged, CI-green
+code, not live defects. Same shape as archived todo 253
+(`forum-write-endpoint-test-gaps`), also filed as p3 for the identical
+reason. No `source_review`/`source_finding` frontmatter: this finding didn't
+come from a `docs/reviews/` or `docs/audits/` doc, it came from an ad hoc
+orchestrator dispatch during todo 254's archival — provenance is recorded
+above and in todo 254's Work Log instead.

--- a/todos/archive/254-completed-p1-forum-moderation-safety-admin.md
+++ b/todos/archive/254-completed-p1-forum-moderation-safety-admin.md
@@ -1,5 +1,5 @@
 ---
-status: in_progress
+status: completed
 priority: p1
 issue_id: "254"
 tags: [forum, moderation, wagtail, admin]
@@ -343,6 +343,48 @@ Path shorthand: `W` = `backend/packages/wagtail_forum/wagtail_forum`, `H` = `bac
   `docs/rules/_discipline.md`, and `docs/LEARNINGS.md` (Django/DRF + Tooling
   sections, both dated 2026-07-12) — see those for detail rather than
   duplicating here.
+
+### 2026-07-13 - Started by completing-todos skill (run 2026-07-13-0050)
+
+- Picked up by automated workflow to re-confirm and archive. All 5 slices
+  (PRs #442–445) plus the post-merge codify pass (PR #446) already merged to
+  `main` (`823299d`); local branch synced via fast-forward before this run
+  started. All 6 acceptance criteria already `[x]` — proceeding via the
+  verify-only path.
+
+### 2026-07-13 - Completed by completing-todos skill (run 2026-07-13-0050)
+
+- Re-verified all 6 acceptance criteria fresh on synced `main` (`823299d`), not
+  just trusting the per-slice Work Log evidence: `python -m pytest
+  packages/wagtail_forum apps/forum_host` → 261/261 passing (matches Slice 5's
+  count exactly, no regressions since merge); `manage.py check` → 0 issues;
+  `makemigrations --check --dry-run` → no changes detected. Verify-only path
+  (no uncommitted diff to implement against).
+- Retrospective `code-review-orchestrator` pass (checklist-compliance angle —
+  kimi-review already covered correctness per-slice) dispatched 4 domain
+  reviewers against the full epic diff (`986bc92^..823299d`, 34 files). 9
+  findings, 0 critical: 1 high, 1 medium, 7 low/info. Code is already merged
+  and CI-green (PR #445, 18 checks), so none repaired here — out of scope for
+  this archival. The two genuinely new + actionable gaps, named so they aren't
+  lost:
+  - HIGH (cross-cutting): `test_bulk_unpublish_action_unpublishes_selected_posts`
+    doesn't assert the acting moderator lands in `ModelLogEntry` — the
+    `get_execution_context()` attribution override is correct but has no
+    regression test (`test_actor_attribution.py` is the pattern to mirror).
+  - MEDIUM (cross-cutting): `PostReportView` (the new report endpoint) is
+    missing an unauthenticated-401 test, unlike every other unsafe-write
+    endpoint in the suite.
+  - LOW (wagtail): cross-slice note — the H16 homepage moderation count and
+    the C1 Report queue were never unified (a post with open reports below
+    the auto-hide threshold doesn't show in the homepage count). Reviewer's
+    own verdict: not a defect, reports stay reachable via the Reports list.
+  - Remaining 6 (3 low from django-drf; 2 low/info + 1 medium from
+    react-typescript; 1 low + 1 info from cross-cutting) are minor nits,
+    repeats of a pre-existing pattern, or already in pending todo 259's scope
+    (web-UX polish: report-`<select>` tap target, error-surfacing contract) —
+    no action needed here.
+- Findings recorded, none repaired — code already merged, out of scope for
+  this archival.
 
 ## Notes
 


### PR DESCRIPTION
## Summary
- Archives todo 254 (forum moderation, safety & Wagtail admin — p1 epic, 5 slices, PRs #442–#446) after re-verifying all 6 acceptance criteria fresh on main: 261/261 `wagtail_forum`+`forum_host` tests, `manage.py check` clean, no migration drift.
- Checks off C1/H16/M16/M19/M20/L21 in the shared `docs/audits/2026-07-11-forum-modernization.md` Finding Status table. 70 findings for other epics (253/255/256/etc.) remain open, so the doc is intentionally **not** renamed to `-COMPLETED`.
- Files todo 265: two genuinely-new, actionable test-coverage gaps (HIGH: bulk-unpublish moderator-attribution has no regression test; MEDIUM: the new report endpoint has no unauthenticated-401 test) surfaced by a retrospective `code-review-orchestrator` checklist pass over the full merged epic diff. Neither is a live defect — both confirmed the underlying code is already correct.

Docs/process only — no source code changes.

## Test plan
- [x] `python -m pytest packages/wagtail_forum apps/forum_host` — 261/261 passing
- [x] `manage.py check` — 0 issues
- [x] `manage.py makemigrations --check --dry-run` — no changes detected
- [x] `kimi-review` staged-diff gate — clean on both commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)