### PR TITLE
security: bump pillow 12.2.0 -> 12.3.0 (pip-audit CVE fix)

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -136,7 +136,7 @@ parso==0.8.5
 pathspec==1.1.1
 pexpect==4.9.0
 pilkit==3.0
-pillow==12.2.0
+pillow==12.3.0
 pillow_heif==1.3.0
 pluggy==1.6.0
 prompt_toolkit==3.0.52


### PR DESCRIPTION
## Summary
- The scheduled `Security Dependency Scan` run (2026-07-13 11:56 UTC) started failing on every open PR after pip-audit's advisory DB picked up 5 new pillow 12.2.0 CVEs: PYSEC-2026-2253/2254/2255/2256/2257 (decompression-bomb and out-of-bounds read/write issues), all fixed in pillow 12.3.0.
- Bumps `pillow==12.2.0` → `pillow==12.3.0` in `backend/requirements.txt`. Per the bump-don't-suppress precedent in `docs/LEARNINGS.md` (2026-06-22, the bleach incident), since a fix version exists this should be a version bump, not another `--ignore-vuln` suppression.

## Verification
- `pillow_heif==1.3.0` requires `pillow>=11.1.0` (no upper pin) — compatible.
- No app code uses the Pillow APIs touched by 12.3.0's breaking changes (`ImageCms` strict-mode validation, TGA 1-mode RLE removal) — grepped clean across `backend/apps`.
- Ran the CI's exact gate command locally against the bumped venv: `pip-audit -r requirements.txt` with all 8 existing `--ignore-vuln` flags → **exit 0**.
- Ran 281 backend tests covering every Pillow call site (`garden_calendar` file-upload security, `plant_identification`, `garden`, `forum_host` ratelimit avatar tests) → all pass, no regressions.

## Test plan
- [x] Local `pip-audit` gate exits 0 with the bumped pin
- [x] Backend test suites touching image upload/validation pass unchanged
- [ ] CI's own `Security Dependency Scan` run on this PR is green (live confirmation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)