### PR TITLE
docs: codify findings from todo-sweep session (PRs #448-454)

### DIFF
--- a/docs/LEARNINGS.md
+++ b/docs/LEARNINGS.md
@@ -839,3 +839,35 @@ every Python/Dart file would be pure noise. Left as prose in
 `docs/rules/_discipline.md` + this entry.
 **Agent**: (process — no diff-reviewable signature; same as the worktree
 PYTHONPATH entry above).
+
+## Security (2026-07-13 additions)
+
+### [2026-07-13] `claude-code-security-review`'s own step outputs can't be trusted for a real merge-gate (todo 249)
+
+**Mistake**: assumed, per the action's naming, that its `results-file` and
+`findings-count` step outputs were live values a downstream gate step could
+read directly. Reading the action's actual source at our pinned SHA
+(`0c6a49f1fa56a1d472575da86a94dbc1edb78eda`, via `gh api
+repos/anthropics/claude-code-security-review/contents/<path>?ref=<sha>`)
+showed both are unreliable: `results-file` is hardcoded near the top of the
+composite step to a literal relative-path string that is never updated to
+reflect where the file actually lands relative to a downstream step's
+`github.workspace`; and the script's own internally-computed HIGH-severity
+exit code is captured into a shell variable
+(`|| CLAUDECODE_EXIT_CODE=$?`) and only ever surfaced as an `::warning::`
+annotation, never re-raised — so the job exits success regardless of
+findings, by design.
+**Fix**: read `${{ github.workspace }}/claudecode-results.json` directly —
+the action unconditionally copies its results there regardless of outcome —
+and parse `.findings[].severity` yourself via `jq`. Confirmed enum (from
+`claudecode/prompts.py`'s REQUIRED OUTPUT FORMAT) is `HIGH|MEDIUM|LOW`
+only; `CRITICAL` is never emitted despite some docs implying a 4-tier scale.
+Implemented as a non-blocking (`continue-on-error: true`) observation step
+in `.github/workflows/security-review.yml` — see the todo for why a true
+blocking gate is still deferred.
+**Rule**: `docs/rules/security.md`. Don't trust a third-party GitHub
+Action's documented/named outputs without reading its actual source at the
+exact pinned SHA in use — a name like `results-file` implies "the current
+results file," not "a hardcoded stale string."
+**Agent**: n/a — CI/workflow finding, not a reviewable application-code
+pattern.

--- a/docs/rules/security.md
+++ b/docs/rules/security.md
@@ -53,3 +53,12 @@ Compact checklist auto-injected before edits. Long-form: `backend/docs/patterns/
   `SPECTACULAR_SETTINGS["SERVE_PERMISSIONS"] = ["rest_framework.permissions.IsAdminUser"]`
   — one knob covers all three views (and any future one). `SERVE_INCLUDE_SCHEMA=False`
   does NOT gate them (it only hides the schema's own path). Surfaced in prod (todo 248).
+- **Don't trust `claude-code-security-review`'s own `results-file`/`findings-count`
+  step outputs.** The action's composite step hardcodes `results-file` to a stale
+  relative-path string it never updates, and captures the script's own internal
+  severity exit code into a shell variable without ever re-raising it — the job
+  always exits success regardless of findings. Read
+  `${{ github.workspace }}/claudecode-results.json` directly (unconditionally
+  copied there) and parse `.findings[].severity` yourself — the enum is
+  `HIGH|MEDIUM|LOW` only, `CRITICAL` is never emitted. See `docs/LEARNINGS.md`
+  2026-07-13.

--- a/docs/rules/testing.md
+++ b/docs/rules/testing.md
@@ -89,3 +89,10 @@ Compact checklist auto-injected before edits.
   keeps passing and proves nothing. To verify an auth test is non-vacuous,
   mutate to `permission_classes = [AllowAny]`, and check the DRF default
   before trusting any mutation-based verification.
+- **An unsaved Django model instance (`Model(fk=saved_obj)`, no `.save()`) has
+  FK attributes set correctly but `.pk`/`.id` stays `None`.** `topic_id` resolves
+  immediately because the FK is assigned at construction, so a test asserting
+  only on the FK looks fine — but any code in the same path that reads the
+  instance's OWN `.pk`/`.id` (e.g. serializing an id into a notification
+  payload) silently gets `None`/`"None"` instead of a real value. Save the
+  instance if anything downstream might read its own primary key.

--- a/docs/rules/triggers.json
+++ b/docs/rules/triggers.json
@@ -362,5 +362,20 @@
     "source": "codify: chore/forum-modernization-audit-2026-07-11",
     "added": "2026-07-11",
     "severity": "warn"
+  },
+  {
+    "id": "security-review-action-untrusted-outputs",
+    "domains": [
+      "security"
+    ],
+    "path_glob": [
+      ".github/workflows/*.yml"
+    ],
+    "content_present": "\\.outputs\\.(results-file|findings-count)",
+    "message": "claude-code-security-review outputs are unreliable: results-file is a hardcoded stale path, findings-count discards the real exit code (job always succeeds). Read ${{ github.workspace }}/claudecode-results.json directly and parse .findings[].severity yourself. See docs/LEARNINGS.md 2026-07-13.",
+    "pattern_ref": "docs/rules/security.md",
+    "source": "codify: docs/codify-todo-sweep-2026-07-13",
+    "added": "2026-07-13",
+    "severity": "warn"
   }
 ]


### PR DESCRIPTION
## Summary

Codification pass after reviewing and merging the 7 todo-sweep PRs (#448-454). Ran kimi-review against the full session diff range and independently verified each finding against the actual code before writing anything down.

- **`docs/rules/security.md` + `docs/LEARNINGS.md`**: the `claude-code-security-review` GitHub Action's `results-file`/`findings-count` step outputs can't be trusted — `results-file` is a hardcoded stale relative path, and the real severity exit code is silently discarded upstream (job always exits success). Read `${{ github.workspace }}/claudecode-results.json` directly instead. This is the primary-source research from todo 249, now durably captured rather than only living in that todo's Work Log.
- **`docs/rules/testing.md`**: an unsaved Django model instance (`Model(fk=saved_obj)`, no `.save()`) has FK attributes set correctly but `.pk`/`.id` stays `None` — flagged by both kimi-review and the domain-reviewer agent on PR #450's test fixtures.
- **`docs/rules/triggers.json`**: registered a write-time trigger (`security-review-action-untrusted-outputs`) for the security-review-action finding, scoped to `.github/workflows/*.yml` — narrow enough signature to be low-noise. Validated via `test_match_triggers.py` (34 passed).

## Not codified (already covered)

The blog `SummaryItem` constructor bug (todo 264, PR #451) was already fully codified by todo 254's 2026-07-12 `LEARNINGS.md` entry and the `wagtail-reviewer` agent's checklist — that entry explicitly named `apps/blog/wagtail_hooks.py` as a predicted second instance before todo 264 fixed it. No new codification needed; this PR doesn't touch either file.

## Test plan

- [x] `python3 scripts/inject/test_match_triggers.py` — 34 passed, including `test_pattern_refs_resolve` and `test_ids_unique` against the new trigger entry
- [x] `kimi-review` pre-commit gate — no CRITICAL/WARNING findings on the staged diff
- [x] Verified each of the 3 codified findings against actual code/source before writing (not taking kimi-review's raw output at face value — one additional kimi finding, `create_superuser()` without a password, was checked and confirmed a false positive, not codified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)