### PR TITLE
docs: codify get_or_create/IntegrityError finding from forum slice 5

### DIFF
--- a/.claude/agents/django-drf-reviewer.md
+++ b/.claude/agents/django-drf-reviewer.md
@@ -52,6 +52,18 @@ Work through each item for every changed file. Emit findings in the structured f
   (todo 253 slice 1); caught only by kimi-review's commit gate afterward. See
   `backend/docs/patterns/architecture/services.md`.
 
+### Forum notifications slice 5 additions (2026-07-16)
+
+- A hand-rolled `except IntegrityError: cls.objects.get(...)` fallback around
+  `get_or_create`/`update_or_create`: check whether it duplicates Django's own
+  internal retry (verified in Django 6 — `get_or_create` already retries its
+  own `.get()` after a failed `create()` and only re-raises when that retry
+  ALSO fails) rather than assuming the fallback is always needed. A redundant
+  wrapper only ever fires in the already-unrecoverable case, converting a
+  clean `IntegrityError` into a confusing masked `DoesNotExist`
+  (`wagtail_forum/models/topic_reads.py`, todo 253 slice 5 follow-up). See
+  `backend/docs/patterns/architecture/services.md` and `docs/rules/database.md`.
+
 ## Output Format (Review Mode)" below — do not write prose
 
 ### LSP Workflow (run before the checklist)

--- a/backend/docs/patterns/architecture/services.md
+++ b/backend/docs/patterns/architecture/services.md
@@ -807,3 +807,70 @@ after the `try/except`. Test it directly — mock the write to raise and assert
 the side-effect's `.delay()`/callable was never called (see
 `test_reply_added_skips_push_when_notification_write_fails` in
 `apps/forum_host/tests/test_signals.py`).
+
+---
+
+### Pattern: Don't Re-Wrap `get_or_create`/`update_or_create`'s Own Race Recovery
+
+**Problem**: this package's house convention (`ForumProfile.for_user`,
+`TopicSubscription.subscribe`/`unsubscribe`) wraps `update_or_create`/
+`get_or_create` in an explicit `except IntegrityError: cls.objects.get(...)`
+fallback, on the assumption that a concurrent duplicate-insert race needs
+manual recovery. In Django 6 (verified against `QuerySet.get_or_create`/
+`_create_object_from_params`/`update_or_create` source, todo 253 slice 5
+follow-up), this is already handled internally: `get_or_create` catches its
+own `create()`'s `IntegrityError`, retries its own `.get()`, and only
+re-raises the *original* `IntegrityError` if that retry ALSO finds nothing.
+`update_or_create` delegates to `get_or_create`, so it inherits the same
+behavior. A caller-added fallback on top can therefore only ever run in the
+case Django has already determined is unrecoverable (not a race — e.g. a
+stale FK reference) — and in that case its own `.get()` finds nothing either,
+turning an already-correctly-typed `IntegrityError` into a confusing masked
+`DoesNotExist`.
+
+**Incorrect** ❌ (the pre-fix shape of `TopicRead.mark_read`,
+`wagtail_forum/models/topic_reads.py`):
+
+```python
+try:
+    obj, _ = cls.objects.update_or_create(
+        user=user, topic_id=topic_id, defaults={"last_read_at": when}
+    )
+except IntegrityError:
+    # Only ever reached when Django's OWN internal retry already failed —
+    # this .get() finds nothing either, raising DoesNotExist chained onto
+    # the original IntegrityError instead of just letting it propagate.
+    obj = cls.objects.get(user=user, topic_id=topic_id)
+    obj.last_read_at = when
+    obj.save(update_fields=["last_read_at"])
+```
+
+**Correct** ✅:
+
+```python
+obj, created = cls.objects.get_or_create(
+    user=user, topic_id=topic_id, defaults={"last_read_at": when}
+)
+# A genuine failure (e.g. a hard-deleted topic_id) now surfaces as the
+# original, correctly-typed IntegrityError — no masking.
+```
+
+**Verification trap**: the first attempt to reproduce the "unrecoverable"
+case wrapped the probe in its own outer `transaction.atomic()` + a savepoint
+rolled back afterward (this repo's usual safe-manual-check convention) and
+observed **no exception at all**. This project's FK constraints are
+`DEFERRABLE INITIALLY DEFERRED` (`pg_constraint.condeferred = True`) — the
+check runs at the enclosing transaction's real **commit**, and a savepoint
+rollback never commits. The same blind spot means an ordinary
+`@pytest.mark.django_db` test (itself one big rolled-back transaction)
+**cannot observe a deferred FK violation raising mid-test either** — verify
+this kind of "does this raise immediately" question with a probe that has no
+outer atomic of its own (letting `get_or_create`'s internal `atomic()` be
+the real top-level transaction), not a wrapped-and-rolled-back one.
+
+**Rule**: before adding (or keeping) a defensive `except IntegrityError:`
+retry around `get_or_create`/`update_or_create`, check whether the exact
+pinned Django version already retries internally — re-implementing that
+recovery outside it doesn't add safety, it adds a second layer that only
+ever activates in the unrecoverable case and actively degrades the
+exception's clarity. Full trail: `docs/LEARNINGS.md` (2026-07-16).

--- a/backend/docs/patterns/architecture/services.md
+++ b/backend/docs/patterns/architecture/services.md
@@ -845,14 +845,18 @@ except IntegrityError:
     obj.save(update_fields=["last_read_at"])
 ```
 
-**Correct** ✅:
+**Correct** ✅ (this snippet shows only the IntegrityError fix in isolation —
+`get_or_create` alone does NOT update `last_read_at` on an existing row, so
+the real method still needs its own follow-up update for a repeat read; see
+`wagtail_forum/models/topic_reads.py` for the full monotonic version):
 
 ```python
 obj, created = cls.objects.get_or_create(
     user=user, topic_id=topic_id, defaults={"last_read_at": when}
 )
 # A genuine failure (e.g. a hard-deleted topic_id) now surfaces as the
-# original, correctly-typed IntegrityError — no masking.
+# original, correctly-typed IntegrityError — no masking. `created` still
+# needs handling for the update case (omitted here — see the real file).
 ```
 
 **Verification trap**: the first attempt to reproduce the "unrecoverable"

--- a/docs/rules/database.md
+++ b/docs/rules/database.md
@@ -57,6 +57,18 @@ Compact checklist auto-injected before edits. Long-form:
   is what makes the check-then-write atomic (e.g. stops an edit's `publish()` from
   resurrecting a concurrently-unpublished row). Catch the exception OUTSIDE the
   `atomic()`, not inside (a caught DB error inside poisons the connection).
+- **Don't wrap `get_or_create`/`update_or_create` in your own
+  `except IntegrityError: .get()` fallback without checking Django's own
+  internals first.** Both already retry their own internal `.get()` once
+  after a failed `create()` and only let `IntegrityError` propagate when that
+  retry ALSO finds nothing — i.e. a genuinely unrecoverable failure (FK
+  violation, etc.), not a lost create-race. A caller-added fallback on top
+  only ever fires in that unrecoverable case, converting an already
+  correctly-typed `IntegrityError` into a confusing masked `DoesNotExist`
+  instead of a safety net. Verify against the exact Django version in
+  `requirements.txt` before assuming — don't take this file's word for it
+  either. See `backend/docs/patterns/architecture/services.md` and
+  `docs/LEARNINGS.md` (2026-07-16) for the full empirical trail.
 - **A `select_for_update().get(pk=…)` re-fetch can itself raise `DoesNotExist`** if
   the row was hard-deleted (e.g. a CASCADE) between the first fetch and the lock.
   In a request handler, catch it and return 404 — do NOT let a blanket

--- a/docs/rules/triggers.json
+++ b/docs/rules/triggers.json
@@ -497,5 +497,20 @@
     "source": "codify: feat/forum-notifications-slice4-mentions",
     "added": "2026-07-14",
     "severity": "warn"
+  },
+  {
+    "id": "redundant-integrityerror-fallback",
+    "domains": [
+      "database"
+    ],
+    "path_glob": [
+      "backend/**/*.py"
+    ],
+    "content_present": "(get_or_create|update_or_create)\\([\\s\\S]*?except\\s+IntegrityError",
+    "message": "except IntegrityError wrapping get_or_create/update_or_create — Django already retries its own .get() internally and only re-raises when that retry ALSO fails; a redundant wrapper masks a clean IntegrityError as a confusing DoesNotExist. Verify against requirements.txt Django version before assuming a fallback is needed.",
+    "pattern_ref": "backend/docs/patterns/architecture/services.md",
+    "source": "todo 253 slice 5 follow-up",
+    "added": "2026-07-16",
+    "severity": "warn"
   }
 ]

--- a/scripts/inject/test_match_triggers.py
+++ b/scripts/inject/test_match_triggers.py
@@ -417,6 +417,28 @@ class TestRealIndexFiresOnKnownBugs(unittest.TestCase):
             "escape-search-query-before-orm-wildcard-lookup", self.fires(tn, ti)
         )
 
+    def test_redundant_integrityerror_fallback_fires(self):
+        tn, ti = write(
+            "backend/apps/forum_integration/models.py",
+            "try:\n"
+            "    obj, _ = cls.objects.update_or_create(\n"
+            "        user=user, topic_id=topic_id, defaults={'last_read_at': when}\n"
+            "    )\n"
+            "except IntegrityError:\n"
+            "    obj = cls.objects.get(user=user, topic_id=topic_id)\n",
+        )
+        self.assertIn("redundant-integrityerror-fallback", self.fires(tn, ti))
+
+    def test_get_or_create_with_no_fallback_silent(self):
+        # No except IntegrityError at all — nothing to double-check.
+        tn, ti = write(
+            "backend/apps/forum_integration/models.py",
+            "obj, created = cls.objects.get_or_create(\n"
+            "    user=user, topic_id=topic_id, defaults={'last_read_at': when}\n"
+            ")\n",
+        )
+        self.assertNotIn("redundant-integrityerror-fallback", self.fires(tn, ti))
+
     def test_tiptap_renderhtml_without_mergeattributes_fires(self):
         tn, ti = write(
             "web/src/components/forum/forumMentionNode.ts",


### PR DESCRIPTION
## Summary

Codifies one genuinely new pattern discovered while resolving PR #468's self-review follow-up (todo 253 slice 5): Django 6's `get_or_create`/`update_or_create` already retry their own internal `.get()` after a failed `create()` and only re-raise the original `IntegrityError` when that retry also fails — so this package's established house convention of wrapping them in a defensive `except IntegrityError: .get()` fallback can, in the one case it's still reachable, convert an already-correctly-typed `IntegrityError` into a confusing masked `DoesNotExist` instead of adding safety.

Ran `/codify` against the full slice-5 diff (`79ba5c4...HEAD`, since the feature branch was already merged) plus a fresh `kimi-review` pass over it. Most WARNING findings from that pass were verified false positives or already-fixed/stale (checked each against the actual current code before deciding, not taken at face value) — only this one held up as a real, not-yet-documented pattern.

## Changes

- `docs/rules/database.md` — terse always/never rule (auto-injected before DB-domain edits)
- `backend/docs/patterns/architecture/services.md` — full pattern writeup: problem, incorrect/correct code shapes, the verification trap that produced a false negative on the first attempt (this project's `DEFERRABLE INITIALLY DEFERRED` FK constraints + a rollback-only savepoint suppressing the very check being tested)
- `.claude/agents/django-drf-reviewer.md` — new checklist item so future reviews catch this
- `docs/rules/triggers.json` + `scripts/inject/test_match_triggers.py` — a write-time trigger (fires on `get_or_create`/`update_or_create` co-occurring with `except IntegrityError`) plus a positive/negative fixture pair

The second commit is a same-day fixup: this branch's own `kimi-review` commit gate caught that the pattern doc's simplified "Correct" code example, read in isolation, could be mistaken for the complete method (`get_or_create` alone doesn't update an existing row) — clarified with a pointer to the real file.

## Test plan

- [x] `python3 scripts/inject/test_match_triggers.py` — 40 passed (38 existing + 2 new fixtures)
- [x] `kimi-review` commit gate — clean on both commits (one WARNING on the first commit addressed in the second, see above)
- Docs-only change; no backend/frontend test suite impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)