### PR TITLE
chore: archive legacy backend/todos (007 completed; 061/090/091 stale)

### DIFF
--- a/backend/todos/README.md
+++ b/backend/todos/README.md
@@ -1,5 +1,7 @@
 # Code Review Todos - Week 3 Quick Wins
 
+> **Archived 2026-07-16**: This legacy todo system is closed — all files now live in `archive/`. Active todos are tracked in the repo-root `todos/`. Everything below is historical.
+
 **Generated:** October 22, 2025
 **Review Type:** Comprehensive multi-agent code review
 **Agents Deployed:** 7 specialized reviewers
@@ -32,6 +34,7 @@
 ## Priority 1 (CRITICAL) - Fix Within 24 Hours
 
 ### 001: Rotate Exposed API Keys 🔴 CRITICAL
+
 - **File:** `001-pending-p1-rotate-exposed-api-keys.md`
 - **Category:** Security
 - **Effort:** 30 minutes
@@ -39,6 +42,7 @@
 - **Action:** Rotate Plant.id, PlantNet, SECRET_KEY, JWT_SECRET_KEY
 
 ### 002: Fix Insecure SECRET_KEY Default 🔴 CRITICAL
+
 - **File:** `002-pending-p1-fix-secret-key-default.md`
 - **Category:** Security
 - **Effort:** 15 minutes
@@ -46,6 +50,7 @@
 - **Action:** Fail fast in production if SECRET_KEY not set
 
 ### 003: Fix Lock Release Error Handling 🔴 CRITICAL
+
 - **File:** `003-pending-p1-lock-release-error-handling.md`
 - **Category:** Data Integrity
 - **Effort:** 15 minutes
@@ -53,6 +58,7 @@
 - **Action:** Wrap lock.release() in try/except with logging
 
 ### 004: Add File Upload Validation 🔴 CRITICAL
+
 - **File:** `004-pending-p1-file-upload-validation.md`
 - **Category:** Security
 - **Effort:** 1 hour
@@ -60,6 +66,7 @@
 - **Action:** Add python-magic for file magic byte validation
 
 ### 005: Add Missing Type Hints 🔴 BLOCKER
+
 - **File:** `005-pending-p1-add-missing-type-hints.md`
 - **Category:** Code Quality
 - **Effort:** 1 hour
@@ -75,6 +82,7 @@
 The comprehensive review found **49 additional findings** across 7 specialized agents:
 
 ### High Priority (11 findings) - Fix Within 1 Week
+
 - PlantNet service missing circuit breaker
 - Permission classes not environment-aware enough
 - Lock timeout values may be too short
@@ -88,6 +96,7 @@ The comprehensive review found **49 additional findings** across 7 specialized a
 - Load testing with 50-100 concurrent users
 
 ### Medium Priority (18 findings) - Fix Within 2 Weeks
+
 - Inconsistent import order
 - Constants not used consistently
 - Logging not following own standards
@@ -104,6 +113,7 @@ The comprehensive review found **49 additional findings** across 7 specialized a
 - And more...
 
 ### Low Priority (14 findings) - Nice-to-Have
+
 - Extract image processing utility
 - Add BaseAPIService abstract class
 - Complete type hints for private methods
@@ -120,6 +130,7 @@ The comprehensive review found **49 additional findings** across 7 specialized a
 ### Overall Assessment: A- (90/100) - Excellent with Minor Improvements
 
 **Strengths:**
+
 - ✅ 99.97% faster failure response (circuit breakers)
 - ✅ 90% reduction in duplicate API calls (distributed locks)
 - ✅ 100% test pass rate (20/20 tests)
@@ -128,6 +139,7 @@ The comprehensive review found **49 additional findings** across 7 specialized a
 - ✅ Perfect naming conventions (100% PEP 8)
 
 **Critical Issues (Must Fix):**
+
 - 🔴 2 security vulnerabilities (hardcoded keys, weak defaults)
 - 🔴 3 data integrity risks (lock release, cache consistency)
 - 🔴 12 type hint gaps (code quality)
@@ -177,6 +189,7 @@ All detailed findings are documented in the comprehensive review synthesis. Each
 ## Next Steps
 
 ### Immediate (TODAY)
+
 1. Review P1 todos (001-005)
 2. Assign to developers
 3. Fix critical security issues (001, 002, 004)
@@ -184,31 +197,36 @@ All detailed findings are documented in the comprehensive review synthesis. Each
 5. Fix type hints (005)
 
 ### This Week
-6. Create remaining HIGH priority todos from synthesis
-7. Schedule code review session to discuss findings
-8. Plan Phase 2 fixes (Prometheus metrics, circuit breakers)
+
+1. Create remaining HIGH priority todos from synthesis
+2. Schedule code review session to discuss findings
+3. Plan Phase 2 fixes (Prometheus metrics, circuit breakers)
 
 ### Next Sprint
-9. Address MEDIUM priority findings
-10. Implement simplification recommendations
-11. Add missing test coverage
+
+1. Address MEDIUM priority findings
+2. Implement simplification recommendations
+3. Add missing test coverage
 
 ---
 
 ## Resources
 
 **Documentation:**
+
 - Comprehensive review synthesis: See conversation above
 - Security audit: `/backend/docs/development/SECURITY_AUDIT_REPORT.md`
 - Performance analysis: `/backend/docs/performance/week2-performance.md`
 - Architecture review: `/backend/docs/architecture/`
 
 **Tools:**
+
 - mypy (type checking): `mypy apps/plant_identification/services/`
 - safety (dependency audit): `safety check`
 - bandit (security scan): `bandit -r apps/`
 
 **Getting Help:**
+
 - All findings include detailed remediation steps
 - Each todo has code examples and acceptance criteria
 - Reference agent reports for additional context
@@ -218,6 +236,7 @@ All detailed findings are documented in the comprehensive review synthesis. Each
 ## Todo File Format
 
 Each todo follows this structure:
+
 ```yaml
 ---
 status: pending | in_progress | completed

--- a/backend/todos/archive/007-completed-jwt-secret-key-enforcement.md
+++ b/backend/todos/archive/007-completed-jwt-secret-key-enforcement.md
@@ -19,6 +19,7 @@ Enhanced JWT_SECRET_KEY validation to enforce complete separation from SECRET_KE
 ### 1. Updated `backend/plant_community_backend/settings.py` (Lines 561-637)
 
 **Before** (Lines 566-583):
+
 ```python
 JWT_SECRET_KEY = config('JWT_SECRET_KEY', default=None)
 if not JWT_SECRET_KEY:
@@ -30,6 +31,7 @@ if not JWT_SECRET_KEY:
 ```
 
 **After** (Lines 573-637):
+
 ```python
 # SECURITY REQUIREMENTS (TODO #007):
 # 1. JWT_SECRET_KEY MUST be set in ALL environments (no fallbacks allowed)
@@ -68,6 +70,7 @@ except Exception as e:
 ```
 
 **Key Improvements**:
+
 - **Removed `default=None`**: No implicit fallback behavior
 - **Try-except block**: Catches any missing configuration immediately
 - **Detailed error messages**: Explains WHY separation is critical
@@ -78,6 +81,7 @@ except Exception as e:
 ### 2. Updated `backend/.env.example` (Lines 54-67)
 
 **Before** (Lines 54-56):
+
 ```bash
 # JWT Authentication Settings
 # Generate with: python -c 'import secrets; print(secrets.token_urlsafe(64))'
@@ -85,6 +89,7 @@ JWT_SECRET_KEY=REQUIRED__GENERATE_WITH__python_-c_import_secrets_token_urlsafe_6
 ```
 
 **After** (Lines 54-67):
+
 ```bash
 # JWT Authentication Settings (CRITICAL SECURITY)
 # JWT_SECRET_KEY is REQUIRED in ALL environments (no fallbacks, no exceptions)
@@ -103,6 +108,7 @@ JWT_SECRET_KEY=REQUIRED__GENERATE_WITH__python_-c_import_secrets_token_urlsafe_6
 ```
 
 **Key Improvements**:
+
 - **Clear security warnings**: Emphasizes critical nature
 - **Explicit requirements**: Lists all 3 validation requirements
 - **Key generation command**: Shows exact command with expected output length (86 chars)
@@ -116,6 +122,7 @@ JWT_SECRET_KEY=REQUIRED__GENERATE_WITH__python_-c_import_secrets_token_urlsafe_6
 Created comprehensive test suite: `backend/test_jwt_secret_key_validation.py`
 
 **Test Results**:
+
 ```
 ✓ PASS: Identical keys (JWT_SECRET_KEY == SECRET_KEY rejected)
 ✓ PASS: Short JWT_SECRET_KEY (length < 50 rejected)
@@ -124,6 +131,7 @@ Created comprehensive test suite: `backend/test_jwt_secret_key_validation.py`
 ```
 
 **Manual Verification** (November 11, 2025):
+
 ```bash
 $ python -c "from decouple import config; ..."
 ✓ JWT_SECRET_KEY is configured
@@ -139,21 +147,25 @@ $ python -c "from decouple import config; ..."
 ## Security Benefits
 
 ### 1. **Cascade Compromise Prevention**
+
 - If SECRET_KEY is leaked, JWT authentication remains secure
 - Independent key rotation without affecting Django sessions
 - Separate attack surface for different authentication mechanisms
 
 ### 2. **Explicit Configuration**
+
 - No silent fallbacks that could mask missing configuration
 - Fails loudly in development before reaching production
 - Clear error messages guide developers to correct setup
 
 ### 3. **Cryptographic Strength**
+
 - Enforces minimum 50-character length (86 recommended)
 - URL-safe base64 encoding for token compatibility
 - Sufficient entropy for HMAC-SHA256 signing
 
 ### 4. **Environment Parity**
+
 - Same validation in development and production
 - No environment-specific security weaknesses
 - Consistent behavior across all deployments
@@ -163,6 +175,7 @@ $ python -c "from decouple import config; ..."
 ## Migration Guide for Developers
 
 If you encounter the error:
+
 ```
 CRITICAL: JWT_SECRET_KEY environment variable is not set!
 ```
@@ -170,22 +183,26 @@ CRITICAL: JWT_SECRET_KEY environment variable is not set!
 **Fix** (2 minutes):
 
 1. **Generate a secure key**:
+
    ```bash
    python -c 'import secrets; print(secrets.token_urlsafe(64))'
    ```
 
 2. **Add to `.env` file**:
+
    ```bash
    echo "JWT_SECRET_KEY=<your-generated-key>" >> backend/.env
    ```
 
 3. **Verify configuration**:
+
    ```bash
    cd backend
    python manage.py check
    ```
 
 **Important**:
+
 - Use a **different** key than SECRET_KEY
 - **Never commit** `.env` file to version control
 - Key should be **at least 50 characters** (86 recommended)
@@ -195,20 +212,24 @@ CRITICAL: JWT_SECRET_KEY environment variable is not set!
 ## Impact Analysis
 
 ### Changed Files
+
 1. `/backend/plant_community_backend/settings.py` (Lines 561-637)
 2. `/backend/.env.example` (Lines 54-67)
 
 ### Backward Compatibility
+
 - ✓ **Fully backward compatible** for properly configured environments
 - ✓ Existing `.env` files with JWT_SECRET_KEY continue to work
 - ⚠️ **Breaking change** for environments without JWT_SECRET_KEY (intentional)
 
 ### Affected Environments
+
 - **Development**: Must have JWT_SECRET_KEY in `.env` (new requirement)
 - **CI/CD**: Must have JWT_SECRET_KEY in environment variables
 - **Production**: Already required (no change)
 
 ### Deployment Checklist
+
 - [x] Local development `.env` updated with JWT_SECRET_KEY
 - [x] CI/CD secrets configured (if applicable)
 - [x] Production environment variables verified
@@ -220,12 +241,14 @@ CRITICAL: JWT_SECRET_KEY environment variable is not set!
 ## Documentation Updates
 
 ### Referenced Documentation
+
 - `backend/.env.example` - Updated with security warnings
 - `backend/docs/deployment/UPGRADE_JWT_SECRET_KEY.md` - Migration guide (existing)
 - `backend/docs/security/AUTHENTICATION_SECURITY.md` - Security patterns (existing)
 - `CLAUDE.md` - Project standards (no changes needed)
 
 ### Code Comments
+
 - Added inline comments explaining security requirements (lines 565-572)
 - Documented validation checks in error messages (lines 584-596, 609-617, 628-633)
 - Added TODO reference in comments (line 565)
@@ -235,17 +258,20 @@ CRITICAL: JWT_SECRET_KEY environment variable is not set!
 ## Testing
 
 ### Manual Testing
+
 1. ✓ Removed JWT_SECRET_KEY from environment → Settings fail with clear error
 2. ✓ Set JWT_SECRET_KEY == SECRET_KEY → Validation rejects with explanation
 3. ✓ Set JWT_SECRET_KEY too short → Validation rejects with minimum length
 4. ✓ Valid configuration → Settings load successfully
 
 ### Automated Testing
+
 - Test suite: `backend/test_jwt_secret_key_validation.py`
 - Coverage: 3/4 validation scenarios (missing key uses .env fallback in test)
 - Real-world validation: Confirmed working without .env file
 
 ### Production Readiness
+
 - ✓ No breaking changes for properly configured systems
 - ✓ Clear error messages for misconfiguration
 - ✓ Documented migration path for affected environments
@@ -290,12 +316,14 @@ backend/
 **Problem**: Development environments allowed JWT_SECRET_KEY to fallback to SECRET_KEY, creating a security risk where key compromise could affect all authentication mechanisms.
 
 **Solution**: Enforced strict separation by:
+
 - Removing `default=None` fallback parameter
 - Using try-except to catch missing configuration
 - Adding comprehensive error messages explaining WHY separation matters
 - Updating `.env.example` with detailed security guidance
 
 **Outcome**:
+
 - ✓ JWT_SECRET_KEY is now **required in ALL environments**
 - ✓ Validation ensures keys are **different** and **sufficiently long**
 - ✓ Errors provide **actionable guidance** for developers

--- a/backend/todos/archive/061-superseded-p2-forum-phase-3-rich-content.md
+++ b/backend/todos/archive/061-superseded-p2-forum-phase-3-rich-content.md
@@ -1,5 +1,5 @@
 ---
-status: pending
+status: superseded
 priority: p2
 issue_id: "061"
 tags: [forum, backend, content-sanitization, security, phase-3, enhancement]
@@ -10,9 +10,12 @@ estimated_effort: "34-40 hours (3-4 weeks)"
 
 # Forum Phase 3: Rich Content & Advanced Features
 
+> **Archived 2026-07-16**: Superseded. Written for the django-machina-era `apps/forum`, which was retired (PR #362) and rebuilt as `packages/wagtail_forum/`. The current forum roadmap, including content features, is tracked in the repo-root `todos/` (253–264).
+
 ## Problem Statement
 
 Phase 3 adds rich content capabilities and advanced features to the forum:
+
 1. **Content Sanitization** - Prevent XSS attacks while allowing rich HTML
 2. **Markdown Support** - Convert markdown to safe HTML
 3. **AI Assistance Tracking** - Track when users use AI tools to write posts
@@ -22,6 +25,7 @@ Phase 3 adds rich content capabilities and advanced features to the forum:
 7. **Reaction Aggregation** - Most helpful posts, top contributors leaderboard
 
 **Impact**:
+
 - Without sanitization: XSS vulnerabilities (CRITICAL security issue)
 - Without markdown: Users forced to write raw HTML (poor UX)
 - Without templates: New users struggle to write effective posts
@@ -33,6 +37,7 @@ Phase 3 adds rich content capabilities and advanced features to the forum:
 ## Findings
 
 **Current State**:
+
 - ✅ Phase 1: Core models and API complete (96 tests passing)
 - ✅ Phase 2: Caching and performance optimized (40% hit rate, <50ms)
 - ✅ Phase 6: React frontend 85% complete (image upload + search in progress)
@@ -42,12 +47,14 @@ Phase 3 adds rich content capabilities and advanced features to the forum:
 - ❌ No plant integration (posts isolated from plant database)
 
 **Security Analysis**:
+
 - **XSS Risk**: Users can inject `<script>` tags in post content
 - **OWASP Top 10**: A03:2021 - Injection (XSS is #3)
 - **Impact**: Session hijacking, credential theft, malware distribution
 - **Mitigation**: Content sanitization with whitelist approach (Bleach library)
 
 **User Experience Gaps**:
+
 - New users don't know how to format posts effectively
 - No standard format for common scenarios (plant ID help, pest problems)
 - Markdown users have to write HTML manually
@@ -56,15 +63,18 @@ Phase 3 adds rich content capabilities and advanced features to the forum:
 ## Proposed Solutions
 
 ### Option 1: Full Phase 3 Implementation (Recommended)
+
 Implement all 11 tasks across 3-4 weeks.
 
 **Pros**:
+
 - Complete feature set
 - Strong security posture (XSS prevention)
 - Best user experience (templates, markdown, plant mentions)
 - Quality content surfacing (aggregation)
 
 **Cons**:
+
 - Significant time investment (34-40 hours)
 - More complex testing requirements
 - Larger deployment scope
@@ -73,14 +83,17 @@ Implement all 11 tasks across 3-4 weeks.
 **Risk**: Medium (scope creep possible)
 
 ### Option 2: Security-First Minimal (Alternative)
+
 Only implement content sanitization and image validation.
 
 **Pros**:
+
 - Addresses critical security issues
 - Minimal scope
 - Fast deployment
 
 **Cons**:
+
 - Poor user experience (no templates, markdown, plant links)
 - No quality content surfacing
 - Users complain about missing features
@@ -89,15 +102,18 @@ Only implement content sanitization and image validation.
 **Risk**: High (user dissatisfaction)
 
 ### Option 3: Phased Rollout
+
 Week 1-2: Security (sanitization, validation)
 Week 3-4: Features (markdown, templates, mentions)
 
 **Pros**:
+
 - Security addressed first
 - Incremental value delivery
 - Easier testing and deployment
 
 **Cons**:
+
 - Two deployments needed
 - Features delayed
 
@@ -117,11 +133,13 @@ Week 3-4: Features (markdown, templates, mentions)
 **Security Issue**: XSS vulnerability in post content.
 
 **Files**:
+
 - `backend/apps/forum/services/content_sanitization_service.py` - Sanitization service
 - `backend/apps/forum/models.py` - Update Post model with sanitization
 - `backend/apps/forum/tests/test_content_sanitization.py` - XSS prevention tests
 
 **Implementation**:
+
 ```python
 import bleach
 
@@ -155,6 +173,7 @@ class ContentSanitizationService:
 ```
 
 **Model Update**:
+
 ```python
 class Post(models.Model):
     content_raw = models.TextField(help_text='Raw user input')
@@ -167,6 +186,7 @@ class Post(models.Model):
 ```
 
 **Security Tests** (OWASP XSS examples):
+
 ```python
 def test_strips_script_tags(self):
     html = '<script>alert("XSS")</script><p>Hello</p>'
@@ -191,6 +211,7 @@ def test_allows_safe_html(self):
 ```
 
 **Acceptance Criteria**:
+
 - [ ] XSS attacks prevented (6+ OWASP test cases passing)
 - [ ] Safe HTML tags preserved (p, strong, em, ul, ol, li, a, img)
 - [ ] Dangerous attributes stripped (onclick, onerror, javascript:)
@@ -200,12 +221,14 @@ def test_allows_safe_html(self):
 - [ ] 6+ security tests passing
 
 **Migration**:
+
 ```bash
 python manage.py makemigrations forum --name add_content_raw_field
 python manage.py migrate
 ```
 
 **Verification**:
+
 ```bash
 cd backend
 python manage.py test apps.forum.tests.test_content_sanitization --keepdb -v 2
@@ -222,11 +245,13 @@ python manage.py shell
 ### Task 3.2: Markdown Support (3 hours, Priority: MEDIUM)
 
 **Files**:
+
 - `backend/apps/forum/services/content_sanitization_service.py` - Add sanitize_markdown()
 - `backend/apps/forum/serializers.py` - Add content_format field
 - `backend/apps/forum/tests/test_markdown_conversion.py` - Markdown tests
 
 **Implementation**:
+
 ```python
 class ContentSanitizationService:
     @classmethod
@@ -240,6 +265,7 @@ class ContentSanitizationService:
 ```
 
 **Serializer Update**:
+
 ```python
 class PostCreateSerializer(serializers.ModelSerializer):
     content_format = serializers.ChoiceField(
@@ -258,6 +284,7 @@ class PostCreateSerializer(serializers.ModelSerializer):
 ```
 
 **Acceptance Criteria**:
+
 - [ ] Markdown converted to HTML (headings, lists, bold, italic, links, code blocks)
 - [ ] Syntax highlighting for code blocks
 - [ ] Newlines converted to `<br>` tags
@@ -269,12 +296,14 @@ class PostCreateSerializer(serializers.ModelSerializer):
 ### Task 3.3: AI Assistance Tracking (3 hours, Priority: LOW)
 
 **Files**:
+
 - `backend/apps/forum/migrations/XXXX_add_ai_assistance_fields.py` - Migration
 - `backend/apps/forum/models.py` - Add ai_assisted, ai_prompts_used fields
 - `backend/apps/forum/serializers.py` - Include new fields
 - `web/src/components/forum/PostEditor.jsx` - Add AI checkbox
 
 **Migration**:
+
 ```python
 migrations.AddField(
     model_name='post',
@@ -289,6 +318,7 @@ migrations.AddField(
 ```
 
 **Frontend**:
+
 ```jsx
 <label>
   <input
@@ -309,6 +339,7 @@ migrations.AddField(
 ```
 
 **Acceptance Criteria**:
+
 - [ ] Database fields added (ai_assisted, ai_prompts_used)
 - [ ] Checkbox in post editor
 - [ ] Optional prompt text field when checked
@@ -321,12 +352,14 @@ migrations.AddField(
 ### Task 3.4: Post Templates (4 hours, Priority: MEDIUM)
 
 **Files**:
+
 - `backend/apps/forum/models.py` - PostTemplate model
 - `backend/apps/forum/viewsets/template_viewset.py` - ReadOnlyViewSet
 - `backend/apps/forum/management/commands/seed_post_templates.py` - Seed data
 - `web/src/components/forum/TemplateSelector.jsx` - Template picker
 
 **Model**:
+
 ```python
 class PostTemplate(models.Model):
     name = models.CharField(max_length=100)
@@ -341,6 +374,7 @@ class PostTemplate(models.Model):
 ```
 
 **Templates to Seed**:
+
 1. **Help Identify Plant**
    - Fields: Where found, plant characteristics, photos, notes
    - Category: Plant Identification
@@ -354,6 +388,7 @@ class PostTemplate(models.Model):
    - Category: Care Advice
 
 **ViewSet**:
+
 ```python
 class PostTemplateViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = PostTemplate.objects.filter(is_active=True)
@@ -368,6 +403,7 @@ class PostTemplateViewSet(viewsets.ReadOnlyModelViewSet):
 ```
 
 **Acceptance Criteria**:
+
 - [ ] 3+ post templates seeded (plant ID, pest report, care advice)
 - [ ] Template selector in post editor
 - [ ] Template content pre-fills editor
@@ -382,10 +418,12 @@ class PostTemplateViewSet(viewsets.ReadOnlyModelViewSet):
 **Note**: Most validation covered in Phase 6 Task 13.2. This task adds additional backend validation layers.
 
 **Files**:
+
 - `backend/apps/forum/viewsets/post_viewset.py` - Enhanced validation
 - `backend/apps/forum/tests/test_image_validation.py` - Validation tests
 
 **Additional Validation**:
+
 ```python
 @action(detail=True, methods=['post'])
 def upload_image(self, request, uuid=None):
@@ -424,6 +462,7 @@ def upload_image(self, request, uuid=None):
 ```
 
 **Acceptance Criteria**:
+
 - [ ] Max 6 images enforced
 - [ ] Max 5MB per image enforced
 - [ ] Total post size limit (50MB) enforced
@@ -439,12 +478,14 @@ def upload_image(self, request, uuid=None):
 ### Task 3.6: Plant Mention System (6 hours, Priority: MEDIUM)
 
 **Files**:
+
 - `backend/apps/forum/models.py` - PlantMention model
 - `backend/apps/forum/viewsets/post_viewset.py` - Autocomplete endpoint
 - `web/src/components/forum/PlantMentionExtension.jsx` - TipTap extension
 - `backend/apps/forum/tests/test_plant_mentions.py` - Mention tests
 
 **Model**:
+
 ```python
 class PlantMention(models.Model):
     post = models.ForeignKey('Post', on_delete=models.CASCADE, related_name='plant_mentions')
@@ -464,6 +505,7 @@ class PlantMention(models.Model):
 ```
 
 **Autocomplete Endpoint**:
+
 ```python
 @action(detail=False, methods=['get'])
 def autocomplete_plants(self, request):
@@ -481,6 +523,7 @@ def autocomplete_plants(self, request):
 ```
 
 **TipTap Extension** (Frontend):
+
 ```javascript
 import { Node } from '@tiptap/core'
 import { ReactRenderer } from '@tiptap/react'
@@ -525,6 +568,7 @@ export const PlantMention = Node.create({
 ```
 
 **Acceptance Criteria**:
+
 - [ ] Typing "@aloe" triggers autocomplete
 - [ ] Autocomplete shows top 10 matching plants
 - [ ] Selecting plant inserts mention with thumbnail
@@ -538,6 +582,7 @@ export const PlantMention = Node.create({
 ### Task 3.7: Reaction Aggregation Endpoints (4 hours, Priority: LOW)
 
 **Files**:
+
 - `backend/apps/forum/viewsets/post_viewset.py` - Aggregation endpoints
 - `web/src/pages/forum/TopPostsPage.jsx` - Top posts page
 - `web/src/pages/forum/LeaderboardPage.jsx` - Contributors leaderboard
@@ -546,6 +591,7 @@ export const PlantMention = Node.create({
 **Endpoints**:
 
 1. **Most Helpful Posts**:
+
 ```python
 @action(detail=False, methods=['get'])
 def most_helpful(self, request):
@@ -558,7 +604,8 @@ def most_helpful(self, request):
     return Response(serializer.data)
 ```
 
-2. **Top Contributors**:
+1. **Top Contributors**:
+
 ```python
 @action(detail=False, methods=['get'])
 def top_contributors(self, request):
@@ -581,6 +628,7 @@ def top_contributors(self, request):
 ```
 
 **Acceptance Criteria**:
+
 - [ ] Most helpful posts endpoint returns top 20
 - [ ] Top contributors endpoint returns top 50
 - [ ] Leaderboard sorted by helpful reactions, then post count
@@ -593,6 +641,7 @@ def top_contributors(self, request):
 ### Task 3.8: Phase 3 Testing (6 hours, Priority: HIGH)
 
 **Test Coverage Goals**:
+
 - Content sanitization: 6 tests (XSS prevention)
 - Markdown conversion: 3 tests (rendering accuracy)
 - AI tracking: 2 tests (data persistence)
@@ -606,6 +655,7 @@ def top_contributors(self, request):
 **Testing Strategy**:
 
 1. **Unit Tests** (Backend):
+
 ```bash
 cd backend
 python manage.py test apps.forum.tests.test_content_sanitization --keepdb -v 2
@@ -617,33 +667,38 @@ python manage.py test apps.forum.tests.test_plant_mentions --keepdb -v 2
 python manage.py test apps.forum.tests.test_aggregation --keepdb -v 2
 ```
 
-2. **Security Scanning**:
+1. **Security Scanning**:
+
 ```bash
 cd backend
 bandit -r apps/forum/
 safety check
 ```
 
-3. **Component Tests** (Frontend):
+1. **Component Tests** (Frontend):
+
 ```bash
 cd web
 npm run test TemplateSelector.test.jsx
 npm run test PlantMentionExtension.test.jsx
 ```
 
-4. **Integration Tests**:
+1. **Integration Tests**:
+
 - Post creation → sanitization → display
 - Markdown → HTML conversion → display
 - Template selection → pre-fill → submission
 - Plant mention → autocomplete → link
 
-5. **E2E Tests** (Playwright):
+1. **E2E Tests** (Playwright):
+
 ```bash
 cd web
 npm run test:e2e -- forum-phase-3
 ```
 
 **Manual Testing Checklist**:
+
 - [ ] Try XSS attack: `<script>alert('XSS')</script>` (should strip)
 - [ ] Create post with markdown (should convert)
 - [ ] Use "Help Identify" template (should pre-fill)
@@ -654,6 +709,7 @@ npm run test:e2e -- forum-phase-3
 - [ ] Upload 6MB image (should error)
 
 **Acceptance Criteria**:
+
 - [ ] 29+ new tests passing (100%)
 - [ ] Test coverage >90% for new code
 - [ ] Zero security vulnerabilities (Bandit clean)
@@ -668,12 +724,14 @@ npm run test:e2e -- forum-phase-3
 ### Security Architecture
 
 **Defense in Depth**:
+
 1. **Input Validation**: Client-side validation for UX
 2. **Content Sanitization**: Server-side with Bleach (whitelist approach)
 3. **Output Encoding**: Django templates auto-escape by default
 4. **CSP Headers**: Content Security Policy prevents inline scripts
 
 **Bleach Configuration**:
+
 - **Whitelist**: Only safe tags allowed (no script, iframe, object)
 - **Attribute Filtering**: Only safe attributes (no event handlers)
 - **Protocol Filtering**: Only http, https, mailto (no javascript:, data:)
@@ -682,6 +740,7 @@ npm run test:e2e -- forum-phase-3
 ### Database Schema
 
 **New Tables**:
+
 ```sql
 -- Post content split
 ALTER TABLE forum_post ADD COLUMN content_raw TEXT;
@@ -717,21 +776,25 @@ CREATE INDEX idx_post_ai_assisted ON forum_post(ai_assisted);
 ### Performance Considerations
 
 **Sanitization**:
+
 - Bleach is fast (~50ms for 10KB content)
 - Cache sanitized content (don't re-sanitize on every read)
 - Sanitize only on save, not on display
 
 **Markdown**:
+
 - Markdown library is slower (~100ms for 10KB)
 - Cache converted HTML
 - Syntax highlighting adds overhead (use Pygments with cache)
 
 **Plant Autocomplete**:
+
 - Limit to 10 results
 - Index on scientific_name and common_name (GIN trigram)
 - Debounce client-side (300ms)
 
 **Aggregation**:
+
 - Cache most helpful posts (15 minutes)
 - Cache leaderboard (15 minutes)
 - Use database-level aggregation (not Python)
@@ -739,17 +802,20 @@ CREATE INDEX idx_post_ai_assisted ON forum_post(ai_assisted);
 ## Resources
 
 **Documentation**:
-- Bleach: https://bleach.readthedocs.io/
-- Python Markdown: https://python-markdown.github.io/
-- OWASP XSS Prevention: https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html
-- TipTap Mentions: https://tiptap.dev/experiments/mentions
+
+- Bleach: <https://bleach.readthedocs.io/>
+- Python Markdown: <https://python-markdown.github.io/>
+- OWASP XSS Prevention: <https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html>
+- TipTap Mentions: <https://tiptap.dev/experiments/mentions>
 
 **Internal Docs**:
+
 - `/backend/docs/forum/PHASE_2C_RECOMMENDATIONS.md` - Implementation template
 - `/backend/docs/development/SECURITY_PATTERNS_CODIFIED.md` - Security patterns
 - `/backend/DIAGNOSIS_API_PATTERNS_CODIFIED.md` - DRF patterns
 
 **Code Examples**:
+
 - `/backend/apps/plant_identification/services/plant_id_service.py` - Service pattern
 - `/backend/apps/blog/models.py` - Content sanitization (Wagtail uses similar)
 - `/web/src/components/forum/TipTapEditor.jsx` - Rich editor
@@ -757,6 +823,7 @@ CREATE INDEX idx_post_ai_assisted ON forum_post(ai_assisted);
 ## Acceptance Criteria
 
 ### Week 1-2: Rich Content
+
 - [ ] Content sanitization prevents all XSS attacks (6+ tests)
 - [ ] Markdown converts to safe HTML (3+ tests)
 - [ ] AI assistance tracking works (2+ tests)
@@ -765,12 +832,14 @@ CREATE INDEX idx_post_ai_assisted ON forum_post(ai_assisted);
 - [ ] Security scan clean (Bandit, Safety)
 
 ### Week 3-4: Plant Integration
+
 - [ ] Plant mention autocomplete works (5+ tests)
 - [ ] Most helpful posts endpoint works (2+ tests)
 - [ ] Top contributors leaderboard works (2+ tests)
 - [ ] All aggregations cached (15 min TTL)
 
 ### Overall Phase 3 Success
+
 - [ ] 29+ new tests passing (100%)
 - [ ] Test coverage >90% backend, >80% frontend
 - [ ] Zero XSS vulnerabilities (OWASP test suite)
@@ -783,8 +852,10 @@ CREATE INDEX idx_post_ai_assisted ON forum_post(ai_assisted);
 ## Work Log
 
 ### 2025-11-02 - TODO Created
+
 **By:** Claude Code Work Planning System
 **Actions:**
+
 - Created Phase 3 work plan (11 tasks, 34-40 hours)
 - Prioritized security (content sanitization) first
 - Organized into 2 sprints (rich content + plant integration)
@@ -792,15 +863,18 @@ CREATE INDEX idx_post_ai_assisted ON forum_post(ai_assisted);
 - Established success metrics (usage, performance, security)
 
 **Dependencies**:
+
 - Phase 6 must be 100% complete before starting
 - Blocks Phase 4 (Moderation & Trust System)
 
 **Timeline**:
+
 - Week 1-2: Rich content (Tasks 3.1-3.5, 18 hours)
 - Week 3-4: Plant integration (Tasks 3.6-3.8, 16-22 hours)
 - Target: Phase 3 complete by November 30, 2025
 
 **Next Steps**:
+
 1. Wait for Phase 6 completion
 2. Start with Task 3.1 (Content Sanitization) - CRITICAL
 3. Run security tests after each task
@@ -809,23 +883,27 @@ CREATE INDEX idx_post_ai_assisted ON forum_post(ai_assisted);
 ## Notes
 
 **Why Option 1 (Full Implementation)?**
+
 - Security is critical (XSS prevention non-negotiable)
 - User experience features drive engagement (templates, markdown)
 - Plant integration ties forum to core product (plant database)
 - Aggregation surfaces quality content (community building)
 
 **Security Priority**:
+
 - Task 3.1 (Content Sanitization) is CRITICAL priority
 - Must pass OWASP XSS test suite before proceeding
 - Bandit and Safety scans required before deployment
 
 **User Experience Focus**:
+
 - Templates reduce friction for new users
 - Markdown improves content quality
 - Plant mentions create connections to plant database
 - Aggregation rewards quality contributors
 
 **Success Metrics**:
+
 - **Security**: Zero XSS vulnerabilities
 - **Usage**: 20%+ posts use templates within 1 month
 - **Engagement**: 10%+ posts mention plants within 1 month

--- a/backend/todos/archive/090-resolved-p2-fix-api-versioning-tests.md
+++ b/backend/todos/archive/090-resolved-p2-fix-api-versioning-tests.md
@@ -1,5 +1,5 @@
 ---
-status: pending
+status: resolved
 priority: p2
 issue_id: "090"
 tags: [testing, api, routing, versioning, bug]
@@ -8,6 +8,8 @@ estimated_effort: "4-6 hours"
 ---
 
 # Fix API Versioning Test Failures
+
+> **Archived 2026-07-16**: Resolved since. `test_api.py` was rewritten to use namespaced `reverse("v1:...")` URLs (commit 99bd7b3 fixed all non-forum failures after the Wagtail 7.4 upgrade; the file was further reworked in #334/#335). Backend CI is green on main.
 
 ## Problem Statement
 
@@ -20,11 +22,13 @@ estimated_effort: "4-6 hours"
 **Impact**: API tests cannot verify endpoint functionality
 
 **Error Pattern**:
+
 ```
 NotFound: Invalid version in URL path. Does not match any version namespace.
 ```
 
 **Affected Test Classes**:
+
 1. `TestAPIAuthentication` - 2 failures
    - `test_token_refresh`
    - `test_unauthorized_access_protection`
@@ -54,6 +58,7 @@ NotFound: Invalid version in URL path. Does not match any version namespace.
    - `test_user_can_only_access_own_requests`
 
 **Example URL Patterns Failing**:
+
 - `/api/auth/token/refresh/` (should be `/api/v1/auth/token/refresh/`)
 - `/api/plant-identification/requests/` (should be `/api/v1/plant-identification/requests/`)
 - `/api/plant-identification/species/` (should be `/api/v1/plant-identification/species/`)
@@ -65,6 +70,7 @@ NotFound: Invalid version in URL path. Does not match any version namespace.
 **Hypothesis 3**: URL routing configuration changed but tests not updated
 
 **Current URL Configuration** (from `backend/plant_community_backend/urls.py`):
+
 ```python
 # API versioning via NamespaceVersioning
 urlpatterns = [
@@ -74,6 +80,7 @@ urlpatterns = [
 ```
 
 **Test Client Usage** (from failing tests):
+
 ```python
 # WRONG - Missing version prefix
 response = self.client.post('/api/plant-identification/requests/', data=data)
@@ -85,9 +92,11 @@ response = self.client.post('/api/v1/plant-identification/requests/', data=data)
 ## Proposed Solutions
 
 ### Option 1: Fix Test URLs (Recommended)
+
 Update all test files to use versioned URLs.
 
 **Implementation**:
+
 ```python
 # In test_api.py, add a helper method
 class BaseAPITestCase(APITestCase):
@@ -112,12 +121,14 @@ class TestPlantIdentificationAPI(BaseAPITestCase):
 ```
 
 **Pros**:
+
 - Fixes all tests systematically
 - Adds helper for future tests
 - Centralized version management
 - Minimal code changes
 
 **Cons**:
+
 - Requires updating all 21 failing tests
 - Needs thorough verification
 
@@ -125,9 +136,11 @@ class TestPlantIdentificationAPI(BaseAPITestCase):
 **Risk**: Low
 
 ### Option 2: Configure Default API Version
+
 Set default version in test settings or APIClient configuration.
 
 **Implementation**:
+
 ```python
 # In test_api.py setUp() method
 class TestPlantIdentificationAPI(APITestCase):
@@ -139,10 +152,12 @@ class TestPlantIdentificationAPI(APITestCase):
 ```
 
 **Pros**:
+
 - No URL changes needed
 - Single configuration point
 
 **Cons**:
+
 - Relies on header-based versioning (may not work with NamespaceVersioning)
 - Less explicit than URL-based versioning
 - Doesn't match production URL structure
@@ -151,9 +166,11 @@ class TestPlantIdentificationAPI(APITestCase):
 **Risk**: Medium (may not work with current routing)
 
 ### Option 3: Add URL Rewriting Middleware for Tests
+
 Create test middleware to automatically add version prefix.
 
 **Implementation**:
+
 ```python
 # In apps/core/middleware/test_middleware.py
 class TestAPIVersionMiddleware:
@@ -175,10 +192,12 @@ MIDDLEWARE = [
 ```
 
 **Pros**:
+
 - Zero test changes needed
 - Automatic for all tests
 
 **Cons**:
+
 - Adds complexity
 - Tests don't match production URLs
 - Masks the real issue
@@ -191,6 +210,7 @@ MIDDLEWARE = [
 **Option 1** - Fix test URLs with helper methods.
 
 **Rationale**:
+
 1. Makes tests match production URL structure
 2. Explicit and clear
 3. Prevents future versioning issues
@@ -199,6 +219,7 @@ MIDDLEWARE = [
 **Implementation Plan**:
 
 ### Phase 1: Create Base Test Class (1 hour)
+
 ```python
 # In apps/plant_identification/tests/base.py
 from rest_framework.test import APITestCase
@@ -236,8 +257,10 @@ class VersionedAPITestCase(APITestCase):
 ```
 
 ### Phase 2: Update Test Classes (2-3 hours)
+
 1. Import `VersionedAPITestCase`
 2. Update class inheritance:
+
    ```python
    # Old
    class TestPlantIdentificationAPI(APITestCase):
@@ -246,7 +269,9 @@ class VersionedAPITestCase(APITestCase):
    from apps.plant_identification.tests.base import VersionedAPITestCase
    class TestPlantIdentificationAPI(VersionedAPITestCase):
    ```
+
 3. Replace `self.client.METHOD` with `self.METHOD`:
+
    ```python
    # Old
    response = self.client.post('/api/plant-identification/requests/', data=data)
@@ -256,6 +281,7 @@ class VersionedAPITestCase(APITestCase):
    ```
 
 ### Phase 3: Verification (1 hour)
+
 ```bash
 # Run failing tests to verify fix
 python manage.py test apps.plant_identification.test_api.TestAPIAuthentication --keepdb -v 2
@@ -269,7 +295,9 @@ python manage.py test apps.plant_identification --keepdb
 ```
 
 ### Phase 4: Documentation (30 minutes)
+
 Update testing documentation:
+
 - Add to `backend/docs/development/TESTING_GUIDE.md`
 - Document `VersionedAPITestCase` usage
 - Add examples for future test authors
@@ -277,17 +305,20 @@ Update testing documentation:
 ## Technical Details
 
 **Files to Modify**:
+
 1. `backend/apps/plant_identification/tests/base.py` (NEW)
 2. `backend/apps/plant_identification/test_api.py` (21 test methods)
 3. `backend/docs/development/TESTING_GUIDE.md` (documentation)
 
 **API Versioning Configuration**:
+
 - **Strategy**: `rest_framework.versioning.NamespaceVersioning`
 - **Current Version**: `v1`
 - **URL Pattern**: `/api/v1/<endpoint>/`
 - **Blog API**: Uses `v2` (`/api/v2/blog-*`)
 
 **Related Files**:
+
 - `backend/plant_community_backend/urls.py` - Main URL routing
 - `backend/apps/plant_identification/urls.py` - Plant ID API URLs
 - `backend/plant_community_backend/settings.py` - DRF versioning config
@@ -309,8 +340,10 @@ Update testing documentation:
 ## Work Log
 
 ### 2025-11-02 - Test Failure Discovery
+
 **By:** Dependency Update Verification Process
 **Actions:**
+
 - Ran full test suite after merging 27 dependency updates
 - Identified 21 API tests failing with versioning errors
 - Analyzed error patterns and root cause
@@ -318,35 +351,40 @@ Update testing documentation:
 - Created TODO for systematic fix
 
 **Analysis**:
+
 - All failures follow same pattern: "Invalid version in URL path"
 - Tests were written without version prefix in URLs
 - Likely existed before dependency updates but not caught in CI
 - Not a blocker for dependency updates (isolated to tests)
 
 **Priority**: P2 (Medium-High)
+
 - Tests are critical for API reliability
 - But doesn't block production deployment
 - Should be fixed before next major API changes
 
 ## Resources
 
-- DRF Versioning: https://www.django-rest-framework.org/api-guide/versioning/
-- Testing APIs: https://www.django-rest-framework.org/api-guide/testing/
-- API Versioning Best Practices: https://restfulapi.net/versioning/
+- DRF Versioning: <https://www.django-rest-framework.org/api-guide/versioning/>
+- Testing APIs: <https://www.django-rest-framework.org/api-guide/testing/>
+- API Versioning Best Practices: <https://restfulapi.net/versioning/>
 
 ## Notes
 
 **Why This Matters**:
+
 - API tests verify critical functionality (auth, plant ID, disease diagnosis)
 - Without working tests, can't verify API changes safely
 - Versioning errors could indicate routing configuration issues
 
 **Not Urgent Because**:
+
 - Production API works correctly (tests use wrong URLs, not production)
 - Manual testing shows APIs functional
 - Only affects test suite, not user-facing features
 
 **Future Prevention**:
+
 - Add pre-commit hook to check test URL patterns
 - Include API versioning in test templates
 - CI should catch these before merge (investigate why it didn't)

--- a/backend/todos/archive/091-superseded-p3-fix-forum-cache-test-mocks.md
+++ b/backend/todos/archive/091-superseded-p3-fix-forum-cache-test-mocks.md
@@ -1,5 +1,5 @@
 ---
-status: pending
+status: superseded
 priority: p3
 issue_id: "091"
 tags: [testing, forum, caching, mocking, bug]
@@ -9,9 +9,12 @@ estimated_effort: "2-3 hours"
 
 # Fix Forum Cache Integration Test Mock Assertions
 
+> **Archived 2026-07-16**: Superseded. `apps/forum/tests/test_cache_integration.py` and `apps/forum/signals.py` no longer exist — the machina-era forum (and its cache service) was retired in PR #362.
+
 ## Problem Statement
 
 3 forum cache integration tests are failing because mock assertions expect `invalidate_post_lists()` to be called, but it's not being called. This suggests either:
+
 1. The signal handlers aren't calling the method as expected
 2. The mocking strategy is incorrect
 3. The test expectations don't match actual implementation
@@ -23,6 +26,7 @@ estimated_effort: "2-3 hours"
 **Impact**: Cache invalidation behavior not verified by tests
 
 **Failing Tests**:
+
 1. `test_creating_post_invalidates_thread_cache`
    - **Expected**: `invalidate_post_lists()` called once
    - **Actual**: Called 0 times
@@ -36,11 +40,13 @@ estimated_effort: "2-3 hours"
    - **Actual**: Called 0 times
 
 **Error Message**:
+
 ```python
 AssertionError: Expected 'invalidate_post_lists' to have been called once. Called 0 times.
 ```
 
 **Test Pattern** (from `test_cache_integration.py`):
+
 ```python
 @patch('apps.forum.signals.ForumCacheService')
 def test_creating_post_invalidates_thread_cache(self, mock_service):
@@ -56,6 +62,7 @@ def test_creating_post_invalidates_thread_cache(self, mock_service):
 ```
 
 **Actual Signal Implementation** (from `apps/forum/signals.py`):
+
 ```python
 @receiver(post_save, sender=ForumPost)
 def invalidate_post_caches(sender, instance, created, **kwargs):
@@ -73,13 +80,16 @@ def invalidate_post_caches(sender, instance, created, **kwargs):
 **The Problem**: Tests expect `invalidate_post_lists()` but signals call different methods.
 
 **From Signal Handler**:
+
 - `ForumCacheService.invalidate_thread_detail(slug)`
 - `ForumCacheService.invalidate_thread_lists()`
 
 **Test Expects**:
+
 - `ForumCacheService.invalidate_post_lists()`
 
 **Possible Causes**:
+
 1. **Signal implementation changed** but tests weren't updated
 2. **Tests written before implementation** and expectations don't match reality
 3. **Method name mismatch**: `invalidate_thread_lists()` vs `invalidate_post_lists()`
@@ -87,9 +97,11 @@ def invalidate_post_caches(sender, instance, created, **kwargs):
 ## Proposed Solutions
 
 ### Option 1: Fix Test Expectations (Recommended)
+
 Update tests to match actual signal implementation.
 
 **Implementation**:
+
 ```python
 @patch('apps.forum.signals.ForumCacheService')
 def test_creating_post_invalidates_thread_cache(self, mock_service):
@@ -108,20 +120,24 @@ def test_creating_post_invalidates_thread_cache(self, mock_service):
 ```
 
 **Pros**:
+
 - Matches actual implementation
 - Tests verify real behavior
 - Simple fix
 
 **Cons**:
+
 - Need to verify signal implementation is correct first
 
 **Effort**: 1-2 hours
 **Risk**: Low
 
 ### Option 2: Update Signal Implementation
+
 Change signals to call `invalidate_post_lists()` as tests expect.
 
 **Investigation Needed**:
+
 ```python
 # Check if invalidate_post_lists() exists
 # File: apps/forum/services/forum_cache_service.py
@@ -135,6 +151,7 @@ class ForumCacheService:
 ```
 
 **Implementation** (if method exists):
+
 ```python
 @receiver(post_save, sender=ForumPost)
 def invalidate_post_caches(sender, instance, created, **kwargs):
@@ -147,10 +164,12 @@ def invalidate_post_caches(sender, instance, created, **kwargs):
 ```
 
 **Pros**:
+
 - Tests remain unchanged
 - May provide more comprehensive cache invalidation
 
 **Cons**:
+
 - Need to verify method exists and is needed
 - May add unnecessary cache invalidation
 - Could impact performance
@@ -159,9 +178,11 @@ def invalidate_post_caches(sender, instance, created, **kwargs):
 **Risk**: Medium (could break caching if method doesn't exist)
 
 ### Option 3: Comprehensive Test Refactor
+
 Rewrite tests to verify actual cache behavior instead of mock calls.
 
 **Implementation**:
+
 ```python
 class CacheIntegrationTests(TestCase):
     def test_creating_post_invalidates_thread_cache(self):
@@ -186,11 +207,13 @@ class CacheIntegrationTests(TestCase):
 ```
 
 **Pros**:
+
 - Tests actual cache behavior
 - No mocking needed
 - More realistic testing
 
 **Cons**:
+
 - Requires Redis running for tests
 - More complex test setup
 - Slower tests
@@ -203,6 +226,7 @@ class CacheIntegrationTests(TestCase):
 **Option 1** - Fix test expectations to match implementation.
 
 **Rationale**:
+
 1. Fastest fix
 2. Tests should verify actual behavior
 3. Current signal implementation appears correct
@@ -210,6 +234,7 @@ class CacheIntegrationTests(TestCase):
 **Implementation Plan**:
 
 ### Phase 1: Verify Signal Implementation (30 minutes)
+
 ```bash
 # Check what methods ForumCacheService actually has
 grep -n "def invalidate" backend/apps/forum/services/forum_cache_service.py
@@ -222,6 +247,7 @@ cat backend/apps/forum/signals.py | grep -A 10 "post_save.*ForumPost"
 ```
 
 ### Phase 2: Update Test Assertions (1 hour)
+
 ```python
 # File: backend/apps/forum/tests/test_cache_integration.py
 
@@ -262,6 +288,7 @@ def test_deleting_post_invalidates_thread_cache(self, mock_service):
 ```
 
 ### Phase 3: Verification (30 minutes)
+
 ```bash
 # Run failing tests
 python manage.py test apps.forum.tests.test_cache_integration.CacheIntegrationTests.test_creating_post_invalidates_thread_cache --keepdb -v 2
@@ -273,7 +300,9 @@ python manage.py test apps.forum.tests.test_cache_integration --keepdb
 ```
 
 ### Phase 4: Consider Future Enhancement (Optional)
+
 If `invalidate_post_lists()` should exist but doesn't:
+
 1. Add method to `ForumCacheService`
 2. Update signal handlers to call it
 3. Add new test to verify post list invalidation
@@ -281,13 +310,16 @@ If `invalidate_post_lists()` should exist but doesn't:
 ## Technical Details
 
 **Files to Modify**:
+
 1. `backend/apps/forum/tests/test_cache_integration.py` (3 test methods)
 
 **Files to Review**:
+
 1. `backend/apps/forum/services/forum_cache_service.py` (verify available methods)
 2. `backend/apps/forum/signals.py` (verify signal implementation)
 
 **Cache Service Methods** (expected):
+
 ```python
 class ForumCacheService:
     @classmethod
@@ -305,6 +337,7 @@ class ForumCacheService:
 ```
 
 **Signal Handlers** (from `apps/forum/signals.py`):
+
 - `invalidate_category_caches` - Category create/update/delete
 - `invalidate_thread_caches` - Thread create/update/delete
 - `invalidate_post_caches` - Post create/update/delete
@@ -323,8 +356,10 @@ class ForumCacheService:
 ## Work Log
 
 ### 2025-11-02 - Test Failure Discovery
+
 **By:** Dependency Update Verification Process
 **Actions:**
+
 - Ran forum cache integration tests after dependency updates
 - Identified 3 tests failing on mock assertions
 - Analyzed signal handler implementation
@@ -332,12 +367,14 @@ class ForumCacheService:
 - Created TODO for systematic fix
 
 **Analysis**:
+
 - Tests written with incorrect expectations
 - Signal implementation appears correct (invalidates thread caches appropriately)
 - `invalidate_post_lists()` method may not exist or may not be needed
 - Simple fix: update test assertions to match reality
 
 **Priority**: P3 (Low-Medium)
+
 - Cache integration works correctly in production
 - Tests verify wrong behavior but actual behavior is correct
 - Not blocking deployment
@@ -347,23 +384,26 @@ class ForumCacheService:
 
 - Forum Cache Service: `backend/apps/forum/services/forum_cache_service.py`
 - Forum Signals: `backend/apps/forum/signals.py`
-- Django Signals: https://docs.djangoproject.com/en/5.2/topics/signals/
-- Python unittest.mock: https://docs.python.org/3/library/unittest.mock.html
+- Django Signals: <https://docs.djangoproject.com/en/5.2/topics/signals/>
+- Python unittest.mock: <https://docs.python.org/3/library/unittest.mock.html>
 
 ## Notes
 
 **Why This Matters**:
+
 - Test suite should verify actual behavior
 - Incorrect mocks give false confidence
 - Could mask real cache invalidation issues
 
 **Why P3 (Not Urgent)**:
+
 - Manual testing shows cache invalidation works
 - Production monitoring shows no cache staleness issues
 - Only affects test suite, not user-facing features
 - Cache hit rate (40%) is healthy
 
 **Future Prevention**:
+
 - Write integration tests that verify actual cache behavior, not just mock calls
 - Consider Option 3 for more realistic cache testing
 - Add cache monitoring to CI to catch invalidation issues


### PR DESCRIPTION
## Summary

Retires the legacy `backend/todos/` system (October–November 2025, pre-dating the repo-root `todos/`). The four loose files move into `backend/todos/archive/`, with statuses corrected and a short archival note recording each verdict:

- **007 jwt-secret-key-enforcement** — completion record from Nov 11 2025 (commit a81416c) whose own "archive this todo" next-step never happened; moved as-is. The enforcement it documents is still live (`settings.py:574-637` + `test_jwt_secret_key_validation.py`).
- **061 forum phase 3 rich content** — superseded: written for the django-machina-era `apps/forum`, retired in #362 and rebuilt as `packages/wagtail_forum/`; the current forum roadmap is tracked in root `todos/` 253–264.
- **090 fix api versioning tests** — resolved since: `test_api.py` was rewritten to namespaced `reverse("v1:...")` URLs (99bd7b3, later reworked in #334/#335); Backend CI is green on main.
- **091 forum cache test mocks** — superseded: `apps/forum/tests/test_cache_integration.py` and `apps/forum/signals.py` no longer exist.
- **README** — banner marking the legacy system closed; active todos live in root `todos/`.

Doc-only; no code changes. Most of the line churn is markdownlint's whole-file autofix (the pre-commit gate lints entire touched files), plus manual MD029 renumbering the autofix couldn't do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)