### PR TITLE
fix: resolve forum-wagtail audit findings (5 verified, 0 deferred)

### DIFF
--- a/.claude/agents/wagtail-reviewer.md
+++ b/.claude/agents/wagtail-reviewer.md
@@ -110,6 +110,24 @@ You review: `apps/blog/`, Wagtail page models, StreamField blocks, signals, Wagt
   is not the same thing — the check is about attributes read off the *User*
   instance specifically.
 
+### Forum-wagtail audit additions (2026-07-17)
+
+- Programmatic page creation (seed/management commands, data migrations):
+  is the parent resolved from `Site.root_page` (default Site, with
+  `DoesNotExist`/`MultipleObjectsReturned` handled)? A parent from
+  `Page.objects.filter(depth=1)` is the unroutable treebeard root — the page
+  gets `url = None` and `route()` never reaches it. Does the code follow
+  `add_child()` with `save_revision().publish()`? And do the tests assert
+  routability (`get_url() is not None` / `is_descendant_of(site_root)`), not
+  just counts and `live`?
+- Hardcoded admin-mount URLs (`/cms/...`, `/blog-admin/...`) in
+  `wagtail_hooks.py`, admin templates, `SearchArea`/`MenuItem`/`SummaryItem`
+  constructions, or listing-button hooks: flag them — the fix is `reverse()`
+  via `Model.snippet_viewset.get_url_name(...)` or the app URL namespace,
+  called inside the hook function body. Also check the converted URL names
+  are exercised by at least one admin render test (explorer listing for
+  listing-button hooks) so a rename fails as `NoReverseMatch` in CI.
+
 ## Output Format (Review Mode)
 
 Return ONLY this JSON structure (no surrounding prose, no markdown fences in the actual response — the example fences below show the schema):

--- a/backend/apps/blog/tests/test_admin_render_smoke.py
+++ b/backend/apps/blog/tests/test_admin_render_smoke.py
@@ -123,3 +123,54 @@ class WagtailAdminRenderSmokeTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIn(b"1 Featured Posts", response.content)
         self.assertIn(b"1 Pending Comments", response.content)
+
+    def test_page_listing_renders_blog_post_buttons_with_resolved_urls(self):
+        """The page explorer listing renders BlogPostPage rows through
+        blog_page_listing_buttons/more_buttons — all five reverse()'d
+        blog_admin URL names execute here, so a renamed or removed route
+        fails as NoReverseMatch instead of shipping a dead admin button
+        (audit 2026-07-17 M2, Phase 6)."""
+        author = User.objects.create_user(username="blog-author-3")
+        index = self._blog_index()
+        featured = BlogPostPage(
+            title="Featured Listed",
+            slug="featured-listed",
+            author=author,
+            publish_date=date.today(),
+            introduction="<p>Intro.</p>",
+            is_featured=True,
+            reading_time=1,  # < 3 → "AI Suggestions" button branch
+        )
+        index.add_child(instance=featured)
+        featured.save_revision().publish()
+        BlogComment.objects.create(
+            post=featured, author=author, content="ok", is_approved=True
+        )
+        plain = BlogPostPage(
+            title="Plain Listed",
+            slug="plain-listed",
+            author=author,
+            publish_date=date.today(),
+            introduction="<p>Intro.</p>",
+        )
+        index.add_child(instance=plain)
+        plain.save_revision().publish()
+
+        admin = User.objects.create_superuser(username="root3", email="r3@x.io")
+        self.client.force_login(admin)
+        response = self.client.get(
+            reverse("wagtailadmin_explore", args=(index.id,)), secure=True
+        )
+
+        self.assertEqual(response.status_code, 200)
+        for name, page in (
+            ("post_comments", featured),
+            ("post_ai_suggestions", featured),
+            ("unfeature_post", featured),
+            ("feature_post", plain),
+            ("tag_plants", featured),
+        ):
+            self.assertIn(
+                reverse(f"blog_admin:{name}", args=(page.id,)).encode(),
+                response.content,
+            )

--- a/backend/apps/blog/tests/test_wagtail_hooks_urls.py
+++ b/backend/apps/blog/tests/test_wagtail_hooks_urls.py
@@ -1,0 +1,36 @@
+"""Blog admin hooks resolve their URLs via the blog_admin namespace.
+
+Audit 2026-07-17 M2: every /blog-admin/... URL in wagtail_hooks.py was
+hardcoded; now they all go through reverse("blog_admin:<name>"). These tests
+render the real admin pages, so a NoReverseMatch (renamed/removed route) or a
+regression to a dead hardcoded path fails loudly instead of 404ing silently.
+"""
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+
+User = get_user_model()
+
+
+@pytest.mark.django_db
+def test_admin_home_renders_blog_menu_and_summary_with_resolved_urls(client):
+    admin = User.objects.create_superuser(username="root", email="r@x.io")
+    client.force_login(admin)
+
+    resp = client.get("/cms/")
+
+    assert resp.status_code == 200
+    # Menu item + "Blog Posts" summary item both carry the dashboard URL.
+    assert reverse("blog_admin:dashboard").encode() in resp.content
+
+
+@pytest.mark.django_db
+def test_admin_search_page_renders_blog_search_area_with_resolved_url(client):
+    admin = User.objects.create_superuser(username="root", email="r@x.io")
+    client.force_login(admin)
+
+    resp = client.get(reverse("wagtailadmin_pages:search"), {"q": "anything"})
+
+    assert resp.status_code == 200
+    assert reverse("blog_admin:search").encode() in resp.content

--- a/backend/apps/blog/wagtail_hooks.py
+++ b/backend/apps/blog/wagtail_hooks.py
@@ -6,8 +6,8 @@ and plant-specific content suggestions for the blog system.
 """
 
 from django.contrib.auth import get_user_model
+from django.urls import reverse
 from django.utils.html import format_html
-from django.utils.safestring import mark_safe
 from wagtail import hooks
 from wagtail.admin import widgets as wagtailadmin_widgets
 from wagtail.admin.menu import MenuItem
@@ -17,6 +17,10 @@ from wagtail.admin.site_summary import SummaryItem
 from .models import BlogComment, BlogPostPage
 
 User = get_user_model()
+
+# Admin URLs are resolved via the blog_admin namespace (apps/blog/admin_urls.py),
+# never hardcoded to the /blog-admin/ mount (audit 2026-07-17 M2). All reverse()
+# calls stay inside hook functions — hooks fire per-request, after URLconf load.
 
 
 @hooks.register("register_rich_text_features")
@@ -34,7 +38,10 @@ def register_blog_menu():
     Add blog management menu items to Wagtail admin.
     """
     return MenuItem(
-        "Blog Management", "/blog-admin/", icon_name="doc-full-inverse", order=200
+        "Blog Management",
+        reverse("blog_admin:dashboard"),
+        icon_name="doc-full-inverse",
+        order=200,
     )
 
 
@@ -124,8 +131,9 @@ def add_blog_stats_panel(request, panels):
                 else ""
             ),
             moderate_html=(
-                mark_safe(
-                    '<a href="/blog-admin/comments/" class="button warning">Moderate Comments</a>'
+                format_html(
+                    '<a href="{}" class="button warning">Moderate Comments</a>',
+                    reverse("blog_admin:moderate_comments"),
                 )
                 if pending_comments > 0
                 else ""
@@ -205,7 +213,7 @@ def add_blog_summary_items(request, items):
             label="Blog Posts",
             count=post_count,
             url_label="View All Posts",
-            url="/blog-admin/",
+            url=reverse("blog_admin:dashboard"),
             icon_name="doc-full",
             order=200,
         )
@@ -218,7 +226,7 @@ def add_blog_summary_items(request, items):
                 label="Featured Posts",
                 count=featured_count,
                 url_label="Manage Featured",
-                url="/blog-admin/featured/",
+                url=reverse("blog_admin:featured_posts"),
                 icon_name="pick",
                 order=201,
             )
@@ -231,7 +239,7 @@ def add_blog_summary_items(request, items):
                 label="Pending Comments",
                 count=pending_comments,
                 url_label="Moderate",
-                url="/blog-admin/comments/",
+                url=reverse("blog_admin:moderate_comments"),
                 icon_name="warning",
                 order=202,
             )
@@ -256,7 +264,7 @@ def blog_page_listing_buttons(
         if page.view_count > 0:
             yield wagtailadmin_widgets.ListingButton(
                 f"{page.view_count:,} views",
-                f"#",  # Could link to detailed analytics
+                "#",  # Could link to detailed analytics
                 icon_name="view",
                 priority=15,
                 attrs={"title": f"{page.view_count:,} total views"},
@@ -267,7 +275,7 @@ def blog_page_listing_buttons(
         if comment_count > 0:
             yield wagtailadmin_widgets.ListingButton(
                 f"Comments ({comment_count})",
-                f"/blog-admin/posts/{page.id}/comments/",
+                reverse("blog_admin:post_comments", args=(page.id,)),
                 icon_name="comment",
                 priority=20,
             )
@@ -276,7 +284,7 @@ def blog_page_listing_buttons(
         if page.reading_time and page.reading_time < 3:
             yield wagtailadmin_widgets.ListingButton(
                 "AI Suggestions",
-                f"/blog-admin/posts/{page.id}/ai-suggestions/",
+                reverse("blog_admin:post_ai_suggestions", args=(page.id,)),
                 icon_name="help",
                 priority=30,
             )
@@ -294,14 +302,14 @@ def blog_page_listing_more_buttons(
         if page.is_featured:
             yield wagtailadmin_widgets.Button(
                 "Unfeature",
-                f"/blog-admin/posts/{page.id}/unfeature/",
+                reverse("blog_admin:unfeature_post", args=(page.id,)),
                 icon_name="cross",
                 priority=10,
             )
         else:
             yield wagtailadmin_widgets.Button(
                 "Feature",
-                f"/blog-admin/posts/{page.id}/feature/",
+                reverse("blog_admin:feature_post", args=(page.id,)),
                 icon_name="pick",
                 priority=10,
             )
@@ -309,7 +317,7 @@ def blog_page_listing_more_buttons(
         # Plant species tagging
         yield wagtailadmin_widgets.Button(
             "Tag Plants",
-            f"/blog-admin/posts/{page.id}/tag-plants/",
+            reverse("blog_admin:tag_plants", args=(page.id,)),
             icon_name="tag",
             priority=20,
         )
@@ -345,7 +353,7 @@ def register_blog_settings_menu_item():
     Add blog settings to the Wagtail admin settings menu.
     """
     return MenuItem(
-        "Blog Settings", "/blog-admin/settings/", icon_name="cog", order=400
+        "Blog Settings", reverse("blog_admin:settings"), icon_name="cog", order=400
     )
 
 
@@ -356,7 +364,7 @@ def register_blog_search():
     """
     return SearchArea(
         "Blog Content",
-        "/blog-admin/search/",
+        reverse("blog_admin:search"),
         name="blog",
         icon_name="doc-full",
         order=300,
@@ -410,7 +418,7 @@ def register_blog_permissions():
                 "delete_blogpostpage",
             ],
         )
-    except:
+    except Exception:
         return []
 
 

--- a/backend/apps/forum_host/management/commands/seed_default_forum.py
+++ b/backend/apps/forum_host/management/commands/seed_default_forum.py
@@ -1,5 +1,5 @@
 from django.core.management.base import BaseCommand, CommandError
-from wagtail.models import Page
+from wagtail.models import Site
 from wagtail_forum.collections import get_forum_image_collection
 from wagtail_forum.models import ForumBoard, ForumIndex
 
@@ -11,26 +11,58 @@ class Command(BaseCommand):
     )
 
     def handle(self, *args, **options):
+        # The forum must live under the Site's root_page (the routable tree),
+        # NOT the depth-1 treebeard root — a page attached there is a sibling
+        # of Home: page.url is None and serve()/route() never reaches it
+        # (audit 2026-07-17 H1).
+        try:
+            site_root = Site.objects.get(is_default_site=True).root_page
+        except Site.DoesNotExist:
+            raise CommandError(
+                "No default Wagtail Site found. Run migrations before seeding."
+            )
+        except Site.MultipleObjectsReturned:
+            raise CommandError(
+                "Multiple default Wagtail Sites found; fix is_default_site "
+                "flags before seeding."
+            )
+
         index = ForumIndex.objects.first()
         if index is None:
-            root = Page.objects.filter(depth=1).first()
-            if root is None:
-                raise CommandError(
-                    "No Wagtail root page found. Run migrations before seeding."
-                )
-            index = root.add_child(instance=ForumIndex(title="Forum", slug="forum"))
+            index = site_root.add_child(
+                instance=ForumIndex(title="Forum", slug="forum")
+            )
+            # Bare add_child leaves live=True with zero revisions and no
+            # first_published_at; publish a revision for parity with
+            # admin-created pages (audit 2026-07-17 L1). These page types
+            # carry no moderation workflow, so publishing directly is safe.
+            index.save_revision().publish()
             self.stdout.write(self.style.SUCCESS("Created ForumIndex 'forum'."))
+        elif not index.is_descendant_of(site_root):
+            # Repair a pre-audit seed that attached the forum outside the
+            # routable tree; move() also fixes descendant url_paths.
+            index.move(site_root, pos="last-child")
+            index = ForumIndex.objects.get(pk=index.pk)
+            # A pre-audit seed also never published a revision — repair that
+            # too, for the index and any boards it already contains.
+            for page in [index, *index.get_children().type(ForumBoard).specific()]:
+                if not page.revisions.exists():
+                    page.save_revision().publish()
+            self.stdout.write(
+                self.style.SUCCESS("Moved ForumIndex under the site root page.")
+            )
         else:
             self.stdout.write("ForumIndex 'forum' already exists.")
 
         if not index.get_children().type(ForumBoard).exists():
-            index.add_child(
+            board = index.add_child(
                 instance=ForumBoard(
                     title="General Discussion",
                     slug="general-discussion",
                     description="Talk about anything plant-related.",
                 )
             )
+            board.save_revision().publish()
             self.stdout.write(self.style.SUCCESS("Created board 'general-discussion'."))
         else:
             self.stdout.write("Forum already seeded; nothing to do.")

--- a/backend/apps/forum_host/tests/test_seed_command.py
+++ b/backend/apps/forum_host/tests/test_seed_command.py
@@ -1,6 +1,6 @@
 import pytest
 from django.core.management import call_command
-from wagtail.models import Collection
+from wagtail.models import Collection, Page, Site
 from wagtail_forum.models import ForumBoard, ForumIndex
 
 
@@ -13,6 +13,57 @@ def test_seed_default_forum_is_idempotent():
     board = ForumBoard.objects.get()
     assert board.live is True
     assert board.slug == "general-discussion"
+
+
+@pytest.mark.django_db
+def test_seed_default_forum_pages_are_routable():
+    # Audit 2026-07-17 H1: seeding under the depth-1 treebeard root instead of
+    # the Site's root_page left the forum as a sibling of Home — outside every
+    # site's routable tree, so page.url was None and serve()/route() never
+    # reached it. The seed must attach under Site.root_page.
+    call_command("seed_default_forum")
+    site_root = Site.objects.get(is_default_site=True).root_page
+    index = ForumIndex.objects.get()
+    board = ForumBoard.objects.get()
+    assert index.is_descendant_of(site_root)
+    assert index.get_url() is not None
+    assert board.get_url() is not None
+
+
+@pytest.mark.django_db
+def test_seed_default_forum_publishes_with_revisions():
+    # Audit 2026-07-17 L1: bare add_child() leaves live=True with zero
+    # revisions and first_published_at=None (no page_published fired) —
+    # seeded pages must have revision parity with admin-created ones.
+    call_command("seed_default_forum")
+    index = ForumIndex.objects.get()
+    board = ForumBoard.objects.get()
+    for page in (index, board):
+        assert page.live is True
+        assert page.revisions.count() == 1
+        assert page.first_published_at is not None
+
+
+@pytest.mark.django_db
+def test_seed_default_forum_repairs_misparented_index():
+    # A DB seeded by the pre-audit command has ForumIndex under the tree root
+    # (unroutable) and no revisions on either page. Re-running the seed must
+    # move it under Site.root_page and publish revisions, rather than leaving
+    # it broken behind the "already exists" branch.
+    tree_root = Page.objects.filter(depth=1).first()
+    index = tree_root.add_child(instance=ForumIndex(title="Forum", slug="forum"))
+    index.add_child(
+        instance=ForumBoard(title="General Discussion", slug="general-discussion")
+    )
+    call_command("seed_default_forum")
+    site_root = Site.objects.get(is_default_site=True).root_page
+    index = ForumIndex.objects.get()
+    board = ForumBoard.objects.get()
+    assert index.is_descendant_of(site_root)
+    assert index.get_url() is not None
+    for page in (index, board):
+        assert page.revisions.count() == 1
+        assert page.first_published_at is not None
 
 
 @pytest.mark.django_db

--- a/backend/docs/patterns/domain/wagtail.md
+++ b/backend/docs/patterns/domain/wagtail.md
@@ -204,3 +204,32 @@ explaining the new number.
 
 Reference: `backend/packages/wagtail_forum/wagtail_forum/workflow.py`,
 `wagtail_forum/tests/test_actor_attribution.py`.
+
+## Concurrency-safe lazy get-or-create for shared Wagtail rows (double-checked locking)
+
+`Collection.name` (like several Wagtail models) has no unique constraint, so a
+bare check-then-create helper can race two concurrent first callers into
+duplicates. Keep the steady-state read lock-free and serialize only the create
+path on the parent row (audit 2026-07-17 L2, `wagtail_forum/collections.py`):
+
+```python
+def get_forum_image_collection():
+    name = get_setting("IMAGE_COLLECTION_NAME")
+    root = Collection.get_first_root_node()
+    existing = root.get_children().filter(name=name).first()
+    if existing is not None:
+        return existing                      # hot path: no lock, no txn
+    with transaction.atomic():
+        locked_root = Collection.objects.select_for_update().get(pk=root.pk)
+        existing = locked_root.get_children().filter(name=name).first()
+        if existing is not None:
+            return existing                  # lost the race — reuse
+        return locked_root.add_child(name=name)
+```
+
+Why the shape matters: locking on *every* call would serialize all image
+operations on one row; the re-check after acquiring the lock is what closes the
+race (READ COMMITTED re-reads committed rows post-lock); and `add_child()`s
+treebeard path/numchild math happens safely under the held parent lock. Test
+the race branch deterministically (monkeypatch the fast path to miss once) —
+NOT with threads + `transaction=True` (see docs/rules/testing.md).

--- a/backend/packages/wagtail_forum/wagtail_forum/collections.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/collections.py
@@ -7,16 +7,28 @@ idempotently so neither the upload view nor body validation depends on a
 separate seeding step.
 """
 
+from django.db import transaction
 from wagtail.models import Collection
 
 from .conf import get_setting
 
 
 def get_forum_image_collection():
-    """Return the forum image collection, creating it under root if absent."""
+    """Return the forum image collection, creating it under root if absent.
+
+    Collection.name has no unique constraint, so bare check-then-create can
+    race two concurrent first callers into duplicate collections (audit
+    2026-07-17 L2). Double-checked locking: the steady-state read stays
+    lock-free; only the create path serializes on the root collection row.
+    """
     name = get_setting("IMAGE_COLLECTION_NAME")
     root = Collection.get_first_root_node()
     existing = root.get_children().filter(name=name).first()
     if existing is not None:
         return existing
-    return root.add_child(name=name)
+    with transaction.atomic():
+        locked_root = Collection.objects.select_for_update().get(pk=root.pk)
+        existing = locked_root.get_children().filter(name=name).first()
+        if existing is not None:
+            return existing
+        return locked_root.add_child(name=name)

--- a/backend/packages/wagtail_forum/wagtail_forum/templates/wagtail_forum/homepage/site_summary_moderation.html
+++ b/backend/packages/wagtail_forum/wagtail_forum/templates/wagtail_forum/homepage/site_summary_moderation.html
@@ -2,7 +2,7 @@
 
 <li>
     {% icon name="warning" %}
-    <a href="/cms/snippets/wagtail_forum/topic/?live=false">
+    <a href="{{ moderation_url }}?live=false">
         {{ count }} Forum post{{ count|pluralize }} awaiting moderation
     </a>
 </li>

--- a/backend/packages/wagtail_forum/wagtail_forum/tests/test_admin.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/tests/test_admin.py
@@ -82,6 +82,13 @@ def test_moderation_summary_item_counts_spam_rejected_post(client):
     assert resp.status_code == 200
     assert b"1 Forum post awaiting moderation" in resp.content
 
+    # Audit 2026-07-17 M1: the panel link is resolved via the snippet
+    # viewset's URL name, not hardcoded to the /cms/ mount.
+    from django.urls import reverse
+
+    expected_url = reverse(Topic.snippet_viewset.get_url_name("list"))
+    assert f'href="{expected_url}?live=false"'.encode() in resp.content
+
 
 @pytest.mark.django_db
 def test_forum_search_area_appears_on_admin_pages_search(client):
@@ -98,6 +105,13 @@ def test_forum_search_area_appears_on_admin_pages_search(client):
 
     assert resp.status_code == 200
     assert b"Forum" in resp.content
+
+    # Audit 2026-07-17 M1: the search area's target is resolved via the
+    # snippet viewset's URL name, not hardcoded to the /cms/ mount.
+    from wagtail_forum.models import Topic
+
+    expected_url = reverse(Topic.snippet_viewset.get_url_name("list"))
+    assert expected_url.encode() in resp.content
 
 
 @pytest.mark.django_db

--- a/backend/packages/wagtail_forum/wagtail_forum/tests/test_collections.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/tests/test_collections.py
@@ -4,6 +4,38 @@ from wagtail_forum.collections import get_forum_image_collection
 
 
 @pytest.mark.django_db
+def test_get_forum_image_collection_locked_recheck_reuses_existing(monkeypatch):
+    # Audit 2026-07-17 L2: Collection.name has no unique constraint, so the
+    # pre-fix check-then-create could race two concurrent first callers into
+    # duplicate "Forum Images" collections. Simulate losing that race
+    # deterministically: the unlocked fast-path check misses (patched to
+    # return nothing once) while the collection already exists — the
+    # select_for_update re-check must find it and NOT create a duplicate.
+    # (Real threads would need django_db(transaction=True), whose teardown
+    # flush deletes Wagtail's migration-seeded root rows and breaks later
+    # tests — banned per tests/api/test_topic_detail.py. Cross-connection
+    # serialization itself is provided by select_for_update semantics.)
+    existing = get_forum_image_collection()
+
+    orig_get_children = Collection.get_children
+    state = {"missed": False}
+
+    def miss_once(self):
+        if not state["missed"]:
+            state["missed"] = True
+            return Collection.objects.none()
+        return orig_get_children(self)
+
+    monkeypatch.setattr(Collection, "get_children", miss_once)
+
+    result = get_forum_image_collection()
+
+    assert state["missed"] is True  # the fast path really did miss
+    assert result.pk == existing.pk
+    assert Collection.objects.filter(name="Forum Images").count() == 1
+
+
+@pytest.mark.django_db
 def test_get_forum_image_collection_is_idempotent():
     first = get_forum_image_collection()
     second = get_forum_image_collection()

--- a/backend/packages/wagtail_forum/wagtail_forum/wagtail_hooks.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/wagtail_hooks.py
@@ -124,7 +124,14 @@ class ForumModerationSummaryItem(SummaryItem):
         self.count = count
 
     def get_context_data(self, parent_context):
-        return {"count": self.count}
+        from django.urls import reverse
+
+        return {
+            "count": self.count,
+            # Resolved, not hardcoded: the admin mount (/cms/ here) is host
+            # config, and this package is reusable (audit 2026-07-17 M1).
+            "moderation_url": reverse(Topic.snippet_viewset.get_url_name("list")),
+        }
 
 
 @hooks.register("construct_homepage_summary_items")
@@ -147,9 +154,11 @@ def register_forum_search_area():
     SearchArea is a plain positional-args class (confirmed via
     wagtail.admin.search.SearchArea) — not the Component-style trap
     ForumModerationSummaryItem's docstring above warns about."""
+    from django.urls import reverse
+
     return SearchArea(
         "Forum",
-        "/cms/snippets/wagtail_forum/topic/",
+        reverse(Topic.snippet_viewset.get_url_name("list")),
         name="forum",
         icon_name="group",
         order=300,

--- a/docs/LEARNINGS.md
+++ b/docs/LEARNINGS.md
@@ -1412,3 +1412,55 @@ guards outside the hunk. A same-session captured trigger reviewing the very
 diff that spawned it is the highest-risk case. Bypass only with the
 refutation written into the commit message; never bypass an unevaluated
 CRITICAL.
+
+## Forum Wagtail-integration audit (2026-07-17 additions)
+
+### [2026-07-17] `seed_default_forum` planted the forum outside the routable page tree
+
+The seed command (wired into `railway.json` preDeployCommand) resolved its
+parent with `Page.objects.filter(depth=1).first()` — the invisible treebeard
+tree root — and `add_child`ed the ForumIndex there, making it a *sibling* of
+the homepage instead of a descendant. Wagtail routing only walks descendants
+of `Site.root_page` (`Page._get_relevant_site_root_paths()` requires
+`url_path.startswith(site_root_path)`), so `page.url`/`full_url` were `None`,
+`route()` never reached the forum, and admin "View live"/sitemaps were dead —
+empirically confirmed against a live DB. The forum had never been deployed, so
+this would have shipped broken on the FIRST production deploy. Root cause:
+conflating "tree root" (depth 1) with "site root page" (depth 2, what
+`Site.root_page` points at). Fix: resolve the default Site's `root_page`
+(guarding `DoesNotExist`/`MultipleObjectsReturned`), add a `Page.move` repair
+branch for already-mis-seeded DBs (with revision backfill), and make the seed
+test assert **routability** (`get_url() is not None`,
+`is_descendant_of(site_root)`) — count/liveness assertions alone can't catch a
+tree-placement bug. Note `Page.move()` leaves the in-memory instance stale
+(treebeard); the post-move refetch is required, not defensive.
+
+### [2026-07-17] `django_db(transaction=True)` passes standalone, fails in-suite (and is itself a flush hazard)
+
+A threaded concurrency test for the collection get-or-create race used
+`django_db(transaction=True)` and passed in isolation, then failed in the full
+suite: `Collection.get_first_root_node()` returned `None` because
+transactional-test teardown flush (plus blog's `TransactionTestCase` in
+`test_analytics.py`, which runs earlier via `testpaths = apps packages`
+ordering) had deleted Wagtail's migration-seeded rows — and the new test's own
+teardown flush would equally break later tests. The repo already documented
+this ban in a code comment (`wagtail_forum/tests/api/test_topic_detail.py`)
+but not in `docs/rules/testing.md`, so it recurred. Replaced with a
+deterministic simulation: monkeypatch the unlocked fast-path check to miss
+once, assert the `select_for_update` re-check reuses the existing row and the
+miss actually happened. Cross-connection serialization itself is
+reasoning-verified from `SELECT ... FOR UPDATE` semantics, flagged as such.
+
+### [2026-07-17] Worktree test runs silently exercise the MAIN checkout's package code
+
+The backend venv installs `wagtail_forum` as a modern editable install whose
+finder hardcodes the main checkout path. In an audit worktree, `import
+wagtail_forum` therefore resolves to main's copy: worktree edits to the
+package are NOT under test unless `PYTHONPATH=<worktree>/backend/packages/
+wagtail_forum` is prepended (plain `sys.path` entries beat the appended
+editable meta-path finder). The visible symptom is pytest's "import file
+mismatch" collection error; the invisible one is green tests against
+unpatched code. Related: two pytest sessions run concurrently (main checkout +
+worktree) share the single `test_plant_community` Postgres DB and destroy each
+other — one baseline run produced 900+ phantom `OperationalError`s. Serialize
+all backend test runs, and re-derive baselines when a run overlapped another.

--- a/docs/audits/2026-07-17-forum-wagtail.md
+++ b/docs/audits/2026-07-17-forum-wagtail.md
@@ -1,0 +1,127 @@
+# Audit: Forum — Wagtail Integration Correctness
+
+> **Date:** 2026-07-17
+> **Trigger:** User-invoked `/audit` after the forum notifications epic work (todo 253
+> slices 1–6, PRs #445–#470). Focus: whether the forum package's Wagtail integration
+> properly follows current Wagtail documentation (7.4.2). Security explicitly
+> out of scope this round (user directive).
+> **Domains:** wagtail
+> **Baseline:** `manage.py test --noinput`: 689 tests OK (8 skipped) | `manage.py check`: 0 issues
+> ⚠ Mid-audit discovery: the authoritative runner is **pytest** (`manage.py test` misses the function-based forum tests, per docs/rules/testing.md); the pre-fix pytest baseline run was invalidated by a concurrent-test-DB collision — close-out relies on the full worktree pytest run below plus the July 11 audit's 906-passed reference.
+> **Versions:** Wagtail 7.4.2, Django 6.0.7, DRF 3.17.1
+> **Branch at start:** `main` (04bf781)
+
+## Findings
+
+Each finding has a lifecycle: `open` → `fixing` → `verified` or `deferred` or `false-positive`.
+
+**Status key:**
+
+- `open` — Found but not yet addressed
+- `fixing` — Work in progress
+- `verified` — Fix applied AND confirmed by test/grep/type-check
+- `deferred` — Intentionally postponed (must link to todo)
+- `false-positive` — Agent was wrong or issue was already fixed
+
+**Research key** (Phase 2.5 verdict, recorded in the `Research` column):
+
+- `confirmed` — current documentation agrees the finding is valid
+- `better-fix` — finding is real, but current docs show a cleaner fix (described in the `Verification` column for Phase 3 to use)
+- `contradicted ⚠` — current docs say the flagged pattern is fine; may be a false positive — decide at triage
+- `—` — research not applicable, or finding predates Phase 2.5
+
+### Critical
+
+| ID  | Finding       | Domain | Agent                 | File(s)     | Research | Status | Verification |
+| --- | ------------- | ------ | --------------------- | ----------- | -------- | ------ | ------------ |
+
+### High
+
+| ID  | Finding       | Domain | Agent                 | File(s)     | Research | Status | Verification |
+| --- | ------------- | ------ | --------------------- | ----------- | -------- | ------ | ------------ |
+| H1  | `seed_default_forum` attaches ForumIndex under the depth-1 treebeard root (`Page.objects.filter(depth=1)`) instead of the Site's `root_page` (depth 2) — pages land as siblings of Home, outside the routable tree: `page.url`/`full_url` = `None`, `route()` never reaches them, admin "View live"/sitemap broken. Empirically verified against live DB. Wired into `railway.json` preDeployCommand, so fires on first prod deploy. Defeats the July H17 fallback-template fix. | wagtail | wagtail-reviewer (serving/host) | `backend/apps/forum_host/management/commands/seed_default_forum.py:16,21` | confirmed | verified | Site.root_page resolution + mis-parented repair via `Page.move`; tests `test_seed_default_forum_pages_are_routable` + `..._repairs_misparented_index` green (5/5 file); kimi-review clean |
+
+### Medium
+
+| ID  | Finding       | Domain | Agent                 | File(s)     | Research | Status | Verification |
+| --- | ------------- | ------ | --------------------- | ----------- | -------- | ------ | ------------ |
+| M1  | Hardcoded `/cms/snippets/wagtail_forum/topic/` admin URL in the forum SearchArea and moderation summary template instead of `reverse()`/`{% url %}` via `SnippetViewSet.get_url_name()` — silently 404s if the admin mount changes or the "reusable" package lands in a host with a different mount. Wagtail's own SearchAreas use `reverse("wagtailimages:index")`. | wagtail | wagtail-reviewer (admin) | `backend/packages/wagtail_forum/wagtail_forum/wagtail_hooks.py:152`, `templates/wagtail_forum/homepage/site_summary_moderation.html:5` | confirmed | verified | Both sites now `reverse(Topic.snippet_viewset.get_url_name("list"))`; tests pin resolved hrefs (test_admin.py 12/12 green); kimi-review clean |
+| M2  | Blog has the same hardcoded-admin-URL anti-pattern M1 was copied from (forum hook docstring says "mirrors the blog's register_blog_search"): 12+ hardcoded `/blog-admin/...` URLs across `apps/blog/wagtail_hooks.py` (SearchArea `/blog-admin/search/`, MenuItem `/blog-admin/settings/`, dashboard buttons, per-page action links). Outside forum scope — found incidentally by Phase 2.5 research. | wagtail | docs-researcher (incidental) | `backend/apps/blog/wagtail_hooks.py:37,128,208-312,348,359` | confirmed | verified | All 11 URLs now `reverse("blog_admin:<name>")` (dead `mark_safe` import dropped, `format_html` with args per rule); new `test_wagtail_hooks_urls.py` renders /cms/ + pages search and pins resolved URLs (2/2 green); kimi-review clean |
+
+### Low
+
+| ID  | Finding       | Domain | Agent                 | File(s)     | Research | Status | Verification |
+| --- | ------------- | ------ | --------------------- | ----------- | -------- | ------ | ------------ |
+| L1  | `seed_default_forum` never calls `save_revision().publish()` after `add_child` — pages are `live=True` with zero revisions and `first_published_at=None`; no `page_published` fires. No current receiver depends on it (grep-confirmed), but diverges from the repo's own blog-seed pattern (`create_demo_blog_posts.py:160`). | wagtail | wagtail-reviewer (serving/host) | `backend/apps/forum_host/management/commands/seed_default_forum.py:21,27-33` | confirmed | verified | `save_revision().publish()` after both `add_child` calls; test `test_seed_default_forum_publishes_with_revisions` asserts live + 1 revision + first_published_at; kimi-review clean |
+| L2  | `get_forum_image_collection()` docstring claims "idempotently" but is non-atomic check-then-create with no unique constraint on `Collection.name` — two concurrent first callers can create duplicate "Forum Images" collections. Primary seeding moved to deploy-time (todo 247) so the race only remains for hosts that skip the seed command; docstring/behavior mismatch. | wagtail | wagtail-reviewer (admin) | `backend/packages/wagtail_forum/wagtail_forum/collections.py:15-22` | — | verified | Double-checked `select_for_update` on root collection row; deterministic locked-recheck race test `test_get_forum_image_collection_locked_recheck_reuses_existing` (first threaded draft violated the repo's no-`transaction=True` rule — flush wiped migration-seeded root rows in full-suite context; reworked per tests/api/test_topic_detail.py convention); kimi-review clean ×2 |
+
+## Deferred Items
+
+Items marked `deferred` must have a linked todo and rationale.
+
+| ID  | Todo | Rationale |
+| --- | ---- | --------- |
+| —   | —    | —         |
+
+## Summary
+
+| Severity  | Found | Verified | Deferred | False-positive | Open  |
+| --------- | ----- | -------- | -------- | -------------- | ----- |
+| Critical  | 0     | 0        | 0        | 0              | 0     |
+| High      | 1     | 1        | 0        | 0              | 0     |
+| Medium    | 2     | 2        | 0        | 0              | 0     |
+| Low       | 2     | 2        | 0        | 0              | 0     |
+| **Total** | 5     | 5        | 0        | 0              | **0** |
+
+## Close-out
+
+- Full worktree pytest suite: **1088 passed, 8 skipped, 0 failed** (`manage.py check`: clean).
+- Worktree test-run mechanics (for future audits): the venv's `wagtail_forum` is an
+  editable install pointing at the MAIN checkout — worktree runs must prepend
+  `PYTHONPATH=<worktree>/backend/packages/wagtail_forum` or package edits are
+  silently not under test; and never run two pytest sessions concurrently (shared
+  `test_plant_community` DB → phantom connection errors).
+
+## Phase 6 — Code Review
+
+`code-review-orchestrator` routed the staged diff to `wagtail-reviewer` +
+`cross-cutting-reviewer` (both verified against installed Wagtail 7.4.2 source).
+No Critical/High/Medium findings. Deduped results:
+
+- **Low (both reviewers): repair branch skipped revision parity** — a
+  pre-audit-seeded forum repaired by `Page.move` kept 0 revisions /
+  `first_published_at=None`, inconsistent with the L1 fix's goal. **Fixed:**
+  the repair branch now publishes a first revision for the index and any
+  pre-existing boards lacking one; repair test asserts revision state for both.
+- **Low (cross-cutting): 5 of the converted blog listing-button URL names were
+  test-unreachable** (no test rendered the page explorer with a BlogPostPage
+  child — a rename would only surface in prod). **Fixed:**
+  `test_page_listing_renders_blog_post_buttons_with_resolved_urls` renders the
+  explorer with a featured + plain post and asserts all five resolved hrefs.
+- **Info (residue, not fixed — outside diff):** `add_blog_stats_panel` still
+  hardcodes `/cms/pages/` links (pre-existing; `/cms/` is a documented fixed
+  convention in CLAUDE.md, unlike the app-local `/blog-admin/` mount); the
+  `Site.DoesNotExist → CommandError` branch has no test (requires deleting the
+  migration-seeded default Site).
+
+Both reviewers independently confirmed: `Page.move` + refetch is required-not-
+defensive (treebeard leaves the in-memory instance stale), the new
+`page_published` emissions from seeding are safe (all repo receivers
+isinstance-guard on other types; no workflow assigned to ForumIndex/ForumBoard),
+`reverse()` in hooks is lazy-safe (menu/search registries are cached_property,
+first accessed at request time), and `snippet_viewset` is set at app-ready via
+`SnippetViewSet.on_register()`. kimi-review clean on the Phase 6 repair diff.
+
+## Fix Commits
+
+| Commit | Description |
+| ------ | ----------- |
+| —      | —           |
+
+## Codification (Phase 8)
+
+Completed after fixes are committed. Each row links to the docs change.
+
+| Finding | Destination | Note |
+| ------- | ----------- | ---- |
+| —       | `docs/rules/<domain>.md` / `*/docs/patterns/...` / `docs/LEARNINGS.md` / agent | — |

--- a/docs/audits/CHANGELOG.md
+++ b/docs/audits/CHANGELOG.md
@@ -231,3 +231,38 @@ links to the full audit manifest with detailed findings and resolutions.
 - **Close baseline:** backend full suite 906 passed / 8 skipped; web 588 passed,
   `tsc` + eslint clean; `manage.py check` + `spectacular` clean.
 - **Commit(s):** branch `chore/forum-modernization-audit-2026-07-11` (PR pending).
+
+### 2026-07-17 — Forum Wagtail-Integration Correctness Audit
+
+- **Trigger:** User-invoked `/audit` after the forum notifications epic work
+  (todo 253 slices 1–6): does the forum package use Wagtail 7.4 APIs the way
+  current documentation says to? Security explicitly out of scope this round.
+- **Manifest:** [2026-07-17-forum-wagtail.md](2026-07-17-forum-wagtail.md)
+- **Findings:** 1 high, 2 medium, 2 low (5 total) from 3 scoped wagtail-reviewer
+  agents; Phase 2.5 Context7 doc research: 4 confirmed, 1 not-applicable, plus
+  1 incidental new finding (M2). Model/data layer and admin integration came
+  back clean — verified against installed Wagtail 7.4.2 source (mixin MRO,
+  GenericRelation overrides, custom Task recursion guard, bulk action contract,
+  workflow API signatures, migrations).
+- **Resolved:** 5 fixed & verified (user selected all), 0 deferred, 0 open.
+- **Headline (H1):** `seed_default_forum` attached ForumIndex under the depth-1
+  treebeard root instead of `Site.root_page` — forum pages were siblings of
+  Home, outside every site's routable tree (`page.url` = None, `route()` never
+  reached them). Wired into `railway.json` preDeployCommand, so it would have
+  shipped an unroutable forum on first prod deploy. Fixed with default-Site
+  resolution + a `Page.move` repair branch for already-mis-seeded DBs, and the
+  seed test now asserts routability.
+- **Also fixed:** L1 seeded pages get `save_revision().publish()` parity;
+  M1 forum admin SearchArea/summary-template URLs resolved via
+  `Topic.snippet_viewset.get_url_name("list")` instead of hardcoded `/cms/`;
+  M2 the blog source of that copied anti-pattern (11 hardcoded `/blog-admin/`
+  URLs → `reverse("blog_admin:*")`); L2 image-collection get-or-create made
+  concurrency-safe via double-checked `select_for_update`.
+- **Process finding:** a threaded `django_db(transaction=True)` concurrency test
+  passed standalone but broke in-suite (teardown flush + blog's
+  `TransactionTestCase` wipe migration-seeded Wagtail root rows) — reworked as
+  a deterministic locked-recheck simulation per the documented convention in
+  `wagtail_forum/tests/api/test_topic_detail.py`.
+- **Close baseline:** full worktree pytest suite 1088 passed / 8 skipped;
+  `manage.py check` clean; kimi-review clean on all four fix diffs.
+- **Commit(s):** branch `chore/forum-wagtail-audit-2026-07-17` (PR pending).

--- a/docs/rules/testing.md
+++ b/docs/rules/testing.md
@@ -104,3 +104,17 @@ Compact checklist auto-injected before edits.
   Verify DOM-lifecycle guards (e.g. an orphan-dropdown `shouldRender` check)
   via Playwright, or flag explicitly in the Work Log that it's
   reasoning-verified, not test-exercised. See `web/docs/patterns/testing.md`.
+- **Never mark a test `django_db(transaction=True)`** — its teardown flush (and
+  any Django `TransactionTestCase`, e.g. blog `test_analytics.py`) deletes
+  Wagtail's migration-seeded root page/collection/Site rows, so the test passes
+  standalone but fails (or breaks LATER tests) in the full suite. For
+  concurrency-shaped logic, simulate the interleaving deterministically instead
+  — monkeypatch the fast-path check to miss once and assert the locked re-check
+  reuses the existing row (see `wagtail_forum/tests/test_collections.py`).
+- **Running backend tests from a git worktree needs two guards:** (1) the venv's
+  `wagtail_forum` is an *editable install pointing at the main checkout* — prepend
+  `PYTHONPATH=<worktree>/backend/packages/wagtail_forum` or the worktree's package
+  edits are silently NOT under test (import-file-mismatch collection errors are
+  the tell); (2) never run two pytest sessions concurrently — they share the one
+  `test_plant_community` Postgres DB and cross-kill with phantom connection
+  errors/DuplicateDatabase. See `docs/LEARNINGS.md` 2026-07-17.

--- a/docs/rules/triggers.json
+++ b/docs/rules/triggers.json
@@ -576,5 +576,51 @@
     "source": "codify: feat/forum-notifications-slice6-fcm-registration",
     "added": "2026-07-16",
     "severity": "warn"
+  },
+  {
+    "id": "wagtail-seed-under-treebeard-root",
+    "domains": [
+      "wagtail"
+    ],
+    "path_glob": [
+      "backend/**/*.py"
+    ],
+    "content_present": "Page\\.objects\\.filter\\(depth=1\\)",
+    "content_absent": "is_default_site",
+    "message": "Page.objects.filter(depth=1) is the UNROUTABLE treebeard root, not the site root — pages attached there get url=None and route() never reaches them. Resolve Site.objects.get(is_default_site=True).root_page instead (audit 2026-07-17 H1).",
+    "pattern_ref": "backend/docs/patterns/domain/wagtail.md",
+    "source": "codify: chore/forum-wagtail-audit-2026-07-17",
+    "added": "2026-07-17",
+    "severity": "warn"
+  },
+  {
+    "id": "pytest-transaction-true-wagtail-flush",
+    "domains": [
+      "testing"
+    ],
+    "path_glob": [
+      "backend/**/test*.py"
+    ],
+    "content_present": "django_db\\(transaction=True\\)",
+    "message": "django_db(transaction=True) teardown-flushes Wagtail migration-seeded rows (root page/collection/Site) — passes standalone, breaks in-suite, and breaks later tests. Simulate the interleaving deterministically instead (monkeypatch the fast-path check; see wagtail_forum/tests/test_collections.py).",
+    "pattern_ref": "docs/rules/testing.md",
+    "source": "codify: chore/forum-wagtail-audit-2026-07-17",
+    "added": "2026-07-17",
+    "severity": "warn"
+  },
+  {
+    "id": "wagtail-hooks-hardcoded-admin-url",
+    "domains": [
+      "wagtail"
+    ],
+    "path_glob": [
+      "backend/**/wagtail_hooks.py"
+    ],
+    "content_present": "[\"']/(cms|blog-admin)/",
+    "message": "Hardcoded admin-mount URL in a wagtail hook — resolves to a silent 404 if the mount changes or the package is reused. Use reverse(Model.snippet_viewset.get_url_name(...)) / reverse(\"blog_admin:<name>\") inside the hook function body (audit 2026-07-17 M1/M2).",
+    "pattern_ref": "backend/docs/patterns/domain/wagtail.md",
+    "source": "codify: chore/forum-wagtail-audit-2026-07-17",
+    "added": "2026-07-17",
+    "severity": "warn"
   }
 ]

--- a/docs/rules/wagtail.md
+++ b/docs/rules/wagtail.md
@@ -92,3 +92,19 @@ Compact checklist auto-injected before edits. Long-form:
 - **An attributed log write adds one `auth_user` existence-check query** — passing
   `user=` into publish/unpublish shifts exact query pins by +1 per logged action;
   update the pin WITH a comment explaining the new number.
+- **Seed/create pages under `Site.root_page`, never `Page.objects.filter(depth=1)`.**
+  The depth-1 treebeard root is NOT the routable site root — a page attached
+  there is a sibling of Home: `page.url` is `None` and `serve()`/`route()` never
+  reach it (shipped-unroutable-forum near-miss, audit 2026-07-17 H1). Resolve
+  `Site.objects.get(is_default_site=True).root_page` (handle `DoesNotExist` and
+  `MultipleObjectsReturned` with a clear error in commands), and follow
+  `add_child()` with `save_revision().publish()` so seeded pages have revision
+  parity (`first_published_at`, `page_published`) with admin-created ones.
+- **Never hardcode the admin mount in hooks or admin templates** (`/cms/...`,
+  `/blog-admin/...`). Resolve inside the hook function body:
+  `reverse(Model.snippet_viewset.get_url_name("list"))` for snippet views,
+  `reverse("blog_admin:<name>")` for app admin URLs, `{% url %}` via a context
+  var in templates. Hook registries are lazy (`cached_property`, first admin
+  request), so `reverse()` in the function body is URLconf-safe; a hardcoded
+  path silently 404s when the mount changes or a reusable package lands in
+  another host (audit 2026-07-17 M1/M2 — the forum copied the blog's bug).


### PR DESCRIPTION
## Summary

Fixes from the 2026-07-17 forum Wagtail-integration correctness audit (`docs/audits/2026-07-17-forum-wagtail.md`) — scope: does the forum package use Wagtail 7.4 APIs the way current docs say to? Security was explicitly out of scope this round (user directive). 5 findings, all fixed and verified; 0 deferred.

- **H1 (High)** `seed_default_forum` attached ForumIndex under the depth-1 treebeard root instead of `Site.root_page` — forum pages were siblings of Home, outside every site's routable tree (`page.url` = None, `route()` unreachable, admin "View live"/sitemap dead). Wired into `railway.json` preDeployCommand, so it would have shipped an unroutable forum on first prod deploy. Fixed with default-Site resolution (+ `MultipleObjectsReturned` guard) and a `Page.move` repair branch (with revision backfill) for already-mis-seeded DBs; seed tests now assert routability.
- **L1** Seeded pages get `save_revision().publish()` parity (revisions + `first_published_at`) instead of bare `live=True` `add_child`.
- **M1** Forum admin SearchArea + moderation-summary link resolve via `Topic.snippet_viewset.get_url_name("list")` instead of hardcoded `/cms/` (the package is documented as reusable).
- **M2** Blog `wagtail_hooks.py` — the source the forum copied the anti-pattern from: all 11 hardcoded `/blog-admin/` URLs now `reverse("blog_admin:*")`; a new explorer-listing render test exercises every converted button URL name (a rename now fails as `NoReverseMatch` in CI instead of shipping a dead admin button).
- **L2** `get_forum_image_collection()` concurrency-safe via double-checked `select_for_update` (lock-free steady-state fast path); deterministic locked-recheck test per the repo's no-`transaction=True` convention.

Also: two pre-existing flake8 violations in `blog/wagtail_hooks.py` cleaned (whole-file pre-commit gate), audit manifest + changelog included.

## Verification

- Full backend pytest suite: **1089 passed, 8 skipped, 0 failed**; `manage.py check` clean.
- Phase 2.5 doc research (Context7, Wagtail 7.4 stable): H1/M1/L1 confirmed against docs + installed source.
- Phase 6 orchestrated review (`wagtail-reviewer` + `cross-cutting-reviewer`): 0 Critical/High/Medium; both Low findings repaired in-session (repair-branch revision parity, listing-button test coverage).
- kimi-review clean on every fix diff and the final staged commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)