### PR TITLE
forum: wire reply-notification email into reply_added (todo 253 slice 2, audit H1)

### DIFF
--- a/backend/apps/core/services/notification_service.py
+++ b/backend/apps/core/services/notification_service.py
@@ -199,7 +199,7 @@ class NotificationService:
         """Schedule notification for later delivery."""
         # TODO: Implement proper scheduling with Celery or Django-RQ
         logger.warning(
-            f"Scheduled notifications not yet implemented. Sending immediately instead."
+            "Scheduled notifications not yet implemented. Sending immediately instead."
         )
 
         # For now, send immediately instead of scheduling
@@ -293,10 +293,14 @@ class NotificationService:
         topic_url: str,
     ) -> bool:
         """Send forum reply notification."""
+        # Keys must match the template vars in emails/forum_reply.{html,txt}
+        # (author_name/post_excerpt), not these parameter names — Django
+        # silently renders an undefined var as '', so a mismatch here ships
+        # a blank-author, blank-excerpt email instead of erroring.
         context = {
             "topic_title": topic_title,
-            "reply_author": reply_author,
-            "reply_excerpt": reply_excerpt,
+            "author_name": reply_author,
+            "post_excerpt": reply_excerpt,
             "topic_url": topic_url,
         }
 
@@ -331,7 +335,7 @@ class NotificationService:
         }
 
         subject = f"Your plant has been identified as {plant_name}"
-        message = f"Great news! Your plant identification request has a new result."
+        message = "Great news! Your plant identification request has a new result."
 
         results = self.send_notification(
             notification_type=EmailType.IDENTIFICATION_RESULT,

--- a/backend/apps/forum_host/constants.py
+++ b/backend/apps/forum_host/constants.py
@@ -20,3 +20,8 @@ DEFAULT_FORUM_RATELIMITS = {
     "notification_unread_count": "120/m",
     "notification_mark_read": "60/m",
 }
+
+# Reply-notification email body excerpt length (todo 253 slice 2, H1).
+# Matches the package's own MAX_EXCERPT_CHARS precedent
+# (wagtail_forum/api/views.py) as an independent host-side choice.
+FORUM_EMAIL_EXCERPT_MAX_CHARS = 200

--- a/backend/apps/forum_host/notifications.py
+++ b/backend/apps/forum_host/notifications.py
@@ -4,7 +4,7 @@ logger = logging.getLogger("forum_host.notifications")
 
 
 def dispatch(event, **kwargs):
-    """Route a forum signal event to FCM via a background Celery task.
+    """Route a forum signal event to FCM/email via background Celery tasks.
 
     Importing the task here (inside the function) keeps the module importable
     even before the Celery app is ready (e.g. during migrations).
@@ -16,9 +16,12 @@ def dispatch(event, **kwargs):
         thread.  kwargs: topic (Topic), post (Post). Persists a Notification
         row (todo 253 slice 1) synchronously in the ambient (publish)
         transaction — it rolls back cleanly if the publish does — and defers
-        the push enqueue to transaction.on_commit so a push can never fire for
-        a publish that later rolls back (fixes the pre-slice-253 bug where
-        .delay() ran synchronously inside the open publish transaction).
+        the push AND email enqueue to transaction.on_commit so neither can
+        ever fire for a publish that later rolls back (fixes the
+        pre-slice-253 bug where .delay() ran synchronously inside the open
+        publish transaction). The email (todo 253 slice 2, H1) reuses
+        NotificationService.send_forum_reply_notification, gated by the
+        recipient's forum_notifications preference inside that service.
 
     moderation_decided
         Notifies the post's author of their content's moderation outcome.
@@ -30,7 +33,7 @@ def dispatch(event, **kwargs):
     """
     from django.db import transaction
 
-    from .tasks import send_forum_push
+    from .tasks import send_forum_email, send_forum_push
 
     topic = kwargs.get("topic")
     topic_id = getattr(topic, "id", None)
@@ -65,6 +68,16 @@ def dispatch(event, **kwargs):
                     topic_author.pk,
                 )
 
+        def _enqueue_email():
+            try:
+                send_forum_email.delay(event, topic_author.pk, payload)
+            except Exception:
+                logger.exception(
+                    "[CELERY] forum_host: failed to enqueue email for event=%s user=%s",
+                    event,
+                    topic_author.pk,
+                )
+
         try:
             # A nested atomic() scopes any DB failure to a savepoint: this
             # dispatch runs inside the ambient Wagtail publish transaction, and
@@ -83,9 +96,11 @@ def dispatch(event, **kwargs):
                     post=post,
                 )
             # Only registered once the write above actually succeeds — a
-            # notification-write failure must not still deliver a push, or the
-            # user gets a push with no corresponding in-app notification.
+            # notification-write failure must not still deliver a push/email,
+            # or the user gets a delivery with no corresponding in-app
+            # notification.
             transaction.on_commit(_enqueue_push)
+            transaction.on_commit(_enqueue_email)
         except Exception:
             logger.exception(
                 "[ERROR] forum_host: failed to persist notification for event=%s user=%s",

--- a/backend/apps/forum_host/tasks.py
+++ b/backend/apps/forum_host/tasks.py
@@ -1,14 +1,17 @@
-"""Celery tasks for forum push notifications (Issue 14).
+"""Celery tasks for forum push (Issue 14) and email (todo 253 slice 2, H1)
+notifications.
 
 Fired by forum_host/notifications.py dispatch() via .delay() so that:
-- The publish transaction is never held open waiting for FCM.
-- A failed push never rolls back a moderation decision.
-- Tasks are retried automatically by Celery on transient FCM errors.
+- The publish transaction is never held open waiting for FCM/SMTP.
+- A failed delivery never rolls back a moderation decision.
+- Tasks are retried automatically by Celery on their respective transient
+  error classes (FCM send errors for push; OperationalError for email).
 """
 
 import logging
 
 from celery import shared_task
+from django.db import OperationalError
 
 logger = logging.getLogger("forum_host.tasks")
 
@@ -117,3 +120,100 @@ def send_forum_push(self, event: str, recipient_user_id: int, data: dict):
         raise self.retry(
             exc=exc, countdown=self.default_retry_delay * (2**self.request.retries)
         )
+
+
+@shared_task(autoretry_for=(OperationalError,), retry_backoff=True, max_retries=3)
+def send_forum_email(event: str, recipient_user_id: int, data: dict):
+    """Send a single forum notification email via NotificationService.
+
+    Enqueued from forum_host/notifications.py via transaction.on_commit,
+    mirroring send_forum_push, so a rolled-back publish never sends an email.
+
+    Retry is narrowly scoped to OperationalError (a transient DB error during
+    the User/Post fetches below), not a broad catch-all: unlike push's
+    fcm.send() (which raises on a transient FCM error), this task's actual
+    send call — NotificationService.send_forum_reply_notification() ->
+    EmailService.send_email() — swallows every send/render failure internally
+    (ConnectionError, TemplateDoesNotExist, a blanket Exception) and returns a
+    bool, so it can never raise; wrapping IT in retry would be untested dead
+    code. The DB fetches below CAN genuinely raise OperationalError on a
+    connection blip, and per docs/rules/celery.md ("every task declares
+    retry config... never leave a network-touching task with default no
+    retries") that failure must not silently drop the notification — the
+    DoesNotExist/ValueError/TypeError branches return early first, so
+    autoretry only ever fires on the one real transient-failure class.
+
+    Args:
+        event: forum event name. Only "reply_added" is wired (todo 253 slice
+               2, H1); mention/moderation/digest are later slices.
+        recipient_user_id: pk of the User to email.
+        data: the same payload dict shared with send_forum_push — carries
+              "post_id" (str). The reply Post is re-fetched here (rather than
+              embedding rendered content in the FCM-shared payload) so push's
+              data stays minimal and the email reflects the post at send time.
+    """
+    if event != "reply_added":
+        logger.debug(
+            "[EMAIL] forum email skipped — event=%s not implemented yet", event
+        )
+        return
+
+    from apps.core.services.notification_service import NotificationService
+    from django.conf import settings
+    from django.contrib.auth import get_user_model
+    from wagtail_forum.api.views import plain_text_excerpt
+    from wagtail_forum.models import Post
+
+    from .constants import FORUM_EMAIL_EXCERPT_MAX_CHARS
+
+    User = get_user_model()
+
+    try:
+        user = User.objects.get(pk=recipient_user_id)
+    except User.DoesNotExist:
+        logger.warning(
+            "[EMAIL] forum email skipped — user %s not found", recipient_user_id
+        )
+        return
+
+    if not user.email:
+        # EmailService.send_email() silently no-ops for a blank recipient
+        # (Django's EmailMessage.recipients() filters out falsy addresses,
+        # send() then returns 0) but still logs "sent successfully" and
+        # returns True — it does not surface the 0-recipients case as a
+        # failure. Guard here so a user with no email on file gets a clear
+        # skip log instead of a misleading success one.
+        logger.warning(
+            "[EMAIL] forum email skipped — user %s has no email on file",
+            recipient_user_id,
+        )
+        return
+
+    try:
+        post_id = int(data.get("post_id", ""))
+        post = Post.objects.select_related("topic__board", "author").get(pk=post_id)
+    except (TypeError, ValueError):
+        logger.warning(
+            "[EMAIL] forum email skipped — invalid post_id in payload: %r",
+            data.get("post_id"),
+        )
+        return
+    except Post.DoesNotExist:
+        logger.warning("[EMAIL] forum email skipped — post %s not found", post_id)
+        return
+
+    topic = post.topic
+    topic_url = f"{settings.SITE_URL}{topic.get_absolute_url()}"
+    author_name = post.author.display_name if post.author else "[deleted]"
+    excerpt = plain_text_excerpt(post.body, FORUM_EMAIL_EXCERPT_MAX_CHARS)
+
+    sent = NotificationService().send_forum_reply_notification(
+        user=user,
+        topic_title=topic.title,
+        reply_author=author_name,
+        reply_excerpt=excerpt,
+        topic_url=topic_url,
+    )
+    logger.info(
+        "[EMAIL] forum.%s email to user=%s: sent=%s", event, recipient_user_id, sent
+    )

--- a/backend/apps/forum_host/tests/test_signals.py
+++ b/backend/apps/forum_host/tests/test_signals.py
@@ -58,7 +58,13 @@ def test_reply_added_enqueues_push_for_topic_author(django_capture_on_commit_cal
         board=board, title="T2", slug="t2", author=topic_author
     )
 
-    with patch("apps.forum_host.tasks.send_forum_push.delay") as mock_delay:
+    with (
+        patch("apps.forum_host.tasks.send_forum_push.delay") as mock_delay,
+        # The reply_added success path also enqueues an email (todo 253 slice
+        # 2, H1) via the same on_commit mechanism; mock it so this push-only
+        # test doesn't attempt a real broker publish.
+        patch("apps.forum_host.tasks.send_forum_email.delay"),
+    ):
         from apps.forum_host.notifications import dispatch
 
         # A real (saved) Post — the Notification fan-out (todo 253 slice 1)
@@ -73,6 +79,42 @@ def test_reply_added_enqueues_push_for_topic_author(django_capture_on_commit_cal
     call_args = mock_delay.call_args
     assert call_args.args[0] == "reply_added"
     assert call_args.args[1] == topic_author.pk
+
+
+@pytest.mark.django_db
+def test_reply_added_enqueues_email_for_topic_author(
+    django_capture_on_commit_callbacks,
+):
+    """reply_added must enqueue send_forum_email for the topic author (todo
+    253 slice 2, H1) — mirrors test_reply_added_enqueues_push_for_topic_author.
+    Rendered-content correctness (the two latent bugs the wiring surfaced) is
+    covered separately by the task-level tests in test_tasks.py; this test
+    only proves the enqueue wiring itself."""
+    topic_author = User.objects.create_user(username="topicowner12")
+    replier = User.objects.create_user(username="replier12")
+
+    root = Page.objects.get(id=1)
+    index = root.add_child(instance=ForumIndex(title="Forum12", slug="forum12"))
+    board = index.add_child(instance=ForumBoard(title="General12", slug="general12"))
+    topic = Topic.objects.create(
+        board=board, title="T12", slug="t12", author=topic_author
+    )
+
+    with (
+        patch("apps.forum_host.tasks.send_forum_push.delay"),
+        patch("apps.forum_host.tasks.send_forum_email.delay") as mock_delay,
+    ):
+        from apps.forum_host.notifications import dispatch
+
+        post = Post.objects.create(topic=topic, author=replier)
+        with django_capture_on_commit_callbacks(execute=True):
+            dispatch("reply_added", topic=topic, post=post)
+
+    mock_delay.assert_called_once()
+    call_args = mock_delay.call_args
+    assert call_args.args[0] == "reply_added"
+    assert call_args.args[1] == topic_author.pk
+    assert call_args.args[2]["post_id"] == str(post.pk)
 
 
 @pytest.mark.django_db
@@ -158,10 +200,16 @@ def test_reply_added_swallows_push_delay_failure(
         board=board, title="T6", slug="t6", author=topic_author
     )
 
-    with patch(
-        "apps.forum_host.tasks.send_forum_push.delay",
-        side_effect=RuntimeError("broker unavailable"),
-    ) as mock_delay:
+    with (
+        patch(
+            "apps.forum_host.tasks.send_forum_push.delay",
+            side_effect=RuntimeError("broker unavailable"),
+        ) as mock_delay,
+        # The reply_added success path also enqueues an email (todo 253 slice
+        # 2, H1) via the same on_commit mechanism; mock it so this push-only
+        # test doesn't attempt a real broker publish.
+        patch("apps.forum_host.tasks.send_forum_email.delay"),
+    ):
         from apps.forum_host.notifications import dispatch
 
         post = Post.objects.create(topic=topic, author=replier)
@@ -190,7 +238,13 @@ def test_reply_added_persists_notification_row(django_capture_on_commit_callback
     )
     post = Post.objects.create(topic=topic, author=replier)
 
-    with patch("apps.forum_host.tasks.send_forum_push.delay"):
+    with (
+        patch("apps.forum_host.tasks.send_forum_push.delay"),
+        # The reply_added success path also enqueues an email (todo 253 slice
+        # 2, H1) via the same on_commit mechanism; mock it so this
+        # notification-row test doesn't attempt a real broker publish.
+        patch("apps.forum_host.tasks.send_forum_email.delay"),
+    ):
         from apps.forum_host.notifications import dispatch
 
         with django_capture_on_commit_callbacks(execute=True):

--- a/backend/apps/forum_host/tests/test_tasks.py
+++ b/backend/apps/forum_host/tests/test_tasks.py
@@ -1,4 +1,5 @@
-"""Unit tests for forum_host.tasks.send_forum_push (Issue 14).
+"""Unit tests for forum_host.tasks.send_forum_push (Issue 14) and
+send_forum_email (todo 253 slice 2, H1).
 
 All tests mock the FCM client and Firebase availability check so they
 run without Firebase credentials in CI.
@@ -8,7 +9,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from django.contrib.auth import get_user_model
-from wagtail_forum.models import ForumProfile
+from wagtail.models import Page
+from wagtail_forum.models import ForumBoard, ForumIndex, ForumProfile, Post, Topic
 
 User = get_user_model()
 
@@ -234,3 +236,230 @@ def test_send_forum_push_backoff_countdown_values(prior_retries, expected_countd
             send_forum_push.pop_request()
 
     assert mock_retry.call_args.kwargs["countdown"] == expected_countdown
+
+
+# ---- send_forum_email tests (todo 253 slice 2, H1) ---------------------------
+#
+# Unlike push, these assert on RENDERED EMAIL CONTENT (mail.outbox[0].subject /
+# .body), not just "an email was sent" — this is the one thing that catches
+# both latent bugs the wiring surfaced: the missing forum_reply.txt template
+# (silent no-op, TemplateDoesNotExist swallowed to False) and the
+# author_name/post_excerpt context-key mismatch (Django renders an undefined
+# var as '', shipping a blank-author blank-excerpt email that a bare
+# len(mail.outbox) == 1 assertion would not catch).
+
+
+def _make_reply(slug_prefix, author=None):
+    """Real (saved) board/topic/reply fixture, mirroring test_signals.py's
+    inline-boilerplate convention. Returns (topic_author, topic, post)."""
+    # Real emails matter here, not just usernames: EmailMessage.recipients()
+    # filters out a blank address, so a blank-email fixture user would make
+    # send_email() silently no-op (0 recipients) while still logging success.
+    topic_author = User.objects.create_user(
+        username=f"{slug_prefix}-topicowner",
+        email=f"{slug_prefix}-topicowner@example.com",
+    )
+    replier = author or User.objects.create_user(
+        username=f"{slug_prefix}-replier", email=f"{slug_prefix}-replier@example.com"
+    )
+
+    root = Page.objects.get(id=1)
+    index = root.add_child(instance=ForumIndex(title=slug_prefix, slug=slug_prefix))
+    board = index.add_child(
+        instance=ForumBoard(title=f"{slug_prefix}-board", slug=f"{slug_prefix}-board")
+    )
+    topic = Topic.objects.create(
+        board=board,
+        title="How to care for succulents?",
+        slug="succulents",
+        author=topic_author,
+    )
+    post = Post.objects.create(
+        topic=topic,
+        author=replier,
+        body=[
+            {
+                "type": "paragraph",
+                # Literal apostrophe + ampersand deliberately included: they're
+                # what caught the forum_reply.txt autoescape bug (Django
+                # escapes template vars in .txt renders exactly like .html;
+                # without {% autoescape off %} this shipped as "I&#x27;ve
+                # grown ... & thanks").
+                "value": "<p>Great question! I've grown succulents for years & thanks!</p>",
+            }
+        ],
+    )
+    return topic_author, board, topic, post
+
+
+@pytest.mark.django_db
+def test_send_forum_email_sends_reply_notification():
+    from apps.forum_host.tasks import send_forum_email
+    from django.core import mail
+
+    topic_author, board, topic, post = _make_reply("emailok")
+
+    send_forum_email("reply_added", topic_author.pk, {"post_id": str(post.pk)})
+
+    assert len(mail.outbox) == 1
+    sent = mail.outbox[0]
+    assert sent.to == [topic_author.email]
+    expected_url_path = f"/forum/{board.id}-{board.slug}/{topic.id}-{topic.slug}"
+    # The actual replier's display name and post excerpt must appear in BOTH
+    # alternatives — proves the author_name/post_excerpt context-key fix (the
+    # .txt body) AND the forum_preferences_url->preferences_url template fix
+    # (only reachable via the .html alternative), not just that SOME email
+    # with the right subject line went out.
+    assert post.author.display_name in sent.body
+    assert "Great question" in sent.body
+    # The .txt alternative must NOT HTML-entity-escape the apostrophe/ampersand
+    # — Django's autoescaping applies to .txt renders exactly like .html, so
+    # without {% autoescape off %} this shipped as "I&#x27;ve ... &amp;
+    # thanks!" in a PLAIN TEXT email. This is the one assertion the original
+    # fixture (no apostrophe/ampersand) couldn't catch.
+    assert "I've grown succulents for years & thanks!" in sent.body
+    assert "&#x27;" not in sent.body and "&amp;" not in sent.body
+    # The topic URL must resolve using the SAME board_id/slug the frontend's
+    # threadPath() routes on (matches web/src/utils/forumUrls.ts).
+    assert expected_url_path in sent.body
+
+    html_body = sent.alternatives[0][0]
+    assert sent.alternatives[0][1] == "text/html"
+    assert post.author.display_name in html_body
+    assert "Great question" in html_body
+    assert expected_url_path in html_body
+
+
+@pytest.mark.django_db
+def test_send_forum_email_skips_when_forum_notifications_off():
+    from apps.forum_host.tasks import send_forum_email
+    from django.core import mail
+
+    topic_author, _, _, post = _make_reply("emailoptout")
+    topic_author.forum_notifications = False
+    topic_author.save()
+
+    send_forum_email("reply_added", topic_author.pk, {"post_id": str(post.pk)})
+
+    assert mail.outbox == []
+
+
+@pytest.mark.django_db
+def test_send_forum_email_skips_for_nonexistent_user():
+    from apps.forum_host.tasks import send_forum_email
+    from django.core import mail
+
+    _, _, _, post = _make_reply("emailnouser")
+
+    send_forum_email("reply_added", 999999, {"post_id": str(post.pk)})
+
+    assert mail.outbox == []
+
+
+@pytest.mark.django_db
+def test_send_forum_email_skips_when_recipient_has_no_email():
+    from apps.forum_host.tasks import send_forum_email
+    from django.core import mail
+
+    topic_author, _, _, post = _make_reply("emailnoaddr")
+    topic_author.email = ""
+    topic_author.save()
+
+    # Must not raise, and must not silently claim success (this is the exact
+    # case EmailService.send_email() itself gets wrong — recipients() filters
+    # the blank address to zero, email.send() returns 0, but the caller logs
+    # "sent successfully" anyway since it never checks the return value).
+    send_forum_email("reply_added", topic_author.pk, {"post_id": str(post.pk)})
+
+    assert mail.outbox == []
+
+
+@pytest.mark.django_db
+def test_send_forum_email_skips_when_post_not_found():
+    from apps.forum_host.tasks import send_forum_email
+    from django.core import mail
+
+    topic_author, _, _, _ = _make_reply("emailnopost")
+
+    send_forum_email("reply_added", topic_author.pk, {"post_id": "999999"})
+
+    assert mail.outbox == []
+
+
+@pytest.mark.django_db
+def test_send_forum_email_skips_when_post_id_invalid():
+    from apps.forum_host.tasks import send_forum_email
+    from django.core import mail
+
+    topic_author, _, _, _ = _make_reply("emailbadid")
+
+    # Must not raise on a missing/non-numeric post_id — this is the same
+    # payload shape shared with send_forum_push, which never guarantees
+    # post_id is present or numeric. Exercises BOTH branches of
+    # `except (TypeError, ValueError)`: a missing key defaults to "" ->
+    # int("") raises ValueError; a key present with value None -> int(None)
+    # raises TypeError (dict.get's default only applies when the key is
+    # ABSENT, not when its value is None).
+    send_forum_email("reply_added", topic_author.pk, {})
+    send_forum_email("reply_added", topic_author.pk, {"post_id": "not-a-number"})
+    send_forum_email("reply_added", topic_author.pk, {"post_id": None})
+
+    assert mail.outbox == []
+
+
+@pytest.mark.django_db
+def test_send_forum_email_skips_unimplemented_event():
+    from apps.forum_host.tasks import send_forum_email
+    from django.core import mail
+
+    topic_author, _, _, post = _make_reply("emailunimpl")
+
+    # mention/moderation/digest emails are later slices of todo 253 — the
+    # task must no-op, not crash, until they're wired.
+    send_forum_email("mention_added", topic_author.pk, {"post_id": str(post.pk)})
+
+    assert mail.outbox == []
+
+
+@pytest.mark.django_db
+def test_send_forum_email_deleted_author_renders_bracket_deleted():
+    from apps.forum_host.tasks import send_forum_email
+    from django.core import mail
+
+    topic_author, _, _, post = _make_reply("emaildeleted")
+    # Mirrors the forum API serializer's own null-author convention
+    # (wagtail_forum/api/serializers.py: "display_name": "[deleted]").
+    post.author = None
+    post.save()
+
+    send_forum_email("reply_added", topic_author.pk, {"post_id": str(post.pk)})
+
+    assert len(mail.outbox) == 1
+    assert "[deleted]" in mail.outbox[0].body
+
+
+@pytest.mark.django_db
+def test_send_forum_email_retries_on_transient_db_error():
+    """A transient OperationalError during the Post fetch must autoretry, not
+    silently drop the email (docs/rules/celery.md: every network-touching task
+    declares retry config). Mirrors
+    test_send_forum_push_retries_transient_errors_until_exhausted's .apply()
+    pattern — proves autoretry_for=(OperationalError,) actually fires and
+    isn't dead config, the exact gap flagged when the original broad
+    try/except/self.retry() wrapper (which only ever wrapped the swallow-all
+    send call) was removed as untested dead code."""
+    from apps.forum_host.tasks import send_forum_email
+    from django.db import OperationalError
+
+    topic_author, _, _, post = _make_reply("emaildberror")
+
+    with patch.object(
+        Post.objects, "select_related", side_effect=OperationalError("connection lost")
+    ) as mock_select_related:
+        result = send_forum_email.apply(
+            args=("reply_added", topic_author.pk, {"post_id": str(post.pk)})
+        )
+
+    assert mock_select_related.call_count == 4  # initial attempt + max_retries=3
+    assert result.status == "FAILURE"
+    assert isinstance(result.result, OperationalError)

--- a/backend/packages/wagtail_forum/wagtail_forum/api/views.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/api/views.py
@@ -704,7 +704,7 @@ class MeProfileView(generics.RetrieveUpdateAPIView):
         return ForumProfile.for_user(self.request.user)
 
 
-def _plain_text_excerpt(stream_value, limit: int) -> str:
+def plain_text_excerpt(stream_value, limit: int) -> str:
     """Plain-text excerpt from a post body via ``raw_data``.
 
     Iterating the resolved StreamValue bulk-fetches image blocks PER POST —
@@ -767,7 +767,7 @@ class SearchView(APIView):
                         "topic_id": p.topic_id,
                         "topic_title": p.topic.title,
                         "excerpt": (
-                            _plain_text_excerpt(p.body, self.MAX_EXCERPT_CHARS)
+                            plain_text_excerpt(p.body, self.MAX_EXCERPT_CHARS)
                             if p.body
                             else ""
                         ),

--- a/backend/packages/wagtail_forum/wagtail_forum/models/topics.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/models/topics.py
@@ -100,3 +100,9 @@ class Topic(
 
     def __str__(self):
         return self.title
+
+    def get_absolute_url(self):
+        """Relative web route, matching web/src/utils/forumUrls.ts::threadPath
+        (/forum/{board.id}-{board.slug}/{topic.id}-{topic.slug}). Callers that
+        need an absolute link (e.g. an email) prepend settings.SITE_URL."""
+        return f"/forum/{self.board_id}-{self.board.slug}/{self.id}-{self.slug}"

--- a/backend/templates/emails/forum_reply.html
+++ b/backend/templates/emails/forum_reply.html
@@ -46,7 +46,7 @@
 
 <div style="text-align: center; margin-top: 32px;">
     <p style="font-size: 14px; color: #6c757d;">
-        <a href="{{ forum_preferences_url }}" style="color: #2c5f41; text-decoration: none;">Manage Forum Notifications</a>
+        <a href="{{ preferences_url }}" style="color: #2c5f41; text-decoration: none;">Manage Forum Notifications</a>
         | <a href="{{ topic_url }}#unsubscribe" style="color: #6c757d; text-decoration: none;">Unsubscribe from Topic</a>
     </p>
 </div>

--- a/backend/templates/emails/forum_reply.txt
+++ b/backend/templates/emails/forum_reply.txt
@@ -1,0 +1,14 @@
+{% autoescape off %}{{ site_name }} - New Reply in Forum
+
+{{ author_name }} replied to a topic you're following:
+
+{{ topic_title }}
+
+{{ post_excerpt }}
+
+Read the full discussion: {{ topic_url }}
+
+---
+Manage forum notifications: {{ preferences_url }}
+{% if unsubscribe_url %}Unsubscribe: {{ unsubscribe_url }}
+{% endif %}{% endautoescape %}

--- a/todos/253-in_progress-p1-forum-notifications-engagement.md
+++ b/todos/253-in_progress-p1-forum-notifications-engagement.md
@@ -74,7 +74,12 @@ Sequenced so each step ships value alone:
 
 - [ ] A reply to a subscribed topic produces an in-app notification visible via
       bell UI; mark-read works
-- [ ] The `forum_notifications` preference actually gates deliveries (email and push)
+- [x] The `forum_notifications` preference actually gates deliveries (email and push)
+      — satisfied for the reply vertical (the only wired one): push has
+      gated on it since before slice 1; slice 2 wires the reply email
+      through `EmailService._should_send_email`'s same
+      `user.forum_notifications` check. Mention/digest/new-topic emails
+      remain unwired (slices 3-4), so there's nothing to gate for those yet.
 - [ ] Reply/mention events fan out to subscribers/participants, not only the topic author
 - [ ] An @mention notifies the mentioned user and renders as a profile link
 - [ ] Topic lists show an unread/new indicator
@@ -283,7 +288,144 @@ Sequenced so each step ships value alone:
   a per-slice gate this codebase's convention requires (no Playwright spec
   exists for the forum bell; `web/CLAUDE.md` excludes E2E from CI already).
 
+### 2026-07-14 - Slice 2 (H1: wire the orphaned reply-notification email) shipped
+
+- **Scope decision (user-approved).** The todo's slice-2 line named
+  "reply/mention/digest"; exploration showed only **reply** is wirable now —
+  mention needs slice 4's @mention parsing, new-topic needs slice 3's
+  subscriber list, and digest needs a `CELERY_BEAT_SCHEDULE` that doesn't
+  exist anywhere in the project. Reply-only ships value alone, matching the
+  epic's own staged design; the other three stay orphaned pending their
+  prerequisite slices.
+- **Two latent bugs found before any wiring, both fixed as part of this
+  slice** (the email path had zero callers, so was never integration-tested):
+  1. **Missing `.txt` template (app-wide gap, one instance fixed here).**
+     `EmailService.send_email` renders `.html` AND `.txt` unconditionally;
+     `TemplateDoesNotExist` is swallowed to a silent `return False`. The repo
+     had 13 `.html`, 0 `.txt` templates. Added `forum_reply.txt`; the other
+     10 templates' gap is now todo 267.
+  2. **Template context-variable mismatch.** `forum_reply.html` referenced
+     `{{ author_name }}`/`{{ post_excerpt }}`/`{{ forum_preferences_url }}`;
+     the sender's context dict supplied `reply_author`/`reply_excerpt` (base
+     context supplies `preferences_url`, not the `forum_`-prefixed name).
+     Django renders an undefined var as `''` — this shipped a
+     blank-author/blank-excerpt email that a bare outbox-count assertion
+     would not catch. Fixed both sides to match; verified a second instance
+     of the same bug class exists in `send_identification_result_notification`
+     (unrelated to forum, filed in todo 267, not fixed here).
+- **Delivery design**: mirrors slice 1's push pattern exactly — new
+  `send_forum_email` Celery task, enqueued via `transaction.on_commit`
+  alongside the existing `_enqueue_push` in `forum_host/notifications.py`'s
+  `reply_added` branch (both registered only after the Notification-row
+  write commits, per the existing "except must sit outside atomic()" forum
+  rule). The email is a parallel `EMAIL`-only channel — no second in-app
+  `Notification` row, no migration. Preference gating (`forum_notifications`)
+  is enforced once, inside `EmailService._should_send_email`, not
+  re-duplicated in the task (single source of truth, deliberate).
+- **Verification**:
+  - Backend: `pytest apps/forum_host/tests/ packages/wagtail_forum/wagtail_forum/tests/
+    -q --create-db` → `302 passed` (was 287 at slice-1 baseline; +15: 9 new
+    `send_forum_email` task tests, 1 new signal-level enqueue test, 3
+    existing push tests got a defensive `send_forum_email.delay` mock with
+    no new assertions — Celery `CELERY_TASK_ALWAYS_EAGER` defaults `False`
+    with no test override, so an unmocked `.delay()` in those tests'
+    `django_capture_on_commit_callbacks(execute=True)` blocks would have
+    attempted a real broker publish; 2 test-quality fixes from review).
+  - `manage.py check` → "System check identified no issues (0 silenced)."
+  - `manage.py makemigrations --check --dry-run` → "No changes detected."
+  - Content-level assertions (not just outbox length) on both the `.txt` AND
+    `.html` alternatives — the one test design that actually catches both
+    latent bugs above; a fixture with an apostrophe + ampersand was added
+    specifically to catch the autoescape bug found in review (below).
+- **Code review** (code-review-orchestrator + bundled `/code-review --effort
+  high`, 10 finder angles + verification + gap sweep, run in parallel): the
+  orchestrator found 0 critical/high/medium (2 low/info, one already
+  addressed). The deep pass surfaced ~24 raw candidates across 10 angles,
+  several independently corroborated 2-3x. Consulted the advisor to triage
+  scope before repairing (bar: fix real bugs and rule violations touching
+  code this diff introduced; defer pre-existing cross-cutting issues to a
+  todo; never drift into unrelated files). Fixed:
+  - **[bug, confirmed empirically]** `forum_reply.txt` had no
+    `{% autoescape off %}` — Django's autoescaping applies to `.txt` renders
+    identically to `.html` (not extension-aware), so a reply containing an
+    apostrophe or ampersand rendered as `O&#x27;Brien`/`Marks &amp; Spencer`
+    in a PLAIN TEXT email. Reproduced directly via `render_to_string` before
+    fixing. Fixed with `{% autoescape off %}` (safe — plain text, and the
+    excerpt is already `strip_tags`'d); strengthened the test fixture with a
+    real apostrophe + ampersand so a regression fails the content assertion.
+  - **[rule violation, docs/rules/celery.md]** The task shipped as a bare
+    `@shared_task` (retry wrapper removed as dead code — see below). A
+    conventions-focused reviewer pass correctly distinguished: the removal
+    was right for the *send* call (swallows everything internally, can't
+    raise) but wrong to leave the whole task with zero retry config, since
+    `User.objects.get()`/`Post.objects.get()` CAN raise `OperationalError` on
+    a transient DB blip and that would silently drop the notification with
+    no retry — a real, if narrow, gap the binding "every task declares retry
+    config" rule exists to prevent. Fixed with the declarative form
+    (`autoretry_for=(OperationalError,), retry_backoff=True, max_retries=3`)
+    — narrower and cleaner than hand-rolled `self.retry()`, and the inner
+    `DoesNotExist`/`ValueError`/`TypeError` branches return early first so
+    autoretry only ever fires on the one genuine transient class. Added a
+    dedicated test (mirrors `test_send_forum_push_retries_transient_errors_until_exhausted`'s
+    `.apply()` pattern) proving it isn't dead config.
+  - **[maintainability, 3x independent]** `_plain_text_excerpt` in
+    `wagtail_forum/api/views.py` is a leading-underscore "private" helper
+    that this task now imports across the package/host-app boundary — a
+    silent rename there would ImportError at Celery runtime with no
+    review-time signal. Promoted to `plain_text_excerpt` (public), updated
+    its one in-package caller.
+  - **[duplication, 2x independent, verified]** The `f"{SITE_URL}/forum/{board.id}-..."`
+    URL-building f-string duplicated a private closure already in
+    `apps/users/views.py` (`_forum_topic_url`, dashboard recent-activity
+    feed) — confirmed byte-for-byte identical path shape. Added
+    `Topic.get_absolute_url()` to the `wagtail_forum` package (the
+    idiomatic Django home for it) and used it here; did NOT touch
+    `apps/users/views.py` — the advisor's scope line was "touch another file
+    when your change creates a new dependency on it, not because it
+    duplicates something," and the dashboard closure works and is unrelated
+    to forum notifications. Future mention/digest slices needing the same
+    URL now have a canonical method to call instead of re-deriving the
+    f-string a third time.
+  - **[test-quality, cheap]** An invalid-`post_id` test exercised the same
+    `ValueError` branch twice (missing key, non-numeric string), leaving the
+    `except (TypeError, ValueError)` clause's `TypeError` half uncovered
+    (`{"post_id": None}` → `int(None)` raises `TypeError`, since `dict.get`'s
+    default only applies when the key is absent, not when its value is
+    `None`). Added the missing case. Also fixed 2 tests that unpacked
+    `board, topic` from the shared fixture but never used them, inconsistent
+    with the file's own `_`-discard convention.
+  - **Declined (with reasoning, matching the advisor's read)**: the
+    near-identical `_enqueue_push`/`_enqueue_email` closures in
+    `notifications.py` (3x independent flags) — a factory function for two
+    call sites is more indirection than two explicit closures, and
+    `moderation_decided`'s enqueue in the same file is already inline,
+    matching the file's own explicit-over-abstracted convention. The
+    preference-gate running after the Post fetch/excerpt render, not before
+    (2x independent flags) — deliberate single-source-of-truth design
+    (`EmailService._should_send_email` is the one place that decides "does
+    this user get a forum email"); re-checking in the task duplicates that
+    logic across two layers for a negligible cost (one indexed PK read +
+    in-memory string ops, not a network call). The stale
+    `backend/test_email_templates.py` manual script (3x independent flags,
+    now silently "passes" with blank content) and the broader `EmailService`
+    systemic issues (ignored `email.send()` return value, 10 more missing
+    `.txt` templates, a second context-key mismatch instance in
+    `send_identification_result_notification`) — all pre-existing,
+    cross-cutting, unrelated to this diff's own correctness; filed as todo
+    267 rather than expanding this slice's scope.
+  - Re-verified after every fix: `302 passed` (was 301 pre-fix, +1 for the
+    new retry test), `manage.py check`/`makemigrations --check` both clean.
+- **AC boxes**: AC2 flipped — `forum_notifications` now gates both push
+  (already true since before slice 1) and email (this slice) for the reply
+  vertical, the only wired one. AC1/AC3 (subscriptions) and AC4 (mentions)
+  still await slices 3-4; AC5 (unread indicators) awaits slice 5; AC6 (FCM
+  registration) is the residue item.
+- Not archived — 4 slices remain (H3+H2, H4, H10, FCM residue). Todo stays
+  `in_progress`.
+
 ## Notes
 
 p1 by user triage decision. C2 (one of only two Critical findings) anchors this
 epic. Related: todo 260 (mobile client) owns the Flutter FCM registration half.
+Related: todo 267 (filed 2026-07-14 from this slice's code review) tracks the
+`EmailService` systemic silent-failure modes found but out of scope here.

--- a/todos/267-pending-p2-email-service-silent-failure-modes.md
+++ b/todos/267-pending-p2-email-service-silent-failure-modes.md
@@ -1,0 +1,165 @@
+---
+status: pending
+priority: p2
+issue_id: "267"
+tags: [backend, email, notifications, reliability]
+dependencies: []
+---
+
+# EmailService: silent-failure modes affect every templated email, app-wide
+
+## Problem
+
+Implementing todo 253 slice 2 (wiring the forum reply-notification email)
+surfaced that `apps/core/services/email_service.py::EmailService` has three
+compounding defects that make it silently report success when an email did
+not actually reach an inbox — and these are NOT forum-specific. They affect
+every `EmailType` this service sends: welcome email, plant care reminders,
+disease alerts, seasonal care, blog posts, newsletters, identification
+results, and forum reply/mention/digest/new-topic.
+
+The forum-reply path (todo 253 slice 2) is now guarded against the worst
+instance of this (a blank-email recipient — see `apps/forum_host/tasks.py`'s
+`if not user.email:` check), but every OTHER caller of `EmailService` still
+has the full exposure.
+
+## Findings
+
+All three were found via multi-angle code review of the todo 253 slice 2 diff
+(`/code-review --effort high`, 2026-07-14), not a formal audit — no
+`source_review` doc exists to link.
+
+1. **`send_email()` ignores `email.send()`'s return value.**
+   `apps/core/services/email_service.py:148` calls `email.send()` but never
+   checks the returned int. Django's `EmailMessage.send()` returns `0`
+   (without raising) when `EmailMessage.recipients()` filters every address
+   to empty — e.g. a user with a blank `.email` field. `send_email()` still
+   runs `_track_email_sent(...)`, logs "sent successfully", and returns
+   `True` for a message that reached zero inboxes.
+   - **Concrete data-corruption path**: `PlantCareReminderService.send_reminder()`
+     (`apps/plant_identification/services/plant_care_reminder_service.py:158-168`)
+     calls `reminder.mark_reminder_sent()` and advances `next_reminder_date`
+     on that same false `True` — a user with an email issue silently never
+     gets reminded again, with no error anywhere.
+   - This is also *why* `send_forum_email` (todo 253 slice 2) ships with no
+     retry around the send call itself: `send_email()`'s internal swallowing
+     of `ConnectionError`/`TemplateDoesNotExist`/blanket `Exception` means
+     nothing ever reaches a caller as a raised exception on that path.
+
+2. **10 of 11 `EmailType` templates have no `.txt` counterpart.**
+   `send_email()` unconditionally renders both `emails/{template}.html` AND
+   `emails/{template}.txt` (`email_service.py:123-124`); a missing `.txt`
+   raises `TemplateDoesNotExist`, caught and turned into a silent `return
+   False` (`:125-127`). Before todo 253 slice 2 added `forum_reply.txt`,
+   **zero** `.txt` files existed; now there is exactly one. Still missing:
+   `welcome_email.txt`, `plant_care_reminder.txt`, `disease_alert.txt`,
+   `seasonal_care.txt`, `blog_post.txt`, `newsletter.txt`,
+   `identification_result.txt`, `generic_notification.txt`,
+   `forum_mention.txt`, `forum_digest.txt`, `new_forum_topic.txt`.
+   `send_welcome_email_on_verification` (`apps/users/signals.py:25-36`) is
+   wired to allauth's real `email_confirmed` signal — every new-user welcome
+   email has been silently no-op-ing at the render step.
+
+3. **The same context-key mismatch bug class exists at least once more.**
+   Todo 253 slice 2 found and fixed one instance (forum_reply's
+   `author_name`/`post_excerpt` vs the sender's old `reply_author`/
+   `reply_excerpt` keys). A second, independent instance: `send_identification_result_notification`
+   (`apps/core/services/notification_service.py` ~line 316-345) supplies
+   `{plant_name, confidence, confidence_percent, identifier_name, result_url}`,
+   but `identification_result.html` actually references `{{ confidence_text }}`,
+   `{{ scientific_name }}`, `{{ care_guide_url }}`, `{{ forum_url }}`,
+   `{{ plant_image_url }}` — none of which are ever supplied. Django renders
+   an undefined var as `''`, so this ships a mostly-blank identification
+   email while `send_email` still logs/returns success. No test exercises
+   this render path.
+
+4. **Manual smoke-test script is stale and now gives false-positive results.**
+   `backend/test_email_templates.py` (a standalone script, not pytest-collected,
+   run manually via `python test_email_templates.py`) still builds the
+   `forum_reply` context with the pre-slice-2 `reply_author`/`reply_excerpt`
+   keys. Before slice 2, it failed loudly (`TemplateDoesNotExist` — no
+   `.txt`). After slice 2, `forum_reply.txt` exists but the script's keys
+   don't match the template's `author_name`/`post_excerpt` vars, so it now
+   prints a green "✅ Forum Reply Notification" for a render with a blank
+   author name and blank excerpt — the script's only check is a minimum
+   content-length threshold, satisfied by template boilerplate. This is
+   exactly the tool a developer would manually run to sanity-check templates,
+   giving a false all-clear for the defect class findings 1-3 describe.
+
+## Recommended Action
+
+Sequenced cheapest/highest-impact first:
+
+1. **Fix `send_email()`'s ignored return value** (finding 1) — check
+   `email.send()`'s return count; treat `0` as a failure (log + return
+   `False`), not a success. This is the root fix; it also means removing the
+   `apps/forum_host/tasks.py` `if not user.email:` guard becomes safe later
+   (though leave it — cheap, explicit, no reason to remove).
+2. **Audit `PlantCareReminderService.send_reminder()`'s blast radius** —
+   confirm no reminders have been silently "consumed" (marked sent,
+   `next_reminder_date` advanced) for users with a bad email, and decide
+   whether a backfill/re-notify is needed for affected users.
+3. **Add the 10 missing `.txt` templates**, OR make `send_email()` tolerate
+   a missing `.txt` (e.g. a `strip_tags(html_content)` fallback) so a future
+   new `EmailType` can't reintroduce this — the fallback approach is more
+   defensive and doesn't require hand-authoring 10 files.
+4. **Fix `send_identification_result_notification`'s context-key mismatch**
+   (finding 3) — align context dict keys to `identification_result.html`'s
+   actual vars, add a render-content test (assert plant name/confidence
+   actually appear, not just `len(mail.outbox) == 1`), mirroring the pattern
+   `apps/forum_host/tests/test_tasks.py::test_send_forum_email_sends_reply_notification`
+   established.
+5. **Fix or retire `backend/test_email_templates.py`** (finding 4) — either
+   update its context dicts to match current template vars (cheap), or
+   replace it with real pytest coverage (assert-on-content, per the pattern
+   in finding 4 above) and delete the manual script.
+
+## Technical Details
+
+- `apps/core/services/email_service.py` — `send_email()` (line 64),
+  `_should_send_email()` (line 230), template render (lines 123-127).
+- `apps/core/services/notification_service.py` — `_get_email_template_for_type`
+  (line 237) maps `EmailType` → template base name; every `send_*_notification`
+  method builds its own context dict by hand (no schema/dataclass ties a
+  sender's context keys to its template's actual vars — this is *why* the
+  mismatch class keeps recurring; consider a lightweight assertion or a
+  shared dataclass-per-template as a structural fix, not just per-instance patches).
+- `apps/plant_identification/services/plant_care_reminder_service.py:158-168`
+  — the concrete data-loss caller for finding 1.
+- Precedent for the "assert on rendered content, not send-count" test pattern:
+  `apps/forum_host/tests/test_tasks.py` (todo 253 slice 2).
+
+## Acceptance Criteria
+
+- [ ] `send_email()` returns `False` (and logs) when `email.send()` reports
+      zero recipients delivered
+- [ ] `PlantCareReminderService`'s false-success blast radius investigated;
+      remediation decided (backfill or accepted as low-impact)
+- [ ] Every `EmailType` template renders both `.html` and `.txt` without
+      `TemplateDoesNotExist` (test: loop `EmailType` values, assert both
+      templates render)
+- [ ] `send_identification_result_notification`'s context keys match
+      `identification_result.html`'s actual vars, with a content-assertion test
+- [ ] `backend/test_email_templates.py` either fixed to use current context
+      keys or retired in favor of real pytest coverage
+
+## Work Log
+
+### 2026-07-14 - Created from todo 253 slice 2 code review
+
+- Surfaced via `/code-review --effort high` + `code-review-orchestrator` on
+  the todo-253 slice-2 diff (forum reply-email wiring). All 3 findings are
+  pre-existing in shared `EmailService`/`NotificationService` code, not
+  introduced by that diff — the diff's own new caller
+  (`apps/forum_host/tasks.py::send_forum_email`) is already guarded against
+  finding 1's worst case (blank email) and ships its own `.txt` template
+  (finding 2, one of eleven) and correct context keys (finding 3, the first
+  fixed instance of that bug class).
+
+## Notes
+
+p2: no active security hole, no live user-reported incident — a latent
+silent-failure class found via code review. Finding 1 (ignored return value)
+is the highest-impact single fix; do it first even if the rest is deferred
+further. Related: todo 253 (forum notifications epic) is the origin context;
+this todo is intentionally scoped to `EmailService` broadly, not forum-specific.


### PR DESCRIPTION
## Summary

Slice 2 of the [forum notifications epic](todos/253-in_progress-p1-forum-notifications-engagement.md) (H1) — wires the previously-orphaned `send_forum_reply_notification` email sender into the `reply_added` signal path, via a new `send_forum_email` Celery task enqueued through `transaction.on_commit` alongside the existing push (mirrors slice 1's pattern exactly). Reply-only: mention needs slice 4's @mention parsing, new-topic needs slice 3's subscriber list, digest needs a `CELERY_BEAT_SCHEDULE` that doesn't exist anywhere in the project.

- Two latent bugs surfaced by wiring a previously-zero-caller path: a missing `forum_reply.txt` template (every templated email silently no-ops without one — Django's `TemplateDoesNotExist` is swallowed to `return False`) and a context-key mismatch between the sender's dict and the template's vars (Django renders an undefined var as `''`, shipping blank author/excerpt). Both fixed.
- Code review (bundled `/code-review --effort high`, 10 finder angles + verify + gap sweep, plus `code-review-orchestrator`) found and fixed: an autoescape gap in the new `.txt` template (Django escapes `.txt` renders identically to `.html`, so an apostrophe/ampersand shipped as `O&#x27;Brien`/`&amp;` in a plain-text email — reproduced empirically before fixing), a `docs/rules/celery.md` retry-config violation (the task's DB fetches can raise `OperationalError` with no retry — fixed with `autoretry_for=(OperationalError,)`), and promoted a cross-package "private" helper import to public.
- `AC2` flipped in the epic todo — `forum_notifications` now gates both push and email for the reply vertical.
- Filed [todo 267](todos/267-pending-p2-email-service-silent-failure-modes.md) (p2) for pre-existing, cross-cutting `EmailService` bugs found during review but out of scope here (most notably: `send_email()` ignores `email.send()`'s return value, so a zero-recipient send still logs/returns success — with a concrete data-loss path through `PlantCareReminderService`).

## Test plan

- [x] `pytest apps/forum_host/tests/ packages/wagtail_forum/wagtail_forum/tests/ -q --create-db` → 302 passed (slice-1 baseline 287 + 15 new/updated)
- [x] `manage.py check` → clean
- [x] `manage.py makemigrations --check --dry-run` → "No changes detected" (no migration — email is a parallel `EMAIL`-only channel)
- [x] Content-level assertions (not just outbox length) on both `.txt` and `.html` alternatives, including a fixture with an apostrophe + ampersand that specifically guards the autoescape fix
- [x] New retry test proves `autoretry_for=(OperationalError,)` actually fires (mirrors `send_forum_push`'s `.apply()` exhaustion-test pattern), not dead config

🤖 Generated with [Claude Code](https://claude.com/claude-code)