### PR TITLE
Forum Wave 1: honesty & polish sprint

### DIFF
--- a/backend/packages/wagtail_forum/wagtail_forum/api/serializers.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/api/serializers.py
@@ -358,10 +358,13 @@ NOTIFICATION_TOPIC_SCHEMA = {
 class NotificationSerializer(serializers.ModelSerializer):
     actor = serializers.SerializerMethodField()
     topic = serializers.SerializerMethodField()
+    # Deep-link target for clients (wave 1.3): the post this notification is
+    # about, or null for a post-less verb.
+    post_id = serializers.IntegerField(read_only=True, allow_null=True)
 
     class Meta:
         model = Notification
-        fields = ["id", "verb", "actor", "topic", "created_at", "read_at"]
+        fields = ["id", "verb", "actor", "topic", "post_id", "created_at", "read_at"]
 
     @extend_schema_field(AUTHOR_SCHEMA)
     def get_actor(self, obj):

--- a/backend/packages/wagtail_forum/wagtail_forum/api/views.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/api/views.py
@@ -838,24 +838,49 @@ class SearchView(APIView):
 
     @extend_schema(
         responses={200: dict},
-        description="Search live topic titles and post bodies. Query param: q.",
+        description=(
+            "Search live topic titles and post bodies. Query params: q "
+            "(required), board (optional board slug filter)."
+        ),
     )
     def get(self, request):
         query = request.query_params.get("q", "").strip()
+        board_slug = request.query_params.get("board", "").strip()
         topics, posts = [], []
         if query:
             backend = get_search_backend()
             boards = _visible_boards()
-            topic_hits = backend.search(
-                query, Topic.objects.filter(live=True, board__in=boards)
+            topic_qs = Topic.objects.filter(live=True, board__in=boards)
+            post_qs = Post.objects.filter(
+                live=True, topic__live=True, topic__board__in=boards
             )
+            if board_slug:
+                # Filter on board_id (declared in search_fields), not
+                # board__slug — the modelsearch DB backend raises
+                # FilterFieldError on an undeclared related-field lookup.
+                board_ids = list(
+                    boards.filter(slug=board_slug).values_list("id", flat=True)
+                )
+                topic_qs = topic_qs.filter(board_id__in=board_ids)
+                post_qs = post_qs.filter(topic__board_id__in=board_ids)
+            topic_hits = backend.search(query, topic_qs.select_related("board"))
             for t in topic_hits[: self.MAX_RESULTS]:
-                topics.append({"id": t.id, "slug": t.slug, "title": t.title})
+                topics.append(
+                    {
+                        "id": t.id,
+                        "slug": t.slug,
+                        "title": t.title,
+                        "reply_count": t.reply_count,
+                        "view_count": t.view_count,
+                        "last_post_at": (
+                            t.last_post_at.isoformat() if t.last_post_at else None
+                        ),
+                        "board_id": t.board_id,
+                        "board_slug": t.board.slug,
+                    }
+                )
             post_hits = backend.search(
-                query,
-                Post.objects.filter(
-                    live=True, topic__live=True, topic__board__in=boards
-                ).select_related("topic"),
+                query, post_qs.select_related("topic", "topic__board")
             )
             for p in post_hits[: self.MAX_RESULTS]:
                 posts.append(
@@ -863,6 +888,9 @@ class SearchView(APIView):
                         "id": p.id,
                         "topic_id": p.topic_id,
                         "topic_title": p.topic.title,
+                        "topic_slug": p.topic.slug,
+                        "board_id": p.topic.board_id,
+                        "board_slug": p.topic.board.slug,
                         "excerpt": (
                             plain_text_excerpt(p.body, self.MAX_EXCERPT_CHARS)
                             if p.body

--- a/backend/packages/wagtail_forum/wagtail_forum/tests/api/test_notifications_api.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/tests/api/test_notifications_api.py
@@ -327,3 +327,22 @@ def test_mark_read_does_not_leak_other_users_notifications():
 def test_mark_read_requires_auth():
     resp = APIClient().post("/forum/notifications/mark-read/", {}, format="json")
     assert resp.status_code == 401
+
+
+# ---- post_id ---------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_notification_list_includes_post_id():
+    recipient = User.objects.create_user(username="postid_recipient")
+    actor = User.objects.create_user(username="postid_actor")
+    board = _board(slug="postid-board")
+    topic, post = _topic_and_post(board, recipient, actor, slug="postid-t")
+    _notify(recipient, actor, topic, post)
+
+    client = APIClient()
+    client.force_authenticate(recipient)
+    resp = client.get("/forum/notifications/")
+
+    assert resp.status_code == 200
+    assert resp.data["results"][0]["post_id"] == post.pk

--- a/backend/packages/wagtail_forum/wagtail_forum/tests/api/test_search_sync.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/tests/api/test_search_sync.py
@@ -2,6 +2,7 @@ import datetime
 
 import pytest
 from django.contrib.auth import get_user_model
+from django.utils import timezone
 from rest_framework.test import APIClient
 from wagtail.models import Page
 from wagtail_forum.models import ForumBoard, ForumIndex, Post, Topic
@@ -294,3 +295,57 @@ def test_prune_tombstones_command_removes_old_rows(capsys):
     assert TopicDeletedLog.objects.filter(topic_id=2).exists()
     out = capsys.readouterr().out
     assert "Pruned 1 tombstone row(s)" in out
+
+
+@pytest.mark.django_db
+def test_search_topics_include_metadata_and_board():
+    root = Page.objects.get(id=1)
+    index = root.add_child(instance=ForumIndex(title="Forum", slug="forum-meta"))
+    board = index.add_child(instance=ForumBoard(title="General", slug="general-meta"))
+    topic = Topic.objects.create(
+        board=board, title="Monstera propagation tips", slug="monstera-meta"
+    )
+    topic.reply_count = 3
+    topic.view_count = 7
+    topic.last_post_at = timezone.now()
+    topic.save()
+
+    resp = APIClient().get("/forum/search/", {"q": "Monstera"})
+
+    assert resp.status_code == 200
+    entry = next(t for t in resp.data["topics"] if t["id"] == topic.id)
+    assert entry["reply_count"] == 3
+    assert entry["view_count"] == 7
+    assert entry["last_post_at"] is not None
+    assert entry["board_id"] == board.id
+    assert entry["board_slug"] == "general-meta"
+
+
+@pytest.mark.django_db
+def test_search_board_filter_narrows_topics_and_posts():
+    root = Page.objects.get(id=1)
+    index = root.add_child(instance=ForumIndex(title="Forum", slug="forum-filter"))
+    board_a = index.add_child(instance=ForumBoard(title="A", slug="board-a"))
+    board_b = index.add_child(instance=ForumBoard(title="B", slug="board-b"))
+    topic_a = Topic.objects.create(board=board_a, title="Fern care", slug="fern-a")
+    topic_b = Topic.objects.create(board=board_b, title="Fern care", slug="fern-b")
+    author = User.objects.create_user(username="fern_author")
+    Post.objects.create(
+        topic=topic_a,
+        author=author,
+        body=[{"type": "paragraph", "value": "<p>Fern watering schedule</p>"}],
+    )
+    Post.objects.create(
+        topic=topic_b,
+        author=author,
+        body=[{"type": "paragraph", "value": "<p>Fern watering schedule</p>"}],
+    )
+
+    resp = APIClient().get("/forum/search/", {"q": "Fern", "board": "board-a"})
+
+    assert resp.status_code == 200
+    assert {t["id"] for t in resp.data["topics"]} == {topic_a.id}
+    assert all(p["board_slug"] == "board-a" for p in resp.data["posts"])
+    post_entry = resp.data["posts"][0]
+    assert post_entry["topic_slug"] == "fern-a"
+    assert post_entry["board_id"] == board_a.id

--- a/docs/LEARNINGS.md
+++ b/docs/LEARNINGS.md
@@ -1464,3 +1464,39 @@ unpatched code. Related: two pytest sessions run concurrently (main checkout +
 worktree) share the single `test_plant_community` Postgres DB and destroy each
 other — one baseline run produced 900+ phantom `OperationalError`s. Serialize
 all backend test runs, and re-derive baselines when a run overlapped another.
+
+### [2026-07-17] Notification deep-link silently no-op'd for posts past the first cursor page
+
+**What broke:** The forum thread view loads only the first cursor page (20
+posts, oldest-first) on mount, but reply notifications carry the **newest**
+post's id — which lives on the *last* page. Clicking such a notification set
+`#post-N` in the URL, the arrival effect ran `getElementById('post-N')`, found
+nothing, and returned — no scroll, no highlight, no cue. Worked for every
+thread ≤20 posts, so it passed the live walkthrough and every per-task review
+(all mocked single-page). The plan had explicitly deferred it as out-of-scope,
+but a whole-branch review flagged it against the acceptance criterion.
+
+**Root cause + fix (three review-caught iterations, all in `ThreadDetailPage.tsx`):**
+
+1. Arrival effect pulls later pages (`handleLoadMore`) until the target mounts —
+   `posts` is in its deps so it re-runs as the list grows.
+2. That created an **unbounded retry loop**: `handleLoadMore`'s catch never
+   clears `nextCursor`, so a persistently-failing page re-fired on every
+   `loadingMore` flip. Fixed with a `chaseCursorRef` — advance at most once per
+   cursor (a failed load leaves `nextCursor` unchanged → guard stops it; manual
+   "Load More" stays the retry).
+3. The auto-chase fires `handleLoadMore` with no user action, which **amplified**
+   a pre-existing cross-thread race: a page resolving after the user navigated
+   away appended thread A's posts to thread B. Fixed by mirroring
+   `handleToggleSubscription`'s guard (capture `requestTopicId`, gate state
+   writes on `currentTopicIdRef.current === requestTopicId`).
+
+**Lessons:** (a) A change to a **shared component** must run the *integration*
+suites that consume it, not just the component's own file — Task 6's reaction
+de-clutter broke a `ThreadDetailPage` reaction test that only surfaced under the
+final full-suite gate because Task 6's gate ran `PostCard.test.tsx` alone.
+(b) An effect that lists a growing collection in its deps re-runs its one-shot
+side effects (scroll) on every append — gate them with a ref (see
+`web/docs/patterns/react-typescript.md` → "One-Shot Side Effects").
+(c) A cheap mocked review can't catch a defect that lives in the interaction of
+real pagination + real routing; the whole-branch review is where it surfaced.

--- a/docs/rules/triggers.json
+++ b/docs/rules/triggers.json
@@ -622,5 +622,21 @@
     "source": "codify: chore/forum-wagtail-audit-2026-07-17",
     "added": "2026-07-17",
     "severity": "warn"
+  },
+  {
+    "id": "jsdom-scrollintoview-prototype",
+    "domains": [
+      "testing",
+      "react"
+    ],
+    "path_glob": [
+      "web/src/**/*.test.tsx"
+    ],
+    "content_present": "(?<![A-Za-z])Element\\.prototype\\.scrollIntoView",
+    "message": "jsdom implements scrollIntoView on HTMLElement.prototype — a spy on Element.prototype is shadowed (records 0 calls). Spy on HTMLElement.prototype.scrollIntoView instead.",
+    "pattern_ref": "web/docs/patterns/testing.md",
+    "source": "codify: feat/forum-wave1-honesty-polish",
+    "added": "2026-07-17",
+    "severity": "warn"
   }
 ]

--- a/docs/superpowers/plans/2026-07-17-forum-wave1-honesty-polish.md
+++ b/docs/superpowers/plans/2026-07-17-forum-wave1-honesty-polish.md
@@ -1,0 +1,1334 @@
+# Forum Wave 1 — Honesty & Polish Sprint Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the web forum's existing features findable and truthful — honest search results, working search-result links, per-post permalinks, notification deep links, visible reactions for logged-out readers, mention styling, and draft autosave — with no new product features.
+
+**Architecture:** Two small backend serializer/view extensions (search payload metadata + notification `post_id`), then web-only changes: the service/mapper layer consumes the new fields, SearchPage drops its decorative filters, PostCard/ThreadDetailPage/NotificationBell gain permalink & highlight affordances, and composers persist drafts to sessionStorage. No new models, no migrations, no new endpoints.
+
+**Tech Stack:** Django/DRF + Wagtail search (package `wagtail_forum`), React 19 + TypeScript + Tailwind 4 + Vitest, TipTap 3 editor.
+
+**Spec:** `docs/superpowers/specs/2026-07-17-forum-app-loop-roadmap-design.md` (Wave 1 section).
+
+## Global Constraints
+
+- Branch: `feat/forum-wave1-honesty-polish` cut fresh from `origin/main` (create via superpowers:using-git-worktrees at execution time). Never push to `main`.
+- React Router imports come from `react-router-dom`, never `react-router` (silent runtime failure otherwise).
+- User-generated HTML is always DOMPurify-sanitized before `dangerouslySetInnerHTML`; the mention transform in Task 5 runs strictly AFTER sanitization.
+- Timer IDs in React use `useRef`, never `useState` (project gotcha #5).
+- The edit-time formatter strips imports that are unused at format time — add an import in the SAME edit as its first usage.
+- Backend: no magic numbers (module constants), bracketed log prefixes (`[SEARCH]` etc.), type hints on service methods.
+- Backend venv: run commands as `cd backend && venv/bin/python -m pytest …`. Package API tests carry `pytestmark = pytest.mark.urls("wagtail_forum.tests.api.urls")` — endpoints mount at root (e.g. `/search/`).
+- Web gates: `npm run type-check`, `npm run lint`, `npm run test` (Vitest `--run`) must pass at every commit.
+- The kimi-review commit hook is active; a `[CRITICAL]` finding blocks the commit — fix, don't bypass.
+
+---
+
+### Task 1: Backend — search results carry real topic metadata + board filter
+
+The search API returns only `{id, slug, title}` per topic, forcing the frontend to fabricate "0 replies • 0 views • recently". Add real counts, activity time, and board identifiers (needed to build working links — today's search-result thread links are broken: `category.id` is empty so `threadPath` produces `/forum/-slug/...` which `parseLeadingId` rejects). Add an optional `board` (slug) query filter.
+
+**Files:**
+
+- Modify: `backend/packages/wagtail_forum/wagtail_forum/api/views.py:832-873` (`SearchView`)
+- Test: `backend/packages/wagtail_forum/wagtail_forum/tests/api/test_search_sync.py` (append)
+
+**Interfaces:**
+
+- Produces (consumed by Task 3): topic entries `{id, slug, title, reply_count, view_count, last_post_at, board_id, board_slug}`; post entries `{id, topic_id, topic_title, topic_slug, board_id, board_slug, excerpt}`; query params `q` + optional `board` (board slug).
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `backend/packages/wagtail_forum/wagtail_forum/tests/api/test_search_sync.py` (reuse the file's existing board/topic builder helpers if present — otherwise these are self-contained; match the file's existing imports):
+
+```python
+@pytest.mark.django_db
+def test_search_topics_include_metadata_and_board():
+    root = Page.objects.get(id=1)
+    index = root.add_child(instance=ForumIndex(title="Forum", slug="forum-meta"))
+    board = index.add_child(instance=ForumBoard(title="General", slug="general-meta"))
+    topic = Topic.objects.create(
+        board=board, title="Monstera propagation tips", slug="monstera-meta"
+    )
+    topic.reply_count = 3
+    topic.view_count = 7
+    topic.last_post_at = timezone.now()
+    topic.save()
+
+    resp = APIClient().get("/search/", {"q": "Monstera"})
+
+    assert resp.status_code == 200
+    entry = next(t for t in resp.data["topics"] if t["id"] == topic.id)
+    assert entry["reply_count"] == 3
+    assert entry["view_count"] == 7
+    assert entry["last_post_at"] is not None
+    assert entry["board_id"] == board.id
+    assert entry["board_slug"] == "general-meta"
+
+
+@pytest.mark.django_db
+def test_search_board_filter_narrows_topics_and_posts():
+    root = Page.objects.get(id=1)
+    index = root.add_child(instance=ForumIndex(title="Forum", slug="forum-filter"))
+    board_a = index.add_child(instance=ForumBoard(title="A", slug="board-a"))
+    board_b = index.add_child(instance=ForumBoard(title="B", slug="board-b"))
+    topic_a = Topic.objects.create(board=board_a, title="Fern care", slug="fern-a")
+    topic_b = Topic.objects.create(board=board_b, title="Fern care", slug="fern-b")
+    author = User.objects.create_user(username="fern_author")
+    Post.objects.create(
+        topic=topic_a,
+        author=author,
+        body=[{"type": "paragraph", "value": "<p>Fern watering schedule</p>"}],
+    )
+    Post.objects.create(
+        topic=topic_b,
+        author=author,
+        body=[{"type": "paragraph", "value": "<p>Fern watering schedule</p>"}],
+    )
+
+    resp = APIClient().get("/search/", {"q": "Fern", "board": "board-a"})
+
+    assert resp.status_code == 200
+    assert {t["id"] for t in resp.data["topics"]} == {topic_a.id}
+    assert all(p["board_slug"] == "board-a" for p in resp.data["posts"])
+    post_entry = resp.data["posts"][0]
+    assert post_entry["topic_slug"] == "fern-a"
+    assert post_entry["board_id"] == board_a.id
+```
+
+If `timezone`, `User`, `Post`, or `APIClient` are not already imported at the top of the file, add them in the same edit (`from django.utils import timezone`, `from rest_framework.test import APIClient`, extend the existing `wagtail_forum.models` import, `User = get_user_model()` if absent).
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd backend && venv/bin/python -m pytest packages/wagtail_forum/wagtail_forum/tests/api/test_search_sync.py -q -k "metadata_and_board or board_filter"`
+Expected: FAIL — `KeyError: 'reply_count'` (and `'board_slug'`).
+
+- [ ] **Step 3: Implement in SearchView**
+
+Replace the body of `SearchView.get` (`api/views.py:843-873`) with:
+
+```python
+    @extend_schema(
+        responses={200: dict},
+        description=(
+            "Search live topic titles and post bodies. Query params: q "
+            "(required), board (optional board slug filter)."
+        ),
+    )
+    def get(self, request):
+        query = request.query_params.get("q", "").strip()
+        board_slug = request.query_params.get("board", "").strip()
+        topics, posts = [], []
+        if query:
+            backend = get_search_backend()
+            boards = _visible_boards()
+            topic_qs = Topic.objects.filter(live=True, board__in=boards)
+            post_qs = Post.objects.filter(
+                live=True, topic__live=True, topic__board__in=boards
+            )
+            if board_slug:
+                topic_qs = topic_qs.filter(board__slug=board_slug)
+                post_qs = post_qs.filter(topic__board__slug=board_slug)
+            topic_hits = backend.search(query, topic_qs.select_related("board"))
+            for t in topic_hits[: self.MAX_RESULTS]:
+                topics.append(
+                    {
+                        "id": t.id,
+                        "slug": t.slug,
+                        "title": t.title,
+                        "reply_count": t.reply_count,
+                        "view_count": t.view_count,
+                        "last_post_at": (
+                            t.last_post_at.isoformat() if t.last_post_at else None
+                        ),
+                        "board_id": t.board_id,
+                        "board_slug": t.board.slug,
+                    }
+                )
+            post_hits = backend.search(
+                query, post_qs.select_related("topic", "topic__board")
+            )
+            for p in post_hits[: self.MAX_RESULTS]:
+                posts.append(
+                    {
+                        "id": p.id,
+                        "topic_id": p.topic_id,
+                        "topic_title": p.topic.title,
+                        "topic_slug": p.topic.slug,
+                        "board_id": p.topic.board_id,
+                        "board_slug": p.topic.board.slug,
+                        "excerpt": (
+                            plain_text_excerpt(p.body, self.MAX_EXCERPT_CHARS)
+                            if p.body
+                            else ""
+                        ),
+                    }
+                )
+        return Response({"topics": topics, "posts": posts})
+```
+
+Note: `select_related("board")` / `("topic", "topic__board")` prevents an N+1 on `board.slug` access — the prior code already had `select_related("topic")` for the same reason.
+
+- [ ] **Step 4: Run tests to verify they pass, plus the whole search file**
+
+Run: `cd backend && venv/bin/python -m pytest packages/wagtail_forum/wagtail_forum/tests/api/test_search_sync.py -q`
+Expected: PASS (all tests in the file, including pre-existing ones).
+
+- [ ] **Step 5: Schema + system checks**
+
+Run: `cd backend && venv/bin/python manage.py spectacular --file /dev/null && venv/bin/python manage.py check`
+Expected: both exit 0.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/packages/wagtail_forum/wagtail_forum/api/views.py backend/packages/wagtail_forum/wagtail_forum/tests/api/test_search_sync.py
+git commit -m "forum: search results carry topic metadata + board filter (wave 1.2)"
+```
+
+---
+
+### Task 2: Backend — notification payload carries post_id
+
+The `Notification` model has a `post` FK (`models/notifications.py:44`) but `NotificationSerializer` doesn't expose it, so the web bell can't deep-link to the post.
+
+**Files:**
+
+- Modify: `backend/packages/wagtail_forum/wagtail_forum/api/serializers.py:358-389` (`NotificationSerializer`)
+- Test: `backend/packages/wagtail_forum/wagtail_forum/tests/api/test_notifications_api.py` (append)
+
+**Interfaces:**
+
+- Produces (consumed by Task 4): notification entries gain `"post_id": int | null`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `test_notifications_api.py` (the file already has `_board`, `_topic_and_post`, `_notify` helpers and an authenticated-client pattern — mirror the existing list tests):
+
+```python
+@pytest.mark.django_db
+def test_notification_list_includes_post_id():
+    recipient = User.objects.create_user(username="postid_recipient")
+    actor = User.objects.create_user(username="postid_actor")
+    board = _board(slug="postid-board")
+    topic, post = _topic_and_post(board, recipient, actor, slug="postid-t")
+    _notify(recipient, actor, topic, post)
+
+    client = APIClient()
+    client.force_authenticate(user=recipient)
+    resp = client.get("/notifications/")
+
+    assert resp.status_code == 200
+    assert resp.data["results"][0]["post_id"] == post.pk
+```
+
+(If the file's existing tests authenticate differently — e.g. `client.force_login` — copy that exact pattern instead.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && venv/bin/python -m pytest packages/wagtail_forum/wagtail_forum/tests/api/test_notifications_api.py -q -k post_id`
+Expected: FAIL — `KeyError: 'post_id'`.
+
+- [ ] **Step 3: Implement**
+
+In `api/serializers.py`, extend `NotificationSerializer`:
+
+```python
+class NotificationSerializer(serializers.ModelSerializer):
+    actor = serializers.SerializerMethodField()
+    topic = serializers.SerializerMethodField()
+    # Deep-link target for clients (wave 1.3): the post this notification is
+    # about, or null for a post-less verb.
+    post_id = serializers.IntegerField(read_only=True, allow_null=True)
+
+    class Meta:
+        model = Notification
+        fields = ["id", "verb", "actor", "topic", "post_id", "created_at", "read_at"]
+```
+
+(Only the `post_id` field declaration and the `fields` list change; `get_actor`/`get_topic` stay as they are.)
+
+- [ ] **Step 4: Run the notifications test file**
+
+Run: `cd backend && venv/bin/python -m pytest packages/wagtail_forum/wagtail_forum/tests/api/test_notifications_api.py -q`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/packages/wagtail_forum/wagtail_forum/api/serializers.py backend/packages/wagtail_forum/wagtail_forum/tests/api/test_notifications_api.py
+git commit -m "forum: expose post_id on notifications (wave 1.3 deep links)"
+```
+
+---
+
+### Task 3: Web — honest search (service, mappers, types, SearchPage)
+
+Consume Task 1's fields end-to-end. Drop the decorative author/date filters and the dead pagination; keep query + category (now actually filtering via `board`). One task because removing the option/response fields from the types breaks SearchPage compilation unless it's updated in the same change.
+
+**Files:**
+
+- Modify: `web/src/services/forumMappers.ts` (`BackendSearchTopic`, `BackendSearchPost`, `mapSearchTopicToThread`, `mapSearchPostToPost`)
+- Modify: `web/src/services/forumService.ts:306-329` (`searchForum`)
+- Modify: `web/src/types/forum.ts` (`SearchForumOptions`, `SearchForumResponse`, `Post` search-only fields)
+- Modify: `web/src/pages/forum/SearchPage.tsx`
+- Test: `web/src/services/forumMappers.test.ts`, `web/src/services/forumService.test.ts` (extend both)
+
+**Interfaces:**
+
+- Consumes: Task 1's search payload.
+- Produces: `SearchForumOptions = { q: string; category?: string }` (category = board slug); `SearchForumResponse = { query, threads, posts, total_threads, total_posts }`; search-result `Thread`s have populated `category` (`id`/`slug` from board) + `post_count`/`view_count`/`last_activity_at`; search-result `Post`s carry `topic_title`, `topic_slug`, `board_id`, `board_slug`.
+
+- [ ] **Step 1: Write the failing mapper/service tests**
+
+In `forumMappers.test.ts`, add (top-level, matching the file's fixture style):
+
+```typescript
+const backendSearchTopic = {
+  id: 31,
+  slug: 'tomato-blight',
+  title: 'Blight-resistant tomatoes',
+  reply_count: 3,
+  view_count: 12,
+  last_post_at: '2026-07-01T10:00:00Z',
+  board_id: 54,
+  board_slug: 'general-discussion',
+};
+
+it('mapSearchTopicToThread carries real metadata and board identity', () => {
+  const thread = mapSearchTopicToThread(backendSearchTopic);
+  expect(thread.post_count).toBe(3);
+  expect(thread.view_count).toBe(12);
+  expect(thread.last_activity_at).toBe('2026-07-01T10:00:00Z');
+  expect(thread.category.id).toBe('54');
+  expect(thread.category.slug).toBe('general-discussion');
+});
+
+it('mapSearchPostToPost carries topic and board identity for links', () => {
+  const post = mapSearchPostToPost({
+    id: 9,
+    topic_id: 31,
+    topic_title: 'Blight-resistant tomatoes',
+    topic_slug: 'tomato-blight',
+    board_id: 54,
+    board_slug: 'general-discussion',
+    excerpt: 'Mountain Magic is the real answer',
+  });
+  expect(post.topic_slug).toBe('tomato-blight');
+  expect(post.board_id).toBe(54);
+  expect(post.board_slug).toBe('general-discussion');
+});
+```
+
+In `forumService.test.ts`, extend the existing `searchForum` block: assert the request URL contains `board=general-discussion` when `category` is passed, and that the response's `total_threads` equals the returned array length (mock fetch with one topic in the new backend shape).
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd web && npx vitest run src/services/forumMappers.test.ts src/services/forumService.test.ts`
+Expected: FAIL — new fields undefined / type errors.
+
+- [ ] **Step 3: Implement mappers + types + service**
+
+`forumMappers.ts` — extend the backend shapes and rewrite the two search mappers:
+
+```typescript
+export interface BackendSearchTopic {
+  id: number;
+  slug: string;
+  title: string;
+  reply_count: number;
+  view_count: number;
+  last_post_at: string | null;
+  board_id: number;
+  board_slug: string;
+}
+
+export interface BackendSearchPost {
+  id: number;
+  topic_id: number;
+  topic_title: string;
+  topic_slug: string;
+  board_id: number;
+  board_slug: string;
+  excerpt: string;
+}
+
+export function mapSearchTopicToThread(t: BackendSearchTopic): Thread {
+  return {
+    id: String(t.id),
+    title: t.title,
+    slug: t.slug,
+    category: { id: String(t.board_id), name: '', slug: t.board_slug, created_at: '' },
+    author: authorFromString(null),
+    created_at: t.last_post_at || '',
+    last_activity_at: t.last_post_at || '',
+    post_count: t.reply_count,
+    view_count: t.view_count,
+    is_active: true,
+  };
+}
+
+export function mapSearchPostToPost(p: BackendSearchPost): Post {
+  return {
+    id: String(p.id),
+    thread: String(p.topic_id),
+    author: authorFromString(null),
+    content_raw: p.excerpt,
+    content_format: 'plain',
+    body: [],
+    created_at: '',
+    is_active: true,
+    reaction_counts: {},
+    can_edit: false,
+    can_delete: false,
+    can_report: false,
+    topic_title: p.topic_title,
+    topic_slug: p.topic_slug,
+    board_id: p.board_id,
+    board_slug: p.board_slug,
+  };
+}
+```
+
+`types/forum.ts` — trim the search types and add the search-only `Post` fields next to the existing `topic_title`:
+
+```typescript
+export interface SearchForumOptions {
+  q: string;
+  /** Board slug — sent to the backend as ?board= */
+  category?: string;
+}
+
+export interface SearchForumResponse {
+  query: string;
+  threads: Thread[];
+  posts: Post[];
+  total_threads: number;
+  total_posts: number;
+}
+```
+
+and inside `Post` (immediately after `topic_title?: string;`):
+
+```typescript
+  /** Search-result-only link identity (mapSearchPostToPost). */
+  topic_slug?: string;
+  board_id?: number;
+  board_slug?: string;
+```
+
+`forumService.ts` — rewrite `searchForum`:
+
+```typescript
+export async function searchForum(options: SearchForumOptions): Promise<SearchForumResponse> {
+  const { q, category } = options;
+  if (!q || q.trim() === '') throw new Error('Search query is required');
+  const params = new URLSearchParams({ q: q.trim() });
+  if (category) params.set('board', category);
+  const data = await authenticatedFetch<{
+    topics: BackendSearchTopic[];
+    posts: BackendSearchPost[];
+  }>(`${FORUM_BASE}/search/?${params}`);
+  const threads = (data.topics || []).map(mapSearchTopicToThread);
+  const posts = (data.posts || []).map(mapSearchPostToPost);
+  // Result sets are server-capped at 50 each; lengths are the real totals up to that cap.
+  return { query: q.trim(), threads, posts, total_threads: threads.length, total_posts: posts.length };
+}
+```
+
+- [ ] **Step 4: Update SearchPage**
+
+In `SearchPage.tsx`:
+
+1. Delete the `author`, `dateFrom`, `dateTo`, `page`, `pageSize` param reads (lines 79-83) and their handlers `handleAuthorFilter` (214-229), `handleDateFilter` (231-245), `handlePageChange` + the `useHandlePageChange` import, and the `Pagination` import + render block (lines 504-513).
+2. Delete the Author / From / To filter inputs (lines 332-373); keep the Category select, changing the grid to `grid-cols-1 md:grid-cols-2` and updating `hasActiveFilters` to `!!category`.
+3. Call `searchForum({ q: query, category })` only, with `[query, category]` as the effect deps.
+4. Thread results: the `ThreadCard` link now works (category is real). Keep `hideAuthor`.
+5. Post results: replace the broken `const topicLink = \`/forum/-topic/${post.thread}\`;` with:
+
+```typescript
+import { threadPath } from '../../utils/forumUrls';
+// …
+const topicLink =
+  post.board_id != null && post.board_slug && post.topic_slug
+    ? `${threadPath(
+        { id: String(post.board_id), slug: post.board_slug, name: post.board_slug },
+        { id: post.thread, slug: post.topic_slug, title: post.topic_title || '' }
+      )}#post-${post.id}`
+    : `/forum`;
+```
+
+(Import `threadPath` in the same edit that uses it — formatter strips early imports.)
+
+- [ ] **Step 5: Add a SearchPage component test**
+
+Create `web/src/pages/forum/SearchPage.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import SearchPage from './SearchPage';
+
+vi.mock('../../services/forumService', () => ({
+  searchForum: vi.fn().mockResolvedValue({
+    query: 'tomato',
+    threads: [
+      {
+        id: '31',
+        title: 'Blight-resistant tomatoes',
+        slug: 'tomato-blight',
+        category: { id: '54', name: '', slug: 'general-discussion', created_at: '' },
+        author: { id: '', username: '[deleted]', display_name: '[deleted]' },
+        created_at: '2026-07-01T10:00:00Z',
+        last_activity_at: '2026-07-01T10:00:00Z',
+        post_count: 3,
+        view_count: 12,
+        is_active: true,
+      },
+    ],
+    posts: [],
+    total_threads: 1,
+    total_posts: 0,
+  }),
+  fetchCategories: vi.fn().mockResolvedValue([]),
+}));
+
+describe('SearchPage', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('renders real counts and no decorative filters', async () => {
+    render(
+      <MemoryRouter initialEntries={['/forum/search?q=tomato']}>
+        <SearchPage />
+      </MemoryRouter>
+    );
+    await waitFor(() => expect(screen.getByText(/Blight-resistant tomatoes/)).toBeInTheDocument());
+    expect(screen.getByTitle('3 replies')).toBeInTheDocument();
+    expect(screen.getByTitle('12 views')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Author')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('From')).not.toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 6: Run the web gates**
+
+Run: `cd web && npm run type-check && npx vitest run src/services src/pages/forum/SearchPage.test.tsx`
+Expected: type-check clean; tests PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add web/src/services/forumMappers.ts web/src/services/forumService.ts web/src/types/forum.ts web/src/pages/forum/SearchPage.tsx web/src/services/forumMappers.test.ts web/src/services/forumService.test.ts web/src/pages/forum/SearchPage.test.tsx
+git commit -m "web/forum: honest search results, working links, real category filter (wave 1.2)"
+```
+
+---
+
+### Task 4: Web — per-post permalinks + notification deep links
+
+Surface the existing `#post-N` DOM anchors: a copy-link button on every post, notification clicks that land on the post, and scroll-highlight on arrival.
+
+**Files:**
+
+- Modify: `web/src/utils/forumUrls.ts` (add `postAnchor`)
+- Modify: `web/src/types/notifications.ts` (add `post_id`)
+- Modify: `web/src/components/layout/NotificationBell.tsx:129-137`
+- Modify: `web/src/components/forum/PostCard.tsx` (copy-link button)
+- Modify: `web/src/pages/forum/ThreadDetailPage.tsx` (hash scroll + highlight)
+- Test: `web/src/utils/forumUrls.test.ts`, new `web/src/components/forum/PostCard.test.tsx`
+
+**Interfaces:**
+
+- Consumes: Task 2's `post_id` field.
+- Produces: `postAnchor(postId: number | string): string` in `utils/forumUrls.ts` (returns `#post-<id>`); `PostCard` renders a "Copy link" button for every post.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `forumUrls.test.ts`:
+
+```typescript
+it('postAnchor builds a #post-N fragment', () => {
+  expect(postAnchor(42)).toBe('#post-42');
+  expect(postAnchor('42')).toBe('#post-42');
+});
+```
+
+Create `web/src/components/forum/PostCard.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import PostCard from './PostCard';
+import type { Post } from '@/types';
+
+const basePost: Post = {
+  id: '21',
+  thread: '28',
+  author: { id: '', username: 'bob_botanist', display_name: 'bob_botanist' },
+  content_raw: '',
+  body: [{ type: 'paragraph', value: '<p>Classic earwig damage</p>' }],
+  created_at: '2026-07-17T10:00:00Z',
+  is_first_post: false,
+  is_active: true,
+  reaction_counts: {},
+  can_edit: false,
+  can_delete: false,
+  can_report: false,
+};
+
+it('copies a permalink to the clipboard', async () => {
+  const writeText = vi.fn().mockResolvedValue(undefined);
+  Object.assign(navigator, { clipboard: { writeText } });
+  render(<PostCard post={basePost} />);
+  fireEvent.click(screen.getByRole('button', { name: /copy link/i }));
+  await waitFor(() =>
+    expect(writeText).toHaveBeenCalledWith(expect.stringContaining('#post-21'))
+  );
+  expect(await screen.findByText(/copied/i)).toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd web && npx vitest run src/utils/forumUrls.test.ts src/components/forum/PostCard.test.tsx`
+Expected: FAIL — `postAnchor` not exported; no copy-link button.
+
+- [ ] **Step 3: Implement `postAnchor` + type + bell navigation**
+
+`utils/forumUrls.ts` — append:
+
+```typescript
+/** Fragment identifier for a specific post inside a thread page. */
+export function postAnchor(postId: number | string): string {
+  return `#post-${postId}`;
+}
+```
+
+`types/notifications.ts` — in `ForumNotification`, after `topic`:
+
+```typescript
+  /** The post this notification is about, for deep links; null for post-less verbs. */
+  post_id: number | null;
+```
+
+`NotificationBell.tsx` — extend the import (`import { threadPath, postAnchor } from '../../utils/forumUrls';`) and change the navigate call (lines 131-136) to:
+
+```typescript
+      navigate(
+        threadPath(
+          { id: String(topic.board_id), slug: topic.board_slug, name: topic.board_slug },
+          { id: String(topic.id), slug: topic.slug, title: topic.title }
+        ) + (notification.post_id != null ? postAnchor(notification.post_id) : '')
+      );
+```
+
+- [ ] **Step 4: Implement the PostCard copy-link button**
+
+In `PostCard.tsx`, add state + handler after the report state (line 52):
+
+```typescript
+  const [copiedLink, setCopiedLink] = useState(false);
+
+  const handleCopyLink = async () => {
+    const url = `${window.location.origin}${window.location.pathname}#post-${post.id}`;
+    try {
+      await navigator.clipboard.writeText(url);
+      setCopiedLink(true);
+      setTimeout(() => setCopiedLink(false), 2000);
+    } catch {
+      window.prompt('Copy link:', url); // clipboard API unavailable (http, old browser)
+    }
+  };
+```
+
+Restructure the actions container (lines 138-159) so it always renders, with copy-link first:
+
+```tsx
+        <div className="flex gap-2 md:opacity-0 md:group-hover:opacity-100 md:group-focus-within:opacity-100 transition-opacity">
+          <button
+            onClick={handleCopyLink}
+            className="min-h-11 px-3 py-1 text-sm text-ink-3 hover:bg-surface-3 rounded inline-flex items-center"
+            title="Copy link to this post"
+            aria-label="Copy link to this post"
+          >
+            {copiedLink ? 'Copied ✓' : '🔗 Copy link'}
+          </button>
+          {showEdit && (
+            /* existing Edit button unchanged */
+          )}
+          {showDelete && (
+            /* existing Delete button unchanged */
+          )}
+        </div>
+```
+
+(Keep the existing Edit/Delete button JSX verbatim inside; only the wrapper's condition `{(showEdit || showDelete) && …}` is removed.)
+
+- [ ] **Step 5: Implement arrival scroll + highlight in ThreadDetailPage**
+
+In `ThreadDetailPage.tsx`: change the router import (line 2) to `import { useParams, Link, useLocation } from 'react-router-dom';`, add `const location = useLocation();` beside the other hooks (after line 56), and add this effect after the load effect (after line 137):
+
+```typescript
+  // Deep-link arrival: scroll to and briefly highlight #post-N once posts render.
+  // If the target is on a later cursor page it simply isn't found — no error.
+  useEffect(() => {
+    if (loading) return;
+    const match = /^#post-(\d+)$/.exec(location.hash);
+    if (!match) return;
+    const el = document.getElementById(`post-${match[1]}`);
+    if (!el) return;
+    el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    el.classList.add('ring-2', 'ring-primary', 'rounded-lg');
+    const timer = setTimeout(
+      () => el.classList.remove('ring-2', 'ring-primary', 'rounded-lg'),
+      2500
+    );
+    return () => clearTimeout(timer);
+  }, [loading, posts, location.hash]);
+```
+
+- [ ] **Step 6: Run gates**
+
+Run: `cd web && npm run type-check && npx vitest run src/utils/forumUrls.test.ts src/components/forum/PostCard.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add web/src/utils/forumUrls.ts web/src/utils/forumUrls.test.ts web/src/types/notifications.ts web/src/components/layout/NotificationBell.tsx web/src/components/forum/PostCard.tsx web/src/components/forum/PostCard.test.tsx web/src/pages/forum/ThreadDetailPage.tsx
+git commit -m "web/forum: post permalinks + notification deep links (wave 1.3)"
+```
+
+---
+
+### Task 5: Web — mention styling in rendered posts
+
+`@username` is stored as literal text; the editor styles it (`forumMentionNode.ts` uses `text-primary font-medium`) but rendered posts show plain text. Wrap mentions in styled spans — strictly AFTER DOMPurify sanitization, text nodes only, never inside links/code.
+
+**Files:**
+
+- Create: `web/src/utils/mentions.ts`
+- Create: `web/src/utils/mentions.test.ts`
+- Modify: `web/src/components/StreamFieldRenderer.tsx` (SafeHTML `postProcess` prop + `mentionHighlight` renderer prop)
+- Modify: `web/src/components/forum/PostCard.tsx:164` (pass the flag)
+- Test: extend `web/src/components/StreamFieldRenderer.test.tsx`
+
+**Interfaces:**
+
+- Produces: `highlightMentions(sanitizedHtml: string): string`; `StreamFieldRenderer` accepts optional `mentionHighlight?: boolean`.
+
+- [ ] **Step 1: Write the failing util tests**
+
+Create `web/src/utils/mentions.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { highlightMentions } from './mentions';
+
+describe('highlightMentions', () => {
+  it('wraps a mention in a styled span', () => {
+    expect(highlightMentions('<p>Thanks @bob_botanist!</p>')).toBe(
+      '<p>Thanks <span class="text-primary font-medium">@bob_botanist</span>!</p>'
+    );
+  });
+
+  it('ignores email addresses', () => {
+    expect(highlightMentions('<p>mail me at jdoe@example.com</p>')).toBe(
+      '<p>mail me at jdoe@example.com</p>'
+    );
+  });
+
+  it('does not touch text inside links or code', () => {
+    const html = '<p><a href="https://x.test">@alice</a> and <code>@beta</code></p>';
+    expect(highlightMentions(html)).toBe(html);
+  });
+
+  it('handles multiple mentions in one text node', () => {
+    expect(highlightMentions('<p>@a and @b</p>')).toBe(
+      '<p><span class="text-primary font-medium">@a</span> and <span class="text-primary font-medium">@b</span></p>'
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd web && npx vitest run src/utils/mentions.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the util**
+
+Create `web/src/utils/mentions.ts`:
+
+```typescript
+/**
+ * Wrap @username mentions in styled spans, matching the composer's mention
+ * styling (forumMentionNode.ts: text-primary font-medium).
+ *
+ * SECURITY: operates on ALREADY-SANITIZED HTML (call after createSafeMarkup),
+ * walks text nodes only, and inserts only a span with a fixed class — it can
+ * never introduce markup from user content.
+ */
+
+// A mention starts the string or follows whitespace/"(" — this skips emails,
+// where "@" follows a word character.
+const MENTION_RE = /(^|[\s(])@([A-Za-z0-9_]+)/g;
+
+export function highlightMentions(sanitizedHtml: string): string {
+  if (!sanitizedHtml.includes('@')) return sanitizedHtml;
+  const doc = new DOMParser().parseFromString(
+    `<div id="__mention_root">${sanitizedHtml}</div>`,
+    'text/html'
+  );
+  const root = doc.getElementById('__mention_root');
+  if (!root) return sanitizedHtml;
+  const walker = doc.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+  const textNodes: Text[] = [];
+  for (let n = walker.nextNode(); n; n = walker.nextNode()) {
+    const parent = (n as Text).parentElement;
+    if (parent && !parent.closest('a, code, pre')) textNodes.push(n as Text);
+  }
+  for (const node of textNodes) {
+    const text = node.textContent || '';
+    MENTION_RE.lastIndex = 0;
+    if (!MENTION_RE.test(text)) continue;
+    const frag = doc.createDocumentFragment();
+    let cursor = 0;
+    MENTION_RE.lastIndex = 0;
+    for (let m = MENTION_RE.exec(text); m; m = MENTION_RE.exec(text)) {
+      const mentionStart = m.index + m[1].length;
+      frag.appendChild(doc.createTextNode(text.slice(cursor, mentionStart)));
+      const span = doc.createElement('span');
+      span.className = 'text-primary font-medium';
+      span.textContent = `@${m[2]}`;
+      frag.appendChild(span);
+      cursor = mentionStart + m[2].length + 1;
+    }
+    frag.appendChild(doc.createTextNode(text.slice(cursor)));
+    node.replaceWith(frag);
+  }
+  return root.innerHTML;
+}
+```
+
+- [ ] **Step 4: Run util tests**
+
+Run: `cd web && npx vitest run src/utils/mentions.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Wire into the renderer + PostCard**
+
+`StreamFieldRenderer.tsx`:
+
+**5a.** `SafeHTML` gains a post-sanitization hook:
+
+```tsx
+interface SafeHTMLProps {
+  html: string;
+  className?: string;
+  /** Applied AFTER sanitization — must never introduce user-controlled markup. */
+  postProcess?: (html: string) => string;
+}
+
+function SafeHTML({ html, className = '', postProcess }: SafeHTMLProps) {
+  const safeMarkup = createSafeMarkup(html, SANITIZE_PRESETS.STREAMFIELD);
+  const markup = postProcess ? { __html: postProcess(safeMarkup.__html) } : safeMarkup;
+  return <div className={className} dangerouslySetInnerHTML={markup} />;
+}
+```
+
+**5b.** Thread the flag through (imports `highlightMentions` in the same edit):
+
+```tsx
+import { highlightMentions } from '../utils/mentions';
+
+interface StreamFieldRendererProps {
+  blocks?: StreamFieldBlockType[] | null;
+  /** Forum posts only: style @username mentions in paragraph blocks. */
+  mentionHighlight?: boolean;
+}
+
+export default function StreamFieldRenderer({ blocks, mentionHighlight }: StreamFieldRendererProps) {
+  if (!blocks || blocks.length === 0) return null;
+  return (
+    <div className="prose prose-lg max-w-none">
+      {blocks.map((block, index) => (
+        <StreamFieldBlock key={block.id || index} block={block} mentionHighlight={mentionHighlight} />
+      ))}
+    </div>
+  );
+}
+```
+
+**5c.** `StreamFieldBlock` accepts and uses it in the paragraph case only:
+
+```tsx
+function StreamFieldBlock({ block, mentionHighlight }: StreamFieldBlockProps & { mentionHighlight?: boolean }) {
+  // …
+    case 'paragraph':
+      return (
+        <SafeHTML
+          html={block.value}
+          className="mb-4 text-ink-2 leading-relaxed"
+          postProcess={mentionHighlight ? highlightMentions : undefined}
+        />
+      );
+```
+
+**5d.** `PostCard.tsx:164` becomes `<StreamFieldRenderer blocks={post.body} mentionHighlight />`.
+
+- [ ] **Step 6: Extend the renderer test**
+
+Append to `StreamFieldRenderer.test.tsx`:
+
+```tsx
+it('styles mentions in paragraphs when mentionHighlight is set', () => {
+  const { container } = render(
+    <StreamFieldRenderer
+      blocks={[{ type: 'paragraph', value: '<p>Thanks @bob_botanist!</p>' }]}
+      mentionHighlight
+    />
+  );
+  const span = container.querySelector('span.text-primary.font-medium');
+  expect(span?.textContent).toBe('@bob_botanist');
+});
+```
+
+- [ ] **Step 7: Run gates and commit**
+
+Run: `cd web && npm run type-check && npx vitest run src/utils/mentions.test.ts src/components/StreamFieldRenderer.test.tsx`
+Expected: PASS.
+
+```bash
+git add web/src/utils/mentions.ts web/src/utils/mentions.test.ts web/src/components/StreamFieldRenderer.tsx web/src/components/forum/PostCard.tsx
+git commit -m "web/forum: style @mentions in rendered posts (wave 1.4)"
+```
+
+---
+
+### Task 6: Web — reaction row de-clutter + logged-out visibility
+
+Today every post shows four zero-count buttons, and logged-out readers see nothing at all (the row is gated on `onReact`). New behavior: at rest show only non-zero counts as pills (read-only when logged out), plus a single "add reaction" affordance for authenticated users that expands the full picker.
+
+**Files:**
+
+- Modify: `web/src/components/forum/PostCard.tsx:167-184`
+- Test: extend `web/src/components/forum/PostCard.test.tsx`
+
+**Interfaces:**
+
+- Consumes: existing `post.reaction_counts` + optional `onReact` prop. No API changes — `ThreadDetailPage` already passes `onReact` only when authenticated (line 453), which now doubles as the read-only switch.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `PostCard.test.tsx`:
+
+```tsx
+it('shows non-zero reaction counts read-only when logged out (no onReact)', () => {
+  render(<PostCard post={{ ...basePost, reaction_counts: { like: 2, love: 0 } }} />);
+  expect(screen.getByText('2')).toBeInTheDocument();
+  expect(screen.queryByRole('button', { name: /add reaction/i })).not.toBeInTheDocument();
+  expect(screen.queryByRole('button', { name: /react love/i })).not.toBeInTheDocument();
+});
+
+it('hides zero counts at rest and expands the picker on demand', () => {
+  const onReact = vi.fn();
+  render(<PostCard post={{ ...basePost, reaction_counts: { like: 1 } }} onReact={onReact} />);
+  expect(screen.queryByRole('button', { name: /react love/i })).not.toBeInTheDocument();
+  fireEvent.click(screen.getByRole('button', { name: /add reaction/i }));
+  fireEvent.click(screen.getByRole('button', { name: /react love/i }));
+  expect(onReact).toHaveBeenCalledWith('21', 'love');
+});
+
+it('renders no reaction row at all for a zero-reaction post viewed logged out', () => {
+  render(<PostCard post={{ ...basePost, reaction_counts: {} }} />);
+  expect(screen.queryByRole('button', { name: /add reaction/i })).not.toBeInTheDocument();
+  expect(screen.queryByText('👍')).not.toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd web && npx vitest run src/components/forum/PostCard.test.tsx`
+Expected: FAIL — current UI renders all four buttons whenever `onReact` exists and nothing without it.
+
+- [ ] **Step 3: Implement**
+
+In `PostCard.tsx`, add state next to the other `useState` calls:
+
+```typescript
+  const [showReactionPicker, setShowReactionPicker] = useState(false);
+  const nonZeroReactions = REACTION_TYPES.filter((t) => (post.reaction_counts?.[t] ?? 0) > 0);
+```
+
+Replace the reactions block (lines 167-184) with:
+
+```tsx
+      {(onReact || nonZeroReactions.length > 0) && (
+        <div className="flex flex-wrap items-center gap-2 pt-4 border-t border-line">
+          {nonZeroReactions.map((type) => (
+            <button
+              key={type}
+              type="button"
+              onClick={onReact ? () => onReact(post.id, type) : undefined}
+              disabled={!onReact}
+              className="inline-flex items-center gap-1 min-h-11 px-3 py-1 bg-surface-2 hover:bg-surface-3 rounded-full text-sm transition-colors disabled:cursor-default disabled:hover:bg-surface-2"
+              aria-label={onReact ? `React ${type}` : `${post.reaction_counts?.[type]} ${type}`}
+              title={onReact ? `React ${type}` : type}
+            >
+              <span>{getReactionEmoji(type)}</span>
+              <span className="font-medium">{post.reaction_counts?.[type]}</span>
+            </button>
+          ))}
+          {onReact && !showReactionPicker && (
+            <button
+              type="button"
+              onClick={() => setShowReactionPicker(true)}
+              className="inline-flex items-center min-h-11 px-3 py-1 text-ink-3 hover:bg-surface-3 rounded-full text-sm transition-colors"
+              aria-label="Add reaction"
+              title="Add reaction"
+            >
+              +🙂
+            </button>
+          )}
+          {onReact &&
+            showReactionPicker &&
+            REACTION_TYPES.filter((t) => !nonZeroReactions.includes(t)).map((type) => (
+              <button
+                key={type}
+                type="button"
+                onClick={() => {
+                  onReact(post.id, type);
+                  setShowReactionPicker(false);
+                }}
+                className="inline-flex items-center min-h-11 px-3 py-1 bg-surface-2 hover:bg-surface-3 rounded-full text-sm transition-colors"
+                aria-label={`React ${type}`}
+                title={`React ${type}`}
+              >
+                {getReactionEmoji(type)}
+              </button>
+            ))}
+        </div>
+      )}
+```
+
+- [ ] **Step 4: Run gates and commit**
+
+Run: `cd web && npm run type-check && npx vitest run src/components/forum/PostCard.test.tsx`
+Expected: PASS.
+
+```bash
+git add web/src/components/forum/PostCard.tsx web/src/components/forum/PostCard.test.tsx
+git commit -m "web/forum: reaction pills — non-zero at rest, read-only for anon (wave 1.5/1.6)"
+```
+
+---
+
+### Task 7: Web — forum search entry point in the header
+
+`/forum/search` exists but nothing links to it.
+
+**Files:**
+
+- Modify: `web/src/components/layout/Header.tsx`
+
+**Interfaces:** none — pure markup.
+
+- [ ] **Step 1: Implement**
+
+In `Header.tsx`: add `Search` to the lucide import (line 3), then add a search icon link inside the right-hand group, immediately before `{isAuthenticated && <NotificationBell />}` (line 98):
+
+```tsx
+            <Link
+              to="/forum/search"
+              aria-label="Search the forum"
+              title="Search the forum"
+              className="p-2 rounded-lg text-ink-2 hover:text-primary hover:bg-surface transition-colors"
+            >
+              <Search className="w-5 h-5" />
+            </Link>
+```
+
+And in the mobile menu, after the Community NavLink (line 191):
+
+```tsx
+            <NavLink
+              to="/forum/search"
+              onClick={closeMenu}
+              className={({ isActive }) =>
+                `block px-3 py-2 rounded-lg font-medium transition-colors ${
+                  isActive ? 'bg-primary/10 text-primary' : 'text-ink-2 hover:bg-surface'
+                }`
+              }
+            >
+              Search Forum
+            </NavLink>
+```
+
+- [ ] **Step 2: Verify + commit**
+
+Run: `cd web && npm run type-check && npm run lint`
+Expected: clean. Visual check happens in Task 9's end-to-end pass.
+
+```bash
+git add web/src/components/layout/Header.tsx
+git commit -m "web/forum: search entry point in header nav (wave 1.1)"
+```
+
+---
+
+### Task 8: Web — composer draft autosave
+
+Navigating away silently loses a half-written post. Persist drafts to sessionStorage: per-board for new threads, per-topic for replies; restore on mount; clear on successful submit.
+
+**Files:**
+
+- Create: `web/src/utils/forumDrafts.ts`
+- Create: `web/src/utils/forumDrafts.test.ts`
+- Modify: `web/src/pages/forum/NewThreadPage.tsx`
+- Modify: `web/src/pages/forum/ThreadDetailPage.tsx`
+
+**Interfaces:**
+
+- Produces: `draftKey(kind: 'reply' | 'new-thread', id: string): string`, `loadDraft(key: string): string | null`, `saveDraft(key: string, value: string): void` (empty value removes), `clearDraft(key: string): void`. All storage errors are swallowed (private-mode Safari, quota).
+
+- [ ] **Step 1: Write the failing util tests**
+
+Create `web/src/utils/forumDrafts.test.ts`:
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { draftKey, loadDraft, saveDraft, clearDraft } from './forumDrafts';
+
+describe('forumDrafts', () => {
+  beforeEach(() => sessionStorage.clear());
+
+  it('round-trips a draft', () => {
+    const key = draftKey('reply', '28');
+    saveDraft(key, '<p>half-written</p>');
+    expect(loadDraft(key)).toBe('<p>half-written</p>');
+    clearDraft(key);
+    expect(loadDraft(key)).toBeNull();
+  });
+
+  it('saving an empty value removes the draft', () => {
+    const key = draftKey('new-thread', '54');
+    saveDraft(key, '<p>x</p>');
+    saveDraft(key, '');
+    expect(loadDraft(key)).toBeNull();
+  });
+
+  it('swallows storage errors', () => {
+    const spy = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('QuotaExceededError');
+    });
+    expect(() => saveDraft(draftKey('reply', '1'), 'x')).not.toThrow();
+    spy.mockRestore();
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd web && npx vitest run src/utils/forumDrafts.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the util**
+
+Create `web/src/utils/forumDrafts.ts`:
+
+```typescript
+/**
+ * Best-effort composer draft persistence (sessionStorage — survives navigation
+ * within the tab, intentionally not across sessions). All storage failures are
+ * swallowed: drafts are a convenience, never a correctness dependency.
+ */
+
+const PREFIX = 'forum-draft:';
+
+export function draftKey(kind: 'reply' | 'new-thread', id: string): string {
+  return `${PREFIX}${kind}:${id}`;
+}
+
+export function loadDraft(key: string): string | null {
+  try {
+    return sessionStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+export function saveDraft(key: string, value: string): void {
+  try {
+    if (value) {
+      sessionStorage.setItem(key, value);
+    } else {
+      sessionStorage.removeItem(key);
+    }
+  } catch {
+    /* private mode / quota — best-effort only */
+  }
+}
+
+export function clearDraft(key: string): void {
+  try {
+    sessionStorage.removeItem(key);
+  } catch {
+    /* ignore */
+  }
+}
+```
+
+- [ ] **Step 4: Run util tests**
+
+Run: `cd web && npx vitest run src/utils/forumDrafts.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Wire NewThreadPage**
+
+In `NewThreadPage.tsx` (import `{ draftKey, loadDraft, saveDraft, clearDraft }` from `'../../utils/forumDrafts'` in the same edit as first usage):
+
+**5a.** Derive the key and restore initial state (replace lines 30-31):
+
+```typescript
+  const newThreadDraftKey = draftKey('new-thread', categoryParam ?? 'unknown');
+  const [title, setTitle] = useState(() => {
+    try {
+      return JSON.parse(loadDraft(newThreadDraftKey) || '{}').title || '';
+    } catch {
+      return '';
+    }
+  });
+  const [body, setBody] = useState(() => {
+    try {
+      return JSON.parse(loadDraft(newThreadDraftKey) || '{}').body || '';
+    } catch {
+      return '';
+    }
+  });
+```
+
+**5b.** Persist on change — add after the load effect (after line 60):
+
+```typescript
+  // Persist the draft on every change; an all-empty draft is removed.
+  useEffect(() => {
+    const isEmpty = title.trim() === '' && isBlankHtml(body);
+    saveDraft(newThreadDraftKey, isEmpty ? '' : JSON.stringify({ title, body }));
+  }, [title, body, newThreadDraftKey]);
+```
+
+**5c.** Clear on success — in `handleSubmit`, immediately after `const res = await createThread({ … });` (line 75), add `clearDraft(newThreadDraftKey);`.
+
+**5d.** TipTap `content` is init-only, but the restored `body` is set before first render (lazy `useState`), so the editor initializes with the draft — pass it as today: `<TipTapEditor content={body} onChange={setBody} … />` (no change needed on line 158).
+
+- [ ] **Step 6: Wire the ThreadDetailPage reply composer**
+
+In `ThreadDetailPage.tsx` (import the same four helpers in the edit that first uses them):
+
+**6a.** Restore per-topic on navigation — inside the `loadData` effect, right after `currentTopicIdRef.current = topicId;` (line 96), add:
+
+```typescript
+    // Restore this topic's reply draft (per-topic key); remount the composer
+    // so TipTap's init-only content picks it up.
+    setReplyBody(topicId != null ? (loadDraft(draftKey('reply', String(topicId))) ?? '') : '');
+    setComposerKey((k) => k + 1);
+```
+
+**6b.** Persist on change — replace the composer's `onChange={setReplyBody}` (line 506) with:
+
+```tsx
+            onChange={(html) => {
+              setReplyBody(html);
+              if (topicId != null) {
+                saveDraft(draftKey('reply', String(topicId)), isBlankHtml(html) ? '' : html);
+              }
+            }}
+```
+
+**6c.** Clear on successful post — in `handleReply`, right after `const res = await createPost({ … });` (line 175), add:
+
+```typescript
+        if (topicId != null) clearDraft(draftKey('reply', String(topicId)));
+```
+
+- [ ] **Step 7: Run the full web gates**
+
+Run: `cd web && npm run type-check && npm run lint && npm run test`
+Expected: all clean/PASS (full suite — this is the last code task).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add web/src/utils/forumDrafts.ts web/src/utils/forumDrafts.test.ts web/src/pages/forum/NewThreadPage.tsx web/src/pages/forum/ThreadDetailPage.tsx
+git commit -m "web/forum: composer draft autosave via sessionStorage (wave 1.7)"
+```
+
+---
+
+### Task 9: End-to-end verification + PR
+
+Exercise every Wave 1 item in the running app (spec acceptance: "each item verified in the running app, not just tests"), then open the PR.
+
+- [ ] **Step 1: Full backend + web gates**
+
+```bash
+cd backend && venv/bin/python -m pytest packages/wagtail_forum -q && venv/bin/python manage.py spectacular --file /dev/null
+cd ../web && npm run type-check && npm run lint && npm run test
+```
+
+Expected: all pass.
+
+- [ ] **Step 2: Live walkthrough (use the bundled `verify` skill / Playwright)**
+
+Start Redis, `backend: venv/bin/python manage.py runserver 8000`, `web: npm run dev`. Then verify each item as a user:
+
+1. Header shows a search icon → lands on `/forum/search`; mobile menu shows "Search Forum".
+2. Search "tomato" (seed data exists in the local dev DB from the 2026-07-17 session — users `alice_gardener`/`bob_botanist`/`carol_composts`, password in that session's seed script): thread card shows REAL reply/view counts and its link opens the thread (previously 404'd).
+3. Category filter actually narrows results (`?board=` visible in the network tab).
+4. Logged out: bob's earwig post shows its 👍/💡 count pills, read-only; posts with no reactions show no row.
+5. Logged in: pills + "+🙂" affordance; picker expands; toggling updates counts.
+6. Hover a post → "🔗 Copy link"; paste the URL in a new tab → page scrolls to and highlights the post.
+7. Click a notification in the bell → lands ON the post (hash + highlight), not just the thread top.
+8. A post containing `@bob_botanist` renders the mention styled (primary color, medium weight).
+9. Type a half reply, navigate away, come back → draft restored; post it → composer clears and the draft is gone. Same for a new-thread title+body.
+
+Fix anything that fails before proceeding.
+
+- [ ] **Step 3: Push branch + open PR**
+
+```bash
+git push -u origin feat/forum-wave1-honesty-polish
+gh pr create --title "Forum Wave 1: honesty & polish sprint" --body "$(cat <<'EOF'
+## Summary
+Wave 1 of docs/superpowers/specs/2026-07-17-forum-app-loop-roadmap-design.md — makes existing forum features findable and truthful. No new product features, no migrations.
+
+- Search results carry real metadata (was fabricated "0 replies • recently") + working links (were broken) + a real board filter
+- Notifications deep-link to the post (#post-N + scroll highlight); per-post copy-link affordance
+- @mentions styled in rendered posts (was plain text)
+- Reaction counts visible to logged-out readers; zero-count buttons replaced with non-zero pills + add-reaction picker
+- Forum search reachable from the header nav
+- Composer drafts autosave to sessionStorage (no more silent data loss)
+
+## Test plan
+- Package API tests extended (search metadata/filter, notification post_id)
+- New/extended Vitest suites: mappers, service, SearchPage, PostCard, mentions, drafts
+- Live walkthrough of all 7 items against the dev stack
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Per the user's standing preference: present the PR diff for their review FIRST; only after they've reviewed, arm `gh pr merge --auto --squash --delete-branch`.
+
+---
+
+## Self-Review (completed at authoring time)
+
+- **Spec coverage:** Wave 1 items 1→Task 7, 2→Tasks 1+3, 3→Tasks 2+4, 4→Task 5, 5→Task 6, 6→Task 6, 7→Task 8. Acceptance ("verified in the running app; search shows real counts; notification lands on the post") → Task 9.
+- **Placeholders:** none — every code step carries the actual code.
+- **Type consistency:** `postAnchor` (Tasks 4), `highlightMentions` (Task 5), `draftKey/loadDraft/saveDraft/clearDraft` (Task 8), and the search payload fields (Tasks 1↔3) are named identically at definition and use sites.
+- **Known judgment calls:** search `total_*` remain array lengths (server caps at 50 — documented in code comment); deep links to posts beyond the first cursor page silently no-op (documented; full resolution needs jump-to-post pagination, out of Wave 1 scope).

--- a/docs/superpowers/specs/2026-07-17-forum-app-loop-roadmap-design.md
+++ b/docs/superpowers/specs/2026-07-17-forum-app-loop-roadmap-design.md
@@ -61,6 +61,9 @@ show real counts; a notification click lands on the specific post.
 - Serializers expose `is_solved` / `solved_post_id`; topic lists show a Solved badge;
   thread view highlights the accepted post with a "mark as answer" affordance.
 - Accepted-answer author gets a notification via the existing pipeline.
+- **Clearing rule (advisor):** unpublishing or deleting the accepted post clears the
+  topic's solved state (`SET_NULL` + signal, or liveness check at serialize) — no
+  dangling Solved badge pointing at a hidden post.
 
 ### Identification embed
 
@@ -73,16 +76,30 @@ show real counts; a notification click lands on the specific post.
   without breaking public forum content — consistent with the app's GDPR posture), and
   no schema-in-body migration pain later.
 - Rendered as a card above the opening post.
+- **Advisor amendments:** the source `identification_result_id` is retained as a plain
+  non-FK field (correlation/analytics later without coupling to private history); the
+  attachment's image FK is `SET_NULL` with a graceful no-photo card fallback; when the
+  topic is solved, the card links to the accepted answer so the snapshot never reads
+  as the final word.
 - v1 is display + compose only. Writing a "confirmed species" back into the ID system
   is **out of scope**.
 - Web entry point: the identify results page gets an "Ask the community" button that
   pre-fills the new-thread composer with the attachment.
+
+### Author display fix (pulled forward from Wave 4 — advisor)
+
+- `PostAuthorSerializer` returns the real `trust_level` (currently hardcoded `None`)
+  and `display_name`. Serializer-only; profiles, avatars, and profile pages stay in
+  Wave 4. Rationale: the mobile client should not launch with faceless authors, and
+  solved-answer badges are hollow without visible reputation.
 
 ### Mobile-gating API hardening (subset of todo 258)
 
 - Idempotency for `PATCH /posts/{id}/` and image upload (audit M35/M36 — flagged
   "land before mobile writes").
 - OpenAPI response-code completeness for every endpoint the mobile client consumes.
+- **Error-envelope consistency (advisor):** normalize error response shapes across
+  the endpoints the mobile client consumes, so mobile error handling is written once.
 - Nothing else from 258 in this wave.
 
 **Acceptance:** solved + embed exercised end-to-end from the web UI; idempotent
@@ -95,7 +112,9 @@ Four slices, one PR each:
 1. **Read-only client** — boards → topic list (cursor pagination, unread badges) →
    thread (posts, reactions, solved highlight, ID-attachment card).
 2. **Auth + writes** — topics/replies/reactions with `Idempotency-Key`, mention
-   autocomplete, image upload.
+   autocomplete, image upload. Composer drafts persist locally (advisor: a
+   background-kill or network blip must not eat a half-written post — the mobile
+   analogue of Wave 1's web autosave).
 3. **Flagship flow** — camera/ID result → "Ask the community" → prefilled composer;
    solved-marking in-thread.
 4. **Push deep links** — notification tap opens the thread at the right post.
@@ -105,7 +124,9 @@ Constraints and fold-ins:
 - Online-first; the `/sync/` delta endpoint enables offline later (**not v1**).
 - The prod Celery topology check and `prune_forum_tombstones` scheduling (todo 261
   items) fold in here — push delivery E2E depends on the first, traffic hygiene on
-  the second.
+  the second. **Explicit gate (advisor):** prod Firebase service-account credentials
+  and the Celery topology check are prerequisites for slice 4 — verify push delivery
+  works before building deep links on top of it.
 - Riverpod 3 + existing app conventions; state/API details resolved in the
   implementation plan, not here.
 - **Editorial gate:** before the app announces the forum, production needs real seed
@@ -133,6 +154,8 @@ Constraints and fold-ins:
 - **SEO:** reduced to meta/OG tags, done opportunistically.
 - **Todo 259 (modal/a11y hardening) and 262 (package docs):** unchanged in backlog.
 - **Quote-reply, tags, threading, polls, DMs, offline forum:** not in these waves.
+  Revisit trigger for tags: topic volume makes browse painful (order of a few
+  hundred topics) — premature taxonomy on a near-empty forum helps nobody.
 
 ## Todo bookkeeping
 

--- a/docs/superpowers/specs/2026-07-17-forum-app-loop-roadmap-design.md
+++ b/docs/superpowers/specs/2026-07-17-forum-app-loop-roadmap-design.md
@@ -1,0 +1,153 @@
+# Forum App-Loop Roadmap — Design
+
+**Date:** 2026-07-17
+**Status:** Approved (brainstorming session, this date)
+**Context:** Product-gap assessment of the shipped `wagtail_forum` package + web client
+(inventoried backend, web frontend, and open todos; live walkthrough with seeded data).
+Supersedes the *sequencing* of epics 253–263 from
+`docs/audits/2026-07-11-forum-modernization.md`; individual findings keep their
+`source_review` traceability.
+
+## Goal and locked decisions
+
+The forum's purpose is an **app community**: it serves Plant ID app users
+(help-identify threads, care Q&A). Three decisions lock the shape:
+
+1. **App community over open growth or portfolio.** SEO/discovery work is demoted to
+   cheap meta tags; package polish stays parked.
+2. **Mobile early.** The Flutter client lands immediately after the backend primitives
+   it needs, not after web reaches feature parity.
+3. **Plant-ID integration is the marquee.** The identification-embed feature is pulled
+   forward from the later wave (todo 263) into Wave 2.
+
+The flagship journey everything sequences around:
+
+> Photo in app → uncertain ID → "Ask the community" → forum topic with the
+> identification embedded → someone answers → author marks it solved → asker
+> gets a push notification.
+
+## Wave 1 — Honesty & polish sprint (web)
+
+Small fixes only; no new features. Makes existing features findable and truthful
+before building on them. All in `web/` except one serializer change.
+
+1. **Search discoverable** — forum search entry point in the header nav.
+2. **Honest search results** — extend `SearchView` topic payload with `reply_count`,
+   `view_count`, `last_post_at`, and board slug; frontend stops fabricating
+   "0 replies • recently". Drop the decorative author/date filter inputs; keep
+   query + category, wiring a `board_id` filter into `SearchView` (the models
+   already declare the needed `FilterField`).
+3. **Permalinks** — per-post copy-link affordance on the existing `#post-N` anchors;
+   notification clicks navigate with the anchor and scroll-highlight the post
+   (add `post_id` to the notification payload if absent).
+4. **Mention styling** — `@username` renders as a highlighted span (becomes a link in
+   Wave 4 when profiles exist).
+5. **Reactions visible logged-out** — read-only non-zero counts for anonymous readers.
+6. **Reaction row de-clutter** — at rest, non-zero counts as pills plus a single
+   "add reaction" affordance; no four zero-count buttons per post.
+7. **Draft autosave** — sessionStorage keyed by board/topic; restore on mount, clear on
+   successful post.
+
+**Acceptance:** each item verified in the running app (not just tests); search results
+show real counts; a notification click lands on the specific post.
+
+## Wave 2 — App-loop backend primitives (+ minimal web UI)
+
+### Solved answers
+
+- `Topic.solved_post` FK (nullable) + `solved_at`.
+- `POST/DELETE /topics/{id}/solution/` with `post_id`.
+- **Decision:** topic author and moderators may mark/unmark. Available on all boards in v1.
+- Serializers expose `is_solved` / `solved_post_id`; topic lists show a Solved badge;
+  thread view highlights the accepted post with a "mark as answer" affordance.
+- Accepted-answer author gets a notification via the existing pipeline.
+
+### Identification embed
+
+- **Decision:** a `ForumIdentificationAttachment` model — a topic-level **snapshot**,
+  not a StreamField body block and not an FK into `plant_identification` records.
+  Created at compose time from an `identification_result_id`: the photo is copied into
+  the forum image collection through the existing 4-layer/IDOR upload pipeline; top-3
+  candidates + confidences + provider stored as JSON.
+- Rationale: no FK into users' private identification history (they can purge history
+  without breaking public forum content — consistent with the app's GDPR posture), and
+  no schema-in-body migration pain later.
+- Rendered as a card above the opening post.
+- v1 is display + compose only. Writing a "confirmed species" back into the ID system
+  is **out of scope**.
+- Web entry point: the identify results page gets an "Ask the community" button that
+  pre-fills the new-thread composer with the attachment.
+
+### Mobile-gating API hardening (subset of todo 258)
+
+- Idempotency for `PATCH /posts/{id}/` and image upload (audit M35/M36 — flagged
+  "land before mobile writes").
+- OpenAPI response-code completeness for every endpoint the mobile client consumes.
+- Nothing else from 258 in this wave.
+
+**Acceptance:** solved + embed exercised end-to-end from the web UI; idempotent
+retries verified for all mobile-bound write endpoints.
+
+## Wave 3 — Flutter forum client (todo 260)
+
+Four slices, one PR each:
+
+1. **Read-only client** — boards → topic list (cursor pagination, unread badges) →
+   thread (posts, reactions, solved highlight, ID-attachment card).
+2. **Auth + writes** — topics/replies/reactions with `Idempotency-Key`, mention
+   autocomplete, image upload.
+3. **Flagship flow** — camera/ID result → "Ask the community" → prefilled composer;
+   solved-marking in-thread.
+4. **Push deep links** — notification tap opens the thread at the right post.
+
+Constraints and fold-ins:
+
+- Online-first; the `/sync/` delta endpoint enables offline later (**not v1**).
+- The prod Celery topology check and `prune_forum_tombstones` scheduling (todo 261
+  items) fold in here — push delivery E2E depends on the first, traffic hygiene on
+  the second.
+- Riverpod 3 + existing app conventions; state/API details resolved in the
+  implementation plan, not here.
+- **Editorial gate:** before the app announces the forum, production needs real seed
+  content (currently one topic). This is content work, tracked alongside slice 4.
+
+**Acceptance:** the full flagship journey works on a device against production.
+
+## Wave 4 — Identity (todo 257)
+
+- Public profile endpoint: `display_name`, avatar, bio, trust level, joined date,
+  post count, recent posts.
+- Avatar upload through the existing image pipeline; rendition-served thumbnails.
+- `PostAuthorSerializer` returns real `trust_level` (currently hardcoded `None`) and
+  avatar thumbnail.
+- Web profile page replaces the "Coming Soon" stub; mobile gets a profile screen.
+- Wave 1 mention highlights become links to profiles.
+- **Decision:** signatures stay dead — field remains, no UI renders it.
+- Badges/gamification deferred.
+
+**Acceptance:** tapping any post author (web and mobile) opens a public profile.
+
+## Demoted / out of scope for this roadmap
+
+- **Todo 255 (AI + premium):** parked until there is real posting activity.
+- **SEO:** reduced to meta/OG tags, done opportunistically.
+- **Todo 259 (modal/a11y hardening) and 262 (package docs):** unchanged in backlog.
+- **Quote-reply, tags, threading, polls, DMs, offline forum:** not in these waves.
+
+## Todo bookkeeping
+
+Re-scope existing todos; do not renumber:
+
+- Solved answers move out of 256; the identification embed moves out of 263 — both
+  into a new Wave 2 epic todo with `source_review` pointing at the 2026-07-11 audit.
+- 258 splits: mobile-gating subset into Wave 2, remainder stays.
+- 260 = Wave 3; 257 = Wave 4; 261 partially folds into Wave 3.
+- Wave 1 gets its own small todo (or ships directly as a reviewed PR).
+
+## Delivery conventions
+
+Per-slice PRs off fresh `main`, kimi-review commit gate, bundled `/code-review` +
+checklist orchestrator on substantial diffs, pattern codification at session end —
+all per existing project workflow. Backend changes carry strict-assertion tests;
+web carries Vitest; mobile carries widget + integration tests per platform
+conventions.

--- a/web/docs/patterns/react-typescript.md
+++ b/web/docs/patterns/react-typescript.md
@@ -253,3 +253,38 @@ completes rather than resolving with stale data. Test the race directly by
 mocking the network call with two manually-resolvable promises and resolving
 them out of order — a debounce-only test (single call, fake-timers advance)
 doesn't exercise this path at all.
+
+## One-Shot Side Effects in a List-Dependent Effect
+
+An effect that lists a **growing collection** in its deps (`posts`, `messages`,
+`rows`) re-runs on every append. That's correct when the effect's job *is* to
+react to the new items — but any **one-shot side effect** in the same effect
+(scroll-into-view, autofocus, a fire-once analytics ping) then fires again on
+every append, not just the first time. In the forum thread deep-link, the
+arrival effect had `posts` in its deps so it could pull later cursor pages until
+the `#post-N` target mounted — but the same effect also called
+`el.scrollIntoView()`, so posting a reply or clicking "Load More" (with the hash
+still in the URL) yanked the viewport back to the anchor on every list change.
+
+Gate the one-shot part on a `useRef` keyed by the effect's *trigger identity*
+(here, the hash), and reset it when a fresh trigger arrives:
+
+```typescript
+const scrolledHashRef = useRef<string | null>(null);
+// reset on navigation (new thread): scrolledHashRef.current = null;
+
+useEffect(() => {
+  const el = document.getElementById(targetId);
+  if (!el) { /* keep loading pages… */ return; }
+  if (scrolledHashRef.current === location.hash) return; // already scrolled to this anchor
+  scrolledHashRef.current = location.hash;
+  el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+}, [loading, posts, location.hash /* …loaders… */]);
+```
+
+Same shape guards the auto-loader itself: advance **once per cursor** via a
+`chaseCursorRef` so a failed page-fetch (which leaves `nextCursor` unchanged)
+can't retry forever. And any request fired automatically from such an effect
+needs a **stale-thread guard** — capture the id before the `await` and skip the
+`setState` if `currentIdRef.current` moved on, or a late page for thread A
+appends to thread B (see `ThreadDetailPage.tsx`).

--- a/web/docs/patterns/testing.md
+++ b/web/docs/patterns/testing.md
@@ -229,3 +229,12 @@ Gotchas:
   the PR/todo Work Log — a passing suite shouldn't imply coverage it doesn't
   have. See `forumMentionNode.ts`'s `shouldRender` guard and todo 253 slice
   4's Work Log for the precedent.
+- jsdom implements `scrollIntoView` on **`HTMLElement.prototype`**, not
+  `Element.prototype`. A test that stubs/spies `Element.prototype.scrollIntoView`
+  gets **silently shadowed** — the real call resolves to jsdom's own
+  `HTMLElement.prototype` no-op, so the spy records 0 calls and an assertion like
+  `toHaveBeenCalledTimes(1)` fails even though the component scrolled correctly.
+  Spy on `HTMLElement.prototype.scrollIntoView` (post-card wrappers are
+  `HTMLElement`s). Cost a green-looking arrival-scroll test a full debug loop in
+  the forum Wave 1 deep-link work — the production code was right, the spy target
+  was wrong.

--- a/web/src/components/StreamFieldRenderer.test.tsx
+++ b/web/src/components/StreamFieldRenderer.test.tsx
@@ -508,6 +508,19 @@ describe('StreamFieldRenderer', () => {
     // Removed test for embed block (no longer supported - TODO #033)
   });
 
+  describe('Mention highlighting', () => {
+    it('styles mentions in paragraphs when mentionHighlight is set', () => {
+      const { container } = render(
+        <StreamFieldRenderer
+          blocks={[{ type: 'paragraph', value: '<p>Thanks @bob_botanist!</p>' }]}
+          mentionHighlight
+        />
+      );
+      const span = container.querySelector('span.text-primary.font-medium');
+      expect(span?.textContent).toBe('@bob_botanist');
+    });
+  });
+
   describe('Performance', () => {
     it('renders many blocks efficiently', () => {
       const blocks: StreamFieldBlock[] = Array.from({ length: 50 }, (_, i) => ({

--- a/web/src/components/StreamFieldRenderer.tsx
+++ b/web/src/components/StreamFieldRenderer.tsx
@@ -1,4 +1,5 @@
 import { createSafeMarkup, SANITIZE_PRESETS } from '../utils/sanitize';
+import { highlightMentions } from '../utils/mentions';
 import type { StreamFieldBlock as StreamFieldBlockType } from '@/types/blog';
 
 /**
@@ -11,11 +12,14 @@ import type { StreamFieldBlock as StreamFieldBlockType } from '@/types/blog';
 interface SafeHTMLProps {
   html: string;
   className?: string;
+  /** Applied AFTER sanitization — must never introduce user-controlled markup. */
+  postProcess?: (html: string) => string;
 }
 
-function SafeHTML({ html, className = '' }: SafeHTMLProps) {
+function SafeHTML({ html, className = '', postProcess }: SafeHTMLProps) {
   const safeMarkup = createSafeMarkup(html, SANITIZE_PRESETS.STREAMFIELD);
-  return <div className={className} dangerouslySetInnerHTML={safeMarkup} />;
+  const markup = postProcess ? { __html: postProcess(safeMarkup.__html) } : safeMarkup;
+  return <div className={className} dangerouslySetInnerHTML={markup} />;
 }
 
 /**
@@ -26,6 +30,8 @@ function SafeHTML({ html, className = '' }: SafeHTMLProps) {
  */
 interface StreamFieldRendererProps {
   blocks?: StreamFieldBlockType[] | null;
+  /** Forum posts only: style @username mentions in paragraph blocks. */
+  mentionHighlight?: boolean;
 }
 
 function renderTextOrSafeHtml(content: string, className = '') {
@@ -55,7 +61,10 @@ function getSafeHref(url: string): string {
   }
 }
 
-export default function StreamFieldRenderer({ blocks }: StreamFieldRendererProps) {
+export default function StreamFieldRenderer({
+  blocks,
+  mentionHighlight,
+}: StreamFieldRendererProps) {
   if (!blocks || blocks.length === 0) {
     return null;
   }
@@ -63,7 +72,11 @@ export default function StreamFieldRenderer({ blocks }: StreamFieldRendererProps
   return (
     <div className="prose prose-lg max-w-none">
       {blocks.map((block, index) => (
-        <StreamFieldBlock key={block.id || index} block={block} />
+        <StreamFieldBlock
+          key={block.id || index}
+          block={block}
+          mentionHighlight={mentionHighlight}
+        />
       ))}
     </div>
   );
@@ -76,9 +89,10 @@ export default function StreamFieldRenderer({ blocks }: StreamFieldRendererProps
  */
 interface StreamFieldBlockProps {
   block: StreamFieldBlockType;
+  mentionHighlight?: boolean;
 }
 
-function StreamFieldBlock({ block }: StreamFieldBlockProps) {
+function StreamFieldBlock({ block, mentionHighlight }: StreamFieldBlockProps) {
   const { type } = block;
 
   switch (type) {
@@ -89,7 +103,13 @@ function StreamFieldBlock({ block }: StreamFieldBlockProps) {
 
     case 'paragraph':
       // Backend: RichTextBlock (HTML string)
-      return <SafeHTML html={block.value} className="mb-4 text-ink-2 leading-relaxed" />;
+      return (
+        <SafeHTML
+          html={block.value}
+          className="mb-4 text-ink-2 leading-relaxed"
+          postProcess={mentionHighlight ? highlightMentions : undefined}
+        />
+      );
 
     case 'image': {
       // Backend (forum PR-3): ImageChooserBlock → {id, url, alt, width, height}.

--- a/web/src/components/forum/PostCard.test.tsx
+++ b/web/src/components/forum/PostCard.test.tsx
@@ -161,22 +161,26 @@ describe('PostCard', () => {
     expect(screen.getByText('1')).toBeInTheDocument();
   });
 
-  it('renders the four reaction buttons when onReact is provided, defaulting counts to 0', () => {
+  it('shows all four reaction options in the picker when no reactions exist yet and onReact is provided', () => {
     const post = createMockPost({
       reaction_counts: {},
     });
 
     renderPostCard(post);
 
-    // All four reaction buttons render when handler is present.
+    // At rest, zero-count buttons are hidden — only "Add reaction" shows.
+    expect(screen.queryByLabelText('React like')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /add reaction/i }));
+
+    // Expanding the picker reveals all four reaction options.
     expect(screen.getByLabelText('React like')).toBeInTheDocument();
     expect(screen.getByLabelText('React love')).toBeInTheDocument();
     expect(screen.getByLabelText('React helpful')).toBeInTheDocument();
     expect(screen.getByLabelText('React thanks')).toBeInTheDocument();
-    expect(screen.getAllByText('0')).toHaveLength(4);
   });
 
-  it('shows each reaction type with its count (0 when absent) when onReact is provided', () => {
+  it('shows only the non-zero reaction as a pill at rest; the zero one appears in the picker', () => {
     const post = createMockPost({
       reaction_counts: {
         like: 0,
@@ -187,7 +191,11 @@ describe('PostCard', () => {
     renderPostCard(post);
 
     expect(screen.getByLabelText('React love')).toHaveTextContent('2');
-    expect(screen.getByLabelText('React like')).toHaveTextContent('0');
+    expect(screen.queryByLabelText('React like')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /add reaction/i }));
+
+    expect(screen.getByLabelText('React like')).toBeInTheDocument();
   });
 
   it('hides reaction buttons when onReact is not provided', () => {
@@ -215,6 +223,7 @@ describe('PostCard', () => {
       </BrowserRouter>
     );
 
+    await userEvent.click(screen.getByRole('button', { name: /add reaction/i }));
     await userEvent.click(screen.getByLabelText('React like'));
 
     expect(onReact).toHaveBeenCalledWith('post-9', 'like');
@@ -427,5 +436,48 @@ describe('PostCard', () => {
       expect(writeText).toHaveBeenCalledWith(expect.stringContaining('#post-21'))
     );
     expect(await screen.findByText(/copied/i)).toBeInTheDocument();
+  });
+
+  it('shows non-zero reaction counts read-only when logged out (no onReact)', () => {
+    const post = createMockPost({ reaction_counts: { like: 2, love: 0 } });
+
+    render(
+      <BrowserRouter>
+        <PostCard post={post} />
+      </BrowserRouter>
+    );
+
+    expect(screen.getByText('2')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /add reaction/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /react love/i })).not.toBeInTheDocument();
+  });
+
+  it('hides zero counts at rest and expands the picker on demand', () => {
+    const onReact = vi.fn();
+    const post = createMockPost({ id: '21', reaction_counts: { like: 1 } });
+
+    render(
+      <BrowserRouter>
+        <PostCard post={post} onReact={onReact} />
+      </BrowserRouter>
+    );
+
+    expect(screen.queryByRole('button', { name: /react love/i })).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /add reaction/i }));
+    fireEvent.click(screen.getByRole('button', { name: /react love/i }));
+    expect(onReact).toHaveBeenCalledWith('21', 'love');
+  });
+
+  it('renders no reaction row at all for a zero-reaction post viewed logged out', () => {
+    const post = createMockPost({ reaction_counts: {} });
+
+    render(
+      <BrowserRouter>
+        <PostCard post={post} />
+      </BrowserRouter>
+    );
+
+    expect(screen.queryByRole('button', { name: /add reaction/i })).not.toBeInTheDocument();
+    expect(screen.queryByText('👍')).not.toBeInTheDocument();
   });
 });

--- a/web/src/components/forum/PostCard.test.tsx
+++ b/web/src/components/forum/PostCard.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { BrowserRouter } from 'react-router-dom';
 import PostCard from './PostCard';
@@ -409,5 +409,23 @@ describe('PostCard', () => {
 
     expect(onReport).not.toHaveBeenCalled();
     expect(screen.getByTitle('Report post')).toBeInTheDocument();
+  });
+
+  it('copies a permalink to the clipboard', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+    const post = createMockPost({ id: '21' });
+
+    render(
+      <BrowserRouter>
+        <PostCard post={post} />
+      </BrowserRouter>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /copy link/i }));
+    await waitFor(() =>
+      expect(writeText).toHaveBeenCalledWith(expect.stringContaining('#post-21'))
+    );
+    expect(await screen.findByText(/copied/i)).toBeInTheDocument();
   });
 });

--- a/web/src/components/forum/PostCard.tsx
+++ b/web/src/components/forum/PostCard.tsx
@@ -51,6 +51,8 @@ function PostCard({ post, onEdit, onDelete, onReact, onReport }: PostCardProps) 
   const [hasReported, setHasReported] = useState(false);
   const [isSubmittingReport, setIsSubmittingReport] = useState(false);
   const [copiedLink, setCopiedLink] = useState(false);
+  const [showReactionPicker, setShowReactionPicker] = useState(false);
+  const nonZeroReactions = REACTION_TYPES.filter((t) => (post.reaction_counts?.[t] ?? 0) > 0);
 
   const handleCopyLink = async () => {
     const url = `${window.location.origin}${window.location.pathname}#post-${post.id}`;
@@ -183,22 +185,50 @@ function PostCard({ post, onEdit, onDelete, onReact, onReport }: PostCardProps) 
         <StreamFieldRenderer blocks={post.body} mentionHighlight />
       </div>
 
-      {/* Reactions — shown only when an onReact handler is provided (Phase 2 write UI). */}
-      {onReact && (
-        <div className="flex gap-3 pt-4 border-t border-line">
-          {REACTION_TYPES.map((type) => (
+      {(onReact || nonZeroReactions.length > 0) && (
+        <div className="flex flex-wrap items-center gap-2 pt-4 border-t border-line">
+          {nonZeroReactions.map((type) => (
             <button
               key={type}
               type="button"
-              onClick={() => onReact(post.id, type)}
-              className="inline-flex items-center gap-1 min-h-11 px-3 py-1 bg-surface-2 hover:bg-surface-3 rounded-full text-sm transition-colors"
-              aria-label={`React ${type}`}
-              title={`React ${type}`}
+              onClick={onReact ? () => onReact(post.id, type) : undefined}
+              disabled={!onReact}
+              className="inline-flex items-center gap-1 min-h-11 px-3 py-1 bg-surface-2 hover:bg-surface-3 rounded-full text-sm transition-colors disabled:cursor-default disabled:hover:bg-surface-2"
+              aria-label={onReact ? `React ${type}` : `${post.reaction_counts?.[type]} ${type}`}
+              title={onReact ? `React ${type}` : type}
             >
               <span>{getReactionEmoji(type)}</span>
-              <span className="font-medium">{post.reaction_counts?.[type] ?? 0}</span>
+              <span className="font-medium">{post.reaction_counts?.[type]}</span>
             </button>
           ))}
+          {onReact && !showReactionPicker && (
+            <button
+              type="button"
+              onClick={() => setShowReactionPicker(true)}
+              className="inline-flex items-center min-h-11 px-3 py-1 text-ink-3 hover:bg-surface-3 rounded-full text-sm transition-colors"
+              aria-label="Add reaction"
+              title="Add reaction"
+            >
+              +🙂
+            </button>
+          )}
+          {onReact &&
+            showReactionPicker &&
+            REACTION_TYPES.filter((t) => !nonZeroReactions.includes(t)).map((type) => (
+              <button
+                key={type}
+                type="button"
+                onClick={() => {
+                  onReact(post.id, type);
+                  setShowReactionPicker(false);
+                }}
+                className="inline-flex items-center min-h-11 px-3 py-1 bg-surface-2 hover:bg-surface-3 rounded-full text-sm transition-colors"
+                aria-label={`React ${type}`}
+                title={`React ${type}`}
+              >
+                {getReactionEmoji(type)}
+              </button>
+            ))}
         </div>
       )}
 

--- a/web/src/components/forum/PostCard.tsx
+++ b/web/src/components/forum/PostCard.tsx
@@ -180,7 +180,7 @@ function PostCard({ post, onEdit, onDelete, onReact, onReport }: PostCardProps) 
 
       {/* Post Content */}
       <div className="mb-4 break-words">
-        <StreamFieldRenderer blocks={post.body} />
+        <StreamFieldRenderer blocks={post.body} mentionHighlight />
       </div>
 
       {/* Reactions — shown only when an onReact handler is provided (Phase 2 write UI). */}

--- a/web/src/components/forum/PostCard.tsx
+++ b/web/src/components/forum/PostCard.tsx
@@ -50,6 +50,18 @@ function PostCard({ post, onEdit, onDelete, onReact, onReport }: PostCardProps) 
   const [reportReason, setReportReason] = useState<string>(REPORT_REASONS[0].value);
   const [hasReported, setHasReported] = useState(false);
   const [isSubmittingReport, setIsSubmittingReport] = useState(false);
+  const [copiedLink, setCopiedLink] = useState(false);
+
+  const handleCopyLink = async () => {
+    const url = `${window.location.origin}${window.location.pathname}#post-${post.id}`;
+    try {
+      await navigator.clipboard.writeText(url);
+      setCopiedLink(true);
+      setTimeout(() => setCopiedLink(false), 2000);
+    } catch {
+      window.prompt('Copy link:', url); // clipboard API unavailable (http, old browser)
+    }
+  };
 
   // Only confirm "Reported" once the request actually succeeds — a network
   // failure must leave the picker open (with the real error surfaced by the
@@ -131,32 +143,39 @@ function PostCard({ post, onEdit, onDelete, onReact, onReport }: PostCardProps) 
           </div>
         </div>
 
-        {/* Actions (edit/delete) — gated on the backend capability flags AND the
-            presence of a handler. Always visible on mobile; on desktop they fade
-            in on hover AND on keyboard focus — opacity-0 keeps them tab-reachable,
-            so a focus reveal is required for WCAG 2.4.7 (audit 2026-07-11 H20). */}
-        {(showEdit || showDelete) && (
-          <div className="flex gap-2 md:opacity-0 md:group-hover:opacity-100 md:group-focus-within:opacity-100 transition-opacity">
-            {showEdit && (
-              <button
-                onClick={() => onEdit!(post)}
-                className="min-h-11 px-3 py-1 text-sm text-sky hover:bg-sky/10 rounded inline-flex items-center"
-                title="Edit post"
-              >
-                ✏️ Edit
-              </button>
-            )}
-            {showDelete && (
-              <button
-                onClick={() => onDelete!(post)}
-                className="min-h-11 px-3 py-1 text-sm text-error hover:bg-error/10 rounded inline-flex items-center"
-                title="Delete post"
-              >
-                🗑️ Delete
-              </button>
-            )}
-          </div>
-        )}
+        {/* Actions — copy-link is available to every post; edit/delete are gated
+            on the backend capability flags AND the presence of a handler. Always
+            visible on mobile; on desktop they fade in on hover AND on keyboard
+            focus — opacity-0 keeps them tab-reachable, so a focus reveal is
+            required for WCAG 2.4.7 (audit 2026-07-11 H20). */}
+        <div className="flex gap-2 md:opacity-0 md:group-hover:opacity-100 md:group-focus-within:opacity-100 transition-opacity">
+          <button
+            onClick={handleCopyLink}
+            className="min-h-11 px-3 py-1 text-sm text-ink-3 hover:bg-surface-3 rounded inline-flex items-center"
+            title="Copy link to this post"
+            aria-label="Copy link to this post"
+          >
+            {copiedLink ? 'Copied ✓' : '🔗 Copy link'}
+          </button>
+          {showEdit && (
+            <button
+              onClick={() => onEdit!(post)}
+              className="min-h-11 px-3 py-1 text-sm text-sky hover:bg-sky/10 rounded inline-flex items-center"
+              title="Edit post"
+            >
+              ✏️ Edit
+            </button>
+          )}
+          {showDelete && (
+            <button
+              onClick={() => onDelete!(post)}
+              className="min-h-11 px-3 py-1 text-sm text-error hover:bg-error/10 rounded inline-flex items-center"
+              title="Delete post"
+            >
+              🗑️ Delete
+            </button>
+          )}
+        </div>
       </div>
 
       {/* Post Content */}

--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { Link, NavLink } from 'react-router-dom';
-import { Menu, X, User, Settings as SettingsIcon, Sun, Moon, Leaf } from 'lucide-react';
+import { Menu, X, User, Settings as SettingsIcon, Sun, Moon, Leaf, Search } from 'lucide-react';
 import { useAuth } from '../../contexts/AuthContext';
 import { useTheme } from '../../contexts/ThemeContext';
 import NotificationBell from './NotificationBell';
@@ -95,6 +95,14 @@ export default function Header() {
               alongside the mobile drawer's own copy) + Desktop Auth Actions +
               Mobile menu button, grouped so they sit together at the row's end. */}
           <div className="flex items-center gap-2 md:gap-4">
+            <Link
+              to="/forum/search"
+              aria-label="Search the forum"
+              title="Search the forum"
+              className="p-2 rounded-lg text-ink-2 hover:text-primary hover:bg-surface transition-colors"
+            >
+              <Search className="w-5 h-5" />
+            </Link>
             {isAuthenticated && <NotificationBell />}
 
             <div className="hidden md:flex items-center gap-4">
@@ -188,6 +196,17 @@ export default function Header() {
               }
             >
               Community
+            </NavLink>
+            <NavLink
+              to="/forum/search"
+              onClick={closeMenu}
+              className={({ isActive }) =>
+                `block px-3 py-2 rounded-lg font-medium transition-colors ${
+                  isActive ? 'bg-primary/10 text-primary' : 'text-ink-2 hover:bg-surface'
+                }`
+              }
+            >
+              Search Forum
             </NavLink>
 
             {/* Theme toggle */}

--- a/web/src/components/layout/NotificationBell.test.tsx
+++ b/web/src/components/layout/NotificationBell.test.tsx
@@ -34,6 +34,7 @@ function makeNotification(overrides: Partial<ForumNotification> = {}): ForumNoti
       board_id: 3,
       board_slug: 'plant-care',
     },
+    post_id: null,
     created_at: '2026-07-14T00:00:00Z',
     read_at: null,
     ...overrides,
@@ -175,6 +176,21 @@ describe('NotificationBell', () => {
     await waitFor(() => {
       expect(screen.queryByTestId('notification-badge')).not.toBeInTheDocument();
     });
+  });
+
+  it('navigates to the specific post anchor when the notification has a post_id', async () => {
+    vi.mocked(notificationService.fetchUnreadCount).mockResolvedValue(1);
+    vi.mocked(notificationService.fetchNotifications).mockResolvedValue({
+      results: [makeNotification({ post_id: 77 })],
+      next: null,
+      previous: null,
+    });
+    renderBell();
+
+    await userEvent.click(await screen.findByLabelText(/notifications/i));
+    await userEvent.click(await screen.findByText('Ada replied to "Watering Tips"'));
+
+    expect(mockNavigate).toHaveBeenCalledWith('/forum/3-plant-care/10-watering-tips#post-77');
   });
 
   it('does not mark an already-read notification read again on click', async () => {

--- a/web/src/components/layout/NotificationBell.tsx
+++ b/web/src/components/layout/NotificationBell.tsx
@@ -7,7 +7,7 @@ import {
   fetchUnreadCount,
   markNotificationsRead,
 } from '../../services/notificationService';
-import { threadPath } from '../../utils/forumUrls';
+import { threadPath, postAnchor } from '../../utils/forumUrls';
 import type { ForumNotification } from '../../types/notifications';
 
 // Generous relative to the backend's 120/m rate limit on this endpoint — this
@@ -132,7 +132,7 @@ export default function NotificationBell() {
         threadPath(
           { id: String(topic.board_id), slug: topic.board_slug, name: topic.board_slug },
           { id: String(topic.id), slug: topic.slug, title: topic.title }
-        )
+        ) + (notification.post_id != null ? postAnchor(notification.post_id) : '')
       );
     }
   };

--- a/web/src/pages/forum/NewThreadPage.test.tsx
+++ b/web/src/pages/forum/NewThreadPage.test.tsx
@@ -33,6 +33,7 @@ function renderPage() {
 describe('NewThreadPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    sessionStorage.clear();
     mockNavigate = vi.fn();
     vi.mocked(ReactRouter.useNavigate).mockReturnValue(
       mockNavigate as unknown as ReturnType<typeof ReactRouter.useNavigate>

--- a/web/src/pages/forum/NewThreadPage.tsx
+++ b/web/src/pages/forum/NewThreadPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, FormEvent } from 'react';
+import { useState, useEffect, useCallback, useMemo, FormEvent } from 'react';
 import { useNavigate, useSearchParams, Link } from 'react-router-dom';
 import { createThread, fetchCategory } from '../../services/forumService';
 import { parseLeadingId, threadPath, categoryPath } from '../../utils/forumUrls';
@@ -29,20 +29,16 @@ export default function NewThreadPage() {
 
   const [category, setCategory] = useState<Category | null>(null);
   const newThreadDraftKey = draftKey('new-thread', categoryParam ?? 'unknown');
-  const [title, setTitle] = useState(() => {
+  // Parse the saved draft once (per key), not once per field.
+  const initialDraft = useMemo<{ title?: string; body?: string }>(() => {
     try {
-      return JSON.parse(loadDraft(newThreadDraftKey) || '{}').title || '';
+      return JSON.parse(loadDraft(newThreadDraftKey) || '{}');
     } catch {
-      return '';
+      return {};
     }
-  });
-  const [body, setBody] = useState(() => {
-    try {
-      return JSON.parse(loadDraft(newThreadDraftKey) || '{}').body || '';
-    } catch {
-      return '';
-    }
-  });
+  }, [newThreadDraftKey]);
+  const [title, setTitle] = useState<string>(() => initialDraft.title || '');
+  const [body, setBody] = useState<string>(() => initialDraft.body || '');
   const [loading, setLoading] = useState<boolean>(true);
   const [submitting, setSubmitting] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);

--- a/web/src/pages/forum/NewThreadPage.tsx
+++ b/web/src/pages/forum/NewThreadPage.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback, FormEvent } from 'react';
 import { useNavigate, useSearchParams, Link } from 'react-router-dom';
 import { createThread, fetchCategory } from '../../services/forumService';
 import { parseLeadingId, threadPath, categoryPath } from '../../utils/forumUrls';
+import { draftKey, loadDraft, saveDraft, clearDraft } from '../../utils/forumDrafts';
 import TipTapEditor from '../../components/forum/TipTapEditor';
 import LoadingSpinner from '../../components/ui/LoadingSpinner';
 import Button from '../../components/ui/Button';
@@ -27,8 +28,21 @@ export default function NewThreadPage() {
   const categoryParam = searchParams.get('category');
 
   const [category, setCategory] = useState<Category | null>(null);
-  const [title, setTitle] = useState('');
-  const [body, setBody] = useState('');
+  const newThreadDraftKey = draftKey('new-thread', categoryParam ?? 'unknown');
+  const [title, setTitle] = useState(() => {
+    try {
+      return JSON.parse(loadDraft(newThreadDraftKey) || '{}').title || '';
+    } catch {
+      return '';
+    }
+  });
+  const [body, setBody] = useState(() => {
+    try {
+      return JSON.parse(loadDraft(newThreadDraftKey) || '{}').body || '';
+    } catch {
+      return '';
+    }
+  });
   const [loading, setLoading] = useState<boolean>(true);
   const [submitting, setSubmitting] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
@@ -59,6 +73,12 @@ export default function NewThreadPage() {
     load();
   }, [categoryParam]);
 
+  // Persist the draft on every change; an all-empty draft is removed.
+  useEffect(() => {
+    const isEmpty = title.trim() === '' && isBlankHtml(body);
+    saveDraft(newThreadDraftKey, isEmpty ? '' : JSON.stringify({ title, body }));
+  }, [title, body, newThreadDraftKey]);
+
   const canSubmit = !!category && title.trim() !== '' && !isBlankHtml(body);
 
   const handleSubmit = useCallback(
@@ -73,6 +93,7 @@ export default function NewThreadPage() {
           title: title.trim(),
           content: body,
         });
+        clearDraft(newThreadDraftKey);
         if (res.status === 'published') {
           navigate(threadPath(category, { id: res.id, slug: res.slug, title: title.trim() }));
         } else {
@@ -91,7 +112,7 @@ export default function NewThreadPage() {
         setSubmitting(false);
       }
     },
-    [category, title, body, navigate]
+    [category, title, body, navigate, newThreadDraftKey]
   );
 
   if (loading) {

--- a/web/src/pages/forum/SearchPage.test.tsx
+++ b/web/src/pages/forum/SearchPage.test.tsx
@@ -36,16 +36,6 @@ function createMockSearchResults(overrides = {}) {
     posts: [],
     total_threads: 0,
     total_posts: 0,
-    page: 1,
-    page_size: 20,
-    has_next_threads: false,
-    has_next_posts: false,
-    filters: {
-      category: null,
-      author: null,
-      date_from: null,
-      date_to: null,
-    },
     ...overrides,
   };
 }
@@ -213,12 +203,18 @@ describe('SearchPage', () => {
         id: 1,
         topic_id: 42,
         topic_title: 'Watering Guide',
+        topic_slug: 'watering-guide',
+        board_id: 1,
+        board_slug: 'plant-care',
         excerpt: 'Water your plants regularly',
       });
       const post2 = mapSearchPostToPost({
         id: 2,
         topic_id: 43,
         topic_title: 'Beginner Tips',
+        topic_slug: 'beginner-tips',
+        board_id: 1,
+        board_slug: 'plant-care',
         excerpt: 'Watering tips for beginners',
       });
       const mockResults = createMockSearchResults({
@@ -242,6 +238,35 @@ describe('SearchPage', () => {
       expect(screen.queryByText('[deleted]')).not.toBeInTheDocument();
       // No empty PostCard author block (PostCard renders author.display_name in a specific element)
       expect(screen.queryByText('Test User')).not.toBeInTheDocument();
+    });
+
+    it('renders real counts and no decorative filters', async () => {
+      const mockResults = createMockSearchResults({
+        query: 'tomato',
+        threads: [
+          createMockThread({
+            id: '31',
+            title: 'Blight-resistant tomatoes',
+            slug: 'tomato-blight',
+            category: { id: '54', name: '', slug: 'general-discussion', created_at: '' },
+            post_count: 3,
+            view_count: 12,
+          }),
+        ],
+        total_threads: 1,
+      });
+
+      vi.spyOn(forumService, 'searchForum').mockResolvedValue(mockResults);
+
+      renderSearchPage('/forum/search?q=tomato');
+
+      await waitFor(() =>
+        expect(screen.getByText(/Blight-resistant tomatoes/)).toBeInTheDocument()
+      );
+      expect(screen.getByTitle('3 replies')).toBeInTheDocument();
+      expect(screen.getByTitle('12 views')).toBeInTheDocument();
+      expect(screen.queryByLabelText('Author')).not.toBeInTheDocument();
+      expect(screen.queryByLabelText('From')).not.toBeInTheDocument();
     });
 
     it('displays no results message when no matches found', async () => {
@@ -283,13 +308,6 @@ describe('SearchPage', () => {
       expect(within(categorySelect).getByText('Plant Care')).toBeInTheDocument();
     });
 
-    it('displays author filter input', () => {
-      renderSearchPage();
-
-      expect(screen.getByLabelText('Author')).toBeInTheDocument();
-      expect(screen.getByPlaceholderText('Username')).toBeInTheDocument();
-    });
-
     it('applies category filter when selected', async () => {
       const mockCategories = [
         createMockCategory({ id: '1', name: 'Plant Care', slug: 'plant-care' }),
@@ -325,7 +343,7 @@ describe('SearchPage', () => {
     });
 
     it('clears all filters when clear button clicked', async () => {
-      renderSearchPage('/forum/search?q=watering&category=plant-care&author=john');
+      renderSearchPage('/forum/search?q=watering&category=plant-care');
 
       await waitFor(() => {
         expect(screen.getByText('Clear filters')).toBeInTheDocument();
@@ -339,7 +357,6 @@ describe('SearchPage', () => {
           expect.objectContaining({
             q: 'watering',
             category: '',
-            author: '',
           })
         );
       });
@@ -349,121 +366,6 @@ describe('SearchPage', () => {
       renderSearchPage('/forum/search?q=watering');
 
       expect(screen.queryByText('Clear filters')).not.toBeInTheDocument();
-    });
-  });
-
-  describe('Pagination', () => {
-    it('displays pagination controls when there are more results', async () => {
-      const mockResults = createMockSearchResults({
-        query: 'watering',
-        threads: [createMockThread()],
-        has_next_threads: true,
-        page: 1,
-      });
-
-      vi.spyOn(forumService, 'searchForum').mockResolvedValue(mockResults);
-
-      renderSearchPage('/forum/search?q=watering');
-
-      await waitFor(() => {
-        expect(screen.getByText('Previous')).toBeInTheDocument();
-        expect(screen.getByText('Next')).toBeInTheDocument();
-        expect(screen.getByText('Page 1')).toBeInTheDocument();
-      });
-    });
-
-    it('disables previous button on first page', async () => {
-      const mockResults = createMockSearchResults({
-        query: 'watering',
-        threads: [createMockThread()],
-        page: 1,
-        has_next_threads: true, // Need this to show pagination controls
-      });
-
-      vi.mocked(forumService.searchForum).mockImplementation(() => Promise.resolve(mockResults));
-
-      renderSearchPage('/forum/search?q=watering');
-
-      await waitFor(() => {
-        const prevButton = screen.getByText('Previous');
-        expect(prevButton).toBeDisabled();
-      });
-    });
-
-    it('disables next button when no more results', async () => {
-      const mockResults = createMockSearchResults({
-        query: 'watering',
-        threads: [createMockThread()],
-        has_next_threads: false,
-        has_next_posts: false,
-        page: 2, // Set page > 1 to ensure pagination controls render
-      });
-
-      vi.mocked(forumService.searchForum).mockImplementation(() => Promise.resolve(mockResults));
-
-      renderSearchPage('/forum/search?q=watering&page=2');
-
-      await waitFor(() => {
-        const nextButton = screen.getByText('Next');
-        expect(nextButton).toBeDisabled();
-      });
-    });
-
-    it('navigates to next page when next button clicked', async () => {
-      const mockResults = createMockSearchResults({
-        query: 'watering',
-        threads: [createMockThread()],
-        has_next_threads: true,
-        page: 1,
-      });
-
-      vi.spyOn(forumService, 'searchForum').mockResolvedValue(mockResults);
-
-      renderSearchPage('/forum/search?q=watering');
-
-      await waitFor(() => {
-        expect(screen.getByText('Next')).toBeInTheDocument();
-      });
-
-      const nextButton = screen.getByText('Next');
-      await userEvent.click(nextButton);
-
-      await waitFor(() => {
-        expect(forumService.searchForum).toHaveBeenCalledWith(
-          expect.objectContaining({
-            q: 'watering',
-            page: 2,
-          })
-        );
-      });
-    });
-
-    it('navigates to previous page when previous button clicked', async () => {
-      const mockResults = createMockSearchResults({
-        query: 'watering',
-        threads: [createMockThread()],
-        page: 2,
-      });
-
-      vi.spyOn(forumService, 'searchForum').mockResolvedValue(mockResults);
-
-      renderSearchPage('/forum/search?q=watering&page=2');
-
-      await waitFor(() => {
-        expect(screen.getByText('Previous')).toBeInTheDocument();
-      });
-
-      const prevButton = screen.getByText('Previous');
-      await userEvent.click(prevButton);
-
-      await waitFor(() => {
-        expect(forumService.searchForum).toHaveBeenCalledWith(
-          expect.objectContaining({
-            q: 'watering',
-            page: 1,
-          })
-        );
-      });
     });
   });
 
@@ -488,11 +390,6 @@ describe('SearchPage', () => {
       const categorySelect = screen.getByLabelText('Category');
       expect(categoryLabel).toBeInTheDocument();
       expect(categorySelect).toHaveAttribute('id', 'category-filter');
-
-      const authorLabel = screen.getByText('Author');
-      const authorInput = screen.getByLabelText('Author');
-      expect(authorLabel).toBeInTheDocument();
-      expect(authorInput).toHaveAttribute('id', 'author-filter');
     });
   });
 });

--- a/web/src/pages/forum/SearchPage.tsx
+++ b/web/src/pages/forum/SearchPage.tsx
@@ -163,7 +163,6 @@ export default function SearchPage() {
           setSearchParams((prev) => {
             const newParams = new URLSearchParams(prev);
             newParams.set('q', value.trim());
-            newParams.set('page', '1'); // Reset to page 1
             return newParams;
           });
         } else {
@@ -189,7 +188,6 @@ export default function SearchPage() {
         } else {
           newParams.delete('category');
         }
-        newParams.set('page', '1');
         return newParams;
       });
     },

--- a/web/src/pages/forum/SearchPage.tsx
+++ b/web/src/pages/forum/SearchPage.tsx
@@ -3,10 +3,9 @@ import { useSearchParams, Link } from 'react-router-dom';
 import { searchForum, fetchCategories } from '../../services/forumService';
 import ThreadCard from '../../components/forum/ThreadCard';
 import LoadingSpinner from '../../components/ui/LoadingSpinner';
-import { Pagination } from '../../components/ui/Pagination';
-import { useHandlePageChange } from '../../hooks/useHandlePageChange';
 import { logger } from '../../utils/logger';
 import { sanitizeSearchQuery } from '../../utils/validation';
+import { threadPath } from '../../utils/forumUrls';
 import type { Category, SearchForumResponse } from '@/types';
 
 /** Strip HTML tags from a string, returning plain text. */
@@ -54,9 +53,8 @@ function hasSearchMatch(text: string | undefined, query: string): boolean {
  *
  * Features:
  * - Debounced search input (300ms)
- * - Category, author, date range filters
+ * - Category filter (board slug)
  * - Separate results for threads and posts
- * - Pagination
  * - Search term highlighting in results
  */
 export default function SearchPage() {
@@ -76,11 +74,6 @@ export default function SearchPage() {
   // ?q=... URL before it reaches state, the API, or the rendered "results for".
   const query = sanitizeSearchQuery(searchParams.get('q') || '');
   const category = searchParams.get('category') || '';
-  const author = searchParams.get('author') || '';
-  const dateFrom = searchParams.get('date_from') || '';
-  const dateTo = searchParams.get('date_to') || '';
-  const page = parseInt(searchParams.get('page') || '1', 10);
-  const pageSize = parseInt(searchParams.get('page_size') || '20', 10);
 
   // Initialize search input from URL
   useEffect(() => {
@@ -121,15 +114,7 @@ export default function SearchPage() {
         setLoading(true);
         setError(null);
 
-        const results = await searchForum({
-          q: query,
-          category,
-          author,
-          date_from: dateFrom,
-          date_to: dateTo,
-          page,
-          page_size: pageSize,
-        });
+        const results = await searchForum({ q: query, category });
 
         setSearchResults(results);
         logger.info('[SEARCH] Results loaded', {
@@ -141,7 +126,7 @@ export default function SearchPage() {
         logger.error('Error performing search', {
           component: 'SearchPage',
           error: err,
-          context: { query, category, author },
+          context: { query, category },
         });
         setError(err instanceof Error ? err.message : 'Search failed');
       } finally {
@@ -150,7 +135,7 @@ export default function SearchPage() {
     };
 
     performSearch();
-  }, [query, category, author, dateFrom, dateTo, page, pageSize]);
+  }, [query, category]);
 
   // Cleanup debounce timer on unmount
   useEffect(() => {
@@ -211,51 +196,13 @@ export default function SearchPage() {
     [setSearchParams]
   );
 
-  const handleAuthorFilter = useCallback(
-    (e: ChangeEvent<HTMLInputElement>) => {
-      const value = e.target.value;
-      setSearchParams((prev) => {
-        const newParams = new URLSearchParams(prev);
-        if (value) {
-          newParams.set('author', value);
-        } else {
-          newParams.delete('author');
-        }
-        newParams.set('page', '1');
-        return newParams;
-      });
-    },
-    [setSearchParams]
-  );
-
-  const handleDateFilter = useCallback(
-    (key: 'date_from' | 'date_to', value: string) => {
-      setSearchParams((prev) => {
-        const newParams = new URLSearchParams(prev);
-        if (value) {
-          newParams.set(key, value);
-        } else {
-          newParams.delete(key);
-        }
-        newParams.set('page', '1');
-        return newParams;
-      });
-    },
-    [setSearchParams]
-  );
-
-  // Handle pagination (shared hook — todo 222 / M14)
-  const handlePageChange = useHandlePageChange(setSearchParams);
-
   // Clear all filters
   const handleClearFilters = useCallback(() => {
     setSearchParams({ q: query });
   }, [query, setSearchParams]);
 
   // Check if any filters are active
-  const hasActiveFilters = useMemo(() => {
-    return !!(category || author || dateFrom || dateTo);
-  }, [category, author, dateFrom, dateTo]);
+  const hasActiveFilters = useMemo(() => !!category, [category]);
 
   return (
     <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
@@ -308,7 +255,7 @@ export default function SearchPage() {
           )}
         </div>
 
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           {/* Category Filter */}
           <div>
             <label htmlFor="category-filter" className="block text-sm font-medium text-ink-2 mb-2">
@@ -327,49 +274,6 @@ export default function SearchPage() {
                 </option>
               ))}
             </select>
-          </div>
-
-          {/* Author Filter */}
-          <div>
-            <label htmlFor="author-filter" className="block text-sm font-medium text-ink-2 mb-2">
-              Author
-            </label>
-            <input
-              id="author-filter"
-              type="text"
-              value={author}
-              onChange={handleAuthorFilter}
-              placeholder="Username"
-              className="w-full px-3 py-2 border border-line-2 rounded-lg focus:ring-2 focus:ring-primary focus:border-transparent bg-surface-2 text-ink"
-            />
-          </div>
-
-          {/* Date From Filter */}
-          <div>
-            <label htmlFor="date-from-filter" className="block text-sm font-medium text-ink-2 mb-2">
-              From
-            </label>
-            <input
-              id="date-from-filter"
-              type="date"
-              value={dateFrom}
-              onChange={(e) => handleDateFilter('date_from', e.target.value)}
-              className="w-full px-3 py-2 border border-line-2 rounded-lg focus:ring-2 focus:ring-primary focus:border-transparent bg-surface-2 text-ink"
-            />
-          </div>
-
-          {/* Date To Filter */}
-          <div>
-            <label htmlFor="date-to-filter" className="block text-sm font-medium text-ink-2 mb-2">
-              To
-            </label>
-            <input
-              id="date-to-filter"
-              type="date"
-              value={dateTo}
-              onChange={(e) => handleDateFilter('date_to', e.target.value)}
-              className="w-full px-3 py-2 border border-line-2 rounded-lg focus:ring-2 focus:ring-primary focus:border-transparent bg-surface-2 text-ink"
-            />
           </div>
         </div>
       </div>
@@ -455,9 +359,19 @@ export default function SearchPage() {
                   // content_raw holds the backend excerpt (may contain truncated HTML tags).
                   // Strip tags so we render plain text only — never dangerouslySetInnerHTML.
                   const plainExcerpt = stripTags(post.content_raw);
-                  // Build a link to the topic by id (topic_title is carried by mapSearchPostToPost).
-                  // topic_id is stored in post.thread; topic_title is carried through.
-                  const topicLink = `/forum/-topic/${post.thread}`;
+                  // Build a real thread link from the board/topic identity carried by
+                  // mapSearchPostToPost, deep-linked to the specific post.
+                  const topicLink =
+                    post.board_id != null && post.board_slug && post.topic_slug
+                      ? `${threadPath(
+                          {
+                            id: String(post.board_id),
+                            slug: post.board_slug,
+                            name: post.board_slug,
+                          },
+                          { id: post.thread, slug: post.topic_slug, title: post.topic_title || '' }
+                        )}#post-${post.id}`
+                      : `/forum`;
                   return (
                     <div key={post.id} className="bg-surface-2 rounded-lg border border-line-2 p-4">
                       <Link
@@ -499,17 +413,6 @@ export default function SearchPage() {
               <p className="text-ink-2 mb-2">No results found for "{query}"</p>
               <p className="text-ink-3 text-sm">Try different keywords or remove some filters</p>
             </div>
-          )}
-
-          {/* Pagination */}
-          {(searchResults.has_next_threads || searchResults.has_next_posts || page > 1) && (
-            <Pagination
-              page={page}
-              onPageChange={handlePageChange}
-              hasPrevious={page > 1}
-              hasNext={searchResults.has_next_threads || searchResults.has_next_posts}
-              variant="secondary"
-            />
           )}
         </div>
       )}

--- a/web/src/pages/forum/ThreadDetailPage.test.tsx
+++ b/web/src/pages/forum/ThreadDetailPage.test.tsx
@@ -721,6 +721,33 @@ describe('ThreadDetailPage', () => {
     });
   });
 
+  it('deep-link to a post on a later cursor page pulls pages until it renders', async () => {
+    // jsdom has no layout engine; the arrival effect calls scrollIntoView.
+    Element.prototype.scrollIntoView = vi.fn();
+    vi.spyOn(forumService, 'fetchThread').mockResolvedValue(createMockThread({ post_count: 21 }));
+    const fetchPostsSpy = vi
+      .spyOn(forumService, 'fetchPosts')
+      .mockResolvedValueOnce({
+        items: [createMockPost({ id: '1' })],
+        meta: { count: 0, next: 'cursor-page-2', previous: null },
+      })
+      .mockResolvedValueOnce({
+        items: [createMockPost({ id: '21' })],
+        meta: { count: 0, next: null, previous: null },
+      });
+
+    render(
+      <MemoryRouter initialEntries={['/forum/3-plant-care/12-watering-tips#post-21']}>
+        <ThreadDetailPage />
+      </MemoryRouter>
+    );
+
+    // post-21 lives on page 2, absent from the first load — the arrival effect
+    // must pull the next page for it to mount (it silently no-op'd before).
+    await waitFor(() => expect(document.getElementById('post-21')).toBeInTheDocument());
+    expect(fetchPostsSpy).toHaveBeenCalledWith({ thread: 12, cursor: 'cursor-page-2' });
+  });
+
   it('displays total post count in header from thread.post_count', async () => {
     const mockThread = createMockThread({ post_count: 150 });
     const mockPosts = {

--- a/web/src/pages/forum/ThreadDetailPage.test.tsx
+++ b/web/src/pages/forum/ThreadDetailPage.test.tsx
@@ -566,8 +566,9 @@ describe('ThreadDetailPage', () => {
 
     renderThreadDetailPage();
 
-    await screen.findByLabelText('React like');
-    expect(screen.getByLabelText('React like')).toHaveTextContent('0');
+    // Zero-count reactions are hidden at rest (de-cluttered row), so expand the
+    // picker before the 'like' control is available.
+    await userEvent.click(await screen.findByLabelText('Add reaction'));
     await userEvent.click(screen.getByLabelText('React like'));
 
     await waitFor(() => expect(screen.getByLabelText('React like')).toHaveTextContent('1'));

--- a/web/src/pages/forum/ThreadDetailPage.test.tsx
+++ b/web/src/pages/forum/ThreadDetailPage.test.tsx
@@ -56,6 +56,7 @@ const mockAuth = (isAuthenticated: boolean) =>
 describe('ThreadDetailPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    sessionStorage.clear();
 
     // Mock useParams to return hybrid id-slug params; lookups use the leading id.
     vi.mocked(ReactRouter.useParams).mockReturnValue({
@@ -773,6 +774,37 @@ describe('ThreadDetailPage', () => {
       (c) => (c[0] as { cursor?: string })?.cursor === 'cursor-page-2'
     );
     expect(page2Calls).toHaveLength(1);
+  });
+
+  it('scrolls to the anchored post once, not again when the post list changes', async () => {
+    // jsdom defines scrollIntoView on HTMLElement.prototype; spy there so the
+    // real call is captured (an Element.prototype assignment gets shadowed).
+    const scrollSpy = vi.fn();
+    HTMLElement.prototype.scrollIntoView = scrollSpy;
+    vi.spyOn(forumService, 'fetchThread').mockResolvedValue(createMockThread({ post_count: 25 }));
+    vi.spyOn(forumService, 'fetchPosts')
+      .mockResolvedValueOnce({
+        items: [createMockPost({ id: '5' })],
+        meta: { count: 0, next: 'cursor-page-2', previous: null },
+      })
+      .mockResolvedValueOnce({
+        items: [createMockPost({ id: '6' })],
+        meta: { count: 0, next: null, previous: null },
+      });
+
+    render(
+      <MemoryRouter initialEntries={['/forum/3-plant-care/12-watering-tips#post-5']}>
+        <ThreadDetailPage />
+      </MemoryRouter>
+    );
+
+    // post-5 is on page 1 → found and scrolled once on arrival.
+    await waitFor(() => expect(scrollSpy).toHaveBeenCalledTimes(1));
+
+    // Loading more changes `posts`; the anchor must NOT be re-scrolled.
+    await userEvent.click(screen.getByText(/Load More Posts/i));
+    await waitFor(() => expect(document.getElementById('post-6')).toBeInTheDocument());
+    expect(scrollSpy).toHaveBeenCalledTimes(1);
   });
 
   it('displays total post count in header from thread.post_count', async () => {

--- a/web/src/pages/forum/ThreadDetailPage.test.tsx
+++ b/web/src/pages/forum/ThreadDetailPage.test.tsx
@@ -748,6 +748,33 @@ describe('ThreadDetailPage', () => {
     expect(fetchPostsSpy).toHaveBeenCalledWith({ thread: 12, cursor: 'cursor-page-2' });
   });
 
+  it('deep-link chase does not retry forever when a later page keeps failing', async () => {
+    Element.prototype.scrollIntoView = vi.fn();
+    vi.spyOn(logger, 'error').mockImplementation(() => {});
+    vi.spyOn(forumService, 'fetchThread').mockResolvedValue(createMockThread({ post_count: 21 }));
+    const fetchPostsSpy = vi
+      .spyOn(forumService, 'fetchPosts')
+      .mockResolvedValueOnce({
+        items: [createMockPost({ id: '1' })],
+        meta: { count: 0, next: 'cursor-page-2', previous: null },
+      })
+      .mockRejectedValue(new Error('page 2 keeps failing'));
+
+    render(
+      <MemoryRouter initialEntries={['/forum/3-plant-care/12-watering-tips#post-21']}>
+        <ThreadDetailPage />
+      </MemoryRouter>
+    );
+
+    // The failing page-2 fetch surfaces the error notice...
+    await screen.findByText(/Failed to load more posts/i);
+    // ...and is NOT retried in a loop: exactly one request for that cursor.
+    const page2Calls = fetchPostsSpy.mock.calls.filter(
+      (c) => (c[0] as { cursor?: string })?.cursor === 'cursor-page-2'
+    );
+    expect(page2Calls).toHaveLength(1);
+  });
+
   it('displays total post count in header from thread.post_count', async () => {
     const mockThread = createMockThread({ post_count: 150 });
     const mockPosts = {

--- a/web/src/pages/forum/ThreadDetailPage.tsx
+++ b/web/src/pages/forum/ThreadDetailPage.tsx
@@ -112,6 +112,9 @@ export default function ThreadDetailPage() {
     // reset unconditionally on every navigation (handleToggleSubscription's
     // own finally guards against that stale request re-enabling it late).
     setSubscribing(false);
+    // Same for an in-flight load-more (the deep-link chase can start one) —
+    // its finally is thread-guarded, so clear the flag here for the new thread.
+    setLoadingMore(false);
 
     const loadData = async () => {
       if (topicId == null) {
@@ -152,14 +155,20 @@ export default function ThreadDetailPage() {
   // Load more posts (cursor pagination)
   const handleLoadMore = useCallback(async () => {
     if (topicId == null || !nextCursor) return;
+    // The deep-link chase fires this automatically, so a response can arrive
+    // after the user has navigated to another thread. Guard state writes on the
+    // thread this request was for, or a late page for thread A would append to
+    // thread B's list (mirrors handleToggleSubscription).
+    const requestTopicId = topicId;
 
     try {
       setLoadingMore(true);
       const postsData = (await fetchPosts({
-        thread: topicId,
+        thread: requestTopicId,
         cursor: nextCursor,
       })) as PaginatedResponse<Post>;
 
+      if (currentTopicIdRef.current !== requestTopicId) return;
       setPosts((prev) => [...prev, ...postsData.items]);
       setNextCursor(postsData.meta.next ?? null);
     } catch (err) {
@@ -168,11 +177,15 @@ export default function ThreadDetailPage() {
         error: err,
         context: { threadId: thread?.id },
       });
-      setNotice(
-        `Failed to load more posts: ${err instanceof Error ? err.message : 'Unknown error'}`
-      );
+      if (currentTopicIdRef.current === requestTopicId) {
+        setNotice(
+          `Failed to load more posts: ${err instanceof Error ? err.message : 'Unknown error'}`
+        );
+      }
     } finally {
-      setLoadingMore(false);
+      if (currentTopicIdRef.current === requestTopicId) {
+        setLoadingMore(false);
+      }
     }
   }, [nextCursor, topicId, thread?.id]);
 

--- a/web/src/pages/forum/ThreadDetailPage.tsx
+++ b/web/src/pages/forum/ThreadDetailPage.tsx
@@ -89,6 +89,11 @@ export default function ThreadDetailPage() {
   // while its request was in flight, so a late success/failure for thread A
   // can't clobber thread B's displayed state.
   const currentTopicIdRef = useRef<number | null>(null);
+  // Remembers the cursor the deep-link auto-chase last requested. A failed
+  // load-more leaves nextCursor unchanged, so gating on "cursor actually
+  // changed" stops the chase after one attempt instead of retrying the same
+  // failing request forever; the manual "Load More" button remains the retry.
+  const chaseCursorRef = useRef<string | null>(null);
 
   // Load thread and initial posts
   useEffect(() => {
@@ -96,6 +101,8 @@ export default function ThreadDetailPage() {
     // effect already re-runs on every topicId change, so it doubles as the
     // sync point.
     currentTopicIdRef.current = topicId;
+    // A new thread starts a fresh deep-link chase.
+    chaseCursorRef.current = null;
     // Restore this topic's reply draft (per-topic key); remount the composer
     // so TipTap's init-only content picks it up.
     setReplyBody(topicId != null ? (loadDraft(draftKey('reply', String(topicId))) ?? '') : '');
@@ -178,7 +185,12 @@ export default function ThreadDetailPage() {
     if (!match) return;
     const el = document.getElementById(`post-${match[1]}`);
     if (!el) {
-      if (nextCursor && !loadingMore) handleLoadMore();
+      // Advance at most once per cursor: a failed load-more leaves nextCursor
+      // unchanged, so this stops the chase instead of retrying it forever.
+      if (nextCursor && !loadingMore && chaseCursorRef.current !== nextCursor) {
+        chaseCursorRef.current = nextCursor;
+        handleLoadMore();
+      }
       return;
     }
     el.scrollIntoView({ behavior: 'smooth', block: 'start' });

--- a/web/src/pages/forum/ThreadDetailPage.tsx
+++ b/web/src/pages/forum/ThreadDetailPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useRef, FormEvent } from 'react';
-import { useParams, Link } from 'react-router-dom';
+import { useParams, Link, useLocation } from 'react-router-dom';
 import {
   fetchThread,
   fetchPosts,
@@ -54,6 +54,7 @@ async function collectAllPosts(threadId: number): Promise<{ items: Post[]; next:
 export default function ThreadDetailPage() {
   const { categorySlug, threadSlug } = useParams<{ categorySlug: string; threadSlug: string }>();
   const { isAuthenticated } = useAuth();
+  const location = useLocation();
 
   // The route param is a hybrid "id-slug"; lookups use the leading topic id.
   const topicId = parseLeadingId(threadSlug);
@@ -135,6 +136,23 @@ export default function ThreadDetailPage() {
 
     loadData();
   }, [topicId, threadSlug, categorySlug]);
+
+  // Deep-link arrival: scroll to and briefly highlight #post-N once posts render.
+  // If the target is on a later cursor page it simply isn't found — no error.
+  useEffect(() => {
+    if (loading) return;
+    const match = /^#post-(\d+)$/.exec(location.hash);
+    if (!match) return;
+    const el = document.getElementById(`post-${match[1]}`);
+    if (!el) return;
+    el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    el.classList.add('ring-2', 'ring-primary', 'rounded-lg');
+    const timer = setTimeout(
+      () => el.classList.remove('ring-2', 'ring-primary', 'rounded-lg'),
+      2500
+    );
+    return () => clearTimeout(timer);
+  }, [loading, posts, location.hash]);
 
   // Load more posts (cursor pagination)
   const handleLoadMore = useCallback(async () => {

--- a/web/src/pages/forum/ThreadDetailPage.tsx
+++ b/web/src/pages/forum/ThreadDetailPage.tsx
@@ -142,23 +142,6 @@ export default function ThreadDetailPage() {
     loadData();
   }, [topicId, threadSlug, categorySlug]);
 
-  // Deep-link arrival: scroll to and briefly highlight #post-N once posts render.
-  // If the target is on a later cursor page it simply isn't found — no error.
-  useEffect(() => {
-    if (loading) return;
-    const match = /^#post-(\d+)$/.exec(location.hash);
-    if (!match) return;
-    const el = document.getElementById(`post-${match[1]}`);
-    if (!el) return;
-    el.scrollIntoView({ behavior: 'smooth', block: 'start' });
-    el.classList.add('ring-2', 'ring-primary', 'rounded-lg');
-    const timer = setTimeout(
-      () => el.classList.remove('ring-2', 'ring-primary', 'rounded-lg'),
-      2500
-    );
-    return () => clearTimeout(timer);
-  }, [loading, posts, location.hash]);
-
   // Load more posts (cursor pagination)
   const handleLoadMore = useCallback(async () => {
     if (topicId == null || !nextCursor) return;
@@ -185,6 +168,27 @@ export default function ThreadDetailPage() {
       setLoadingMore(false);
     }
   }, [nextCursor, topicId, thread?.id]);
+
+  // Deep-link arrival: scroll to and briefly highlight #post-N once posts render.
+  // If the target sits on a later cursor page, pull pages until it appears (this
+  // effect re-runs as `posts` grows), then stop when there is nothing left to load.
+  useEffect(() => {
+    if (loading) return;
+    const match = /^#post-(\d+)$/.exec(location.hash);
+    if (!match) return;
+    const el = document.getElementById(`post-${match[1]}`);
+    if (!el) {
+      if (nextCursor && !loadingMore) handleLoadMore();
+      return;
+    }
+    el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    el.classList.add('ring-2', 'ring-primary', 'rounded-lg');
+    const timer = setTimeout(
+      () => el.classList.remove('ring-2', 'ring-primary', 'rounded-lg'),
+      2500
+    );
+    return () => clearTimeout(timer);
+  }, [loading, posts, location.hash, nextCursor, loadingMore, handleLoadMore]);
 
   // Submit a reply. A published reply is refetched into the list; a pending reply
   // (untrusted author) is unlisted, so we only confirm it was submitted.

--- a/web/src/pages/forum/ThreadDetailPage.tsx
+++ b/web/src/pages/forum/ThreadDetailPage.tsx
@@ -94,6 +94,10 @@ export default function ThreadDetailPage() {
   // changed" stops the chase after one attempt instead of retrying the same
   // failing request forever; the manual "Load More" button remains the retry.
   const chaseCursorRef = useRef<string | null>(null);
+  // The hash we've already scrolled to. The arrival effect re-runs on every
+  // `posts` change (the chase needs that), so without this it would re-scroll
+  // to the anchor on each reply/Load-More while the hash lingers in the URL.
+  const scrolledHashRef = useRef<string | null>(null);
 
   // Load thread and initial posts
   useEffect(() => {
@@ -101,8 +105,9 @@ export default function ThreadDetailPage() {
     // effect already re-runs on every topicId change, so it doubles as the
     // sync point.
     currentTopicIdRef.current = topicId;
-    // A new thread starts a fresh deep-link chase.
+    // A new thread starts a fresh deep-link chase and a fresh scroll target.
     chaseCursorRef.current = null;
+    scrolledHashRef.current = null;
     // Restore this topic's reply draft (per-topic key); remount the composer
     // so TipTap's init-only content picks it up.
     setReplyBody(topicId != null ? (loadDraft(draftKey('reply', String(topicId))) ?? '') : '');
@@ -206,6 +211,10 @@ export default function ThreadDetailPage() {
       }
       return;
     }
+    // Scroll to a given anchor only once — not again on later posts changes
+    // (a reply, a Load More) while the same hash sits in the URL.
+    if (scrolledHashRef.current === location.hash) return;
+    scrolledHashRef.current = location.hash;
     el.scrollIntoView({ behavior: 'smooth', block: 'start' });
     el.classList.add('ring-2', 'ring-primary', 'rounded-lg');
     const timer = setTimeout(

--- a/web/src/pages/forum/ThreadDetailPage.tsx
+++ b/web/src/pages/forum/ThreadDetailPage.tsx
@@ -13,6 +13,7 @@ import {
 } from '../../services/forumService';
 import { parseLeadingId } from '../../utils/forumUrls';
 import { bodyBlocksToHtml } from '../../utils/forumBody';
+import { draftKey, loadDraft, saveDraft, clearDraft } from '../../utils/forumDrafts';
 import PostCard from '../../components/forum/PostCard';
 import TipTapEditor from '../../components/forum/TipTapEditor';
 import LoadingSpinner from '../../components/ui/LoadingSpinner';
@@ -95,6 +96,10 @@ export default function ThreadDetailPage() {
     // effect already re-runs on every topicId change, so it doubles as the
     // sync point.
     currentTopicIdRef.current = topicId;
+    // Restore this topic's reply draft (per-topic key); remount the composer
+    // so TipTap's init-only content picks it up.
+    setReplyBody(topicId != null ? (loadDraft(draftKey('reply', String(topicId))) ?? '') : '');
+    setComposerKey((k) => k + 1);
     // A subscribe/unsubscribe request still in flight for the PREVIOUS
     // thread must not leave this thread's Follow button stuck loading —
     // reset unconditionally on every navigation (handleToggleSubscription's
@@ -191,6 +196,7 @@ export default function ThreadDetailPage() {
         setReplySubmitting(true);
         setNotice(null);
         const res = await createPost({ thread: topicId, content: replyBody });
+        if (topicId != null) clearDraft(draftKey('reply', String(topicId)));
         setReplyBody('');
         setComposerKey((k) => k + 1); // remount the editor so it visibly clears
         if (res.status === 'published') {
@@ -521,7 +527,12 @@ export default function ThreadDetailPage() {
           <TipTapEditor
             key={composerKey}
             content={replyBody}
-            onChange={setReplyBody}
+            onChange={(html) => {
+              setReplyBody(html);
+              if (topicId != null) {
+                saveDraft(draftKey('reply', String(topicId)), isBlankHtml(html) ? '' : html);
+              }
+            }}
             placeholder="Write a reply..."
           />
           <Button

--- a/web/src/services/forumMappers.test.ts
+++ b/web/src/services/forumMappers.test.ts
@@ -275,7 +275,16 @@ describe('forumMappers (wagtail_forum contract)', () => {
   // -------------------------------------------------------------------------
 
   it('mapSearchTopicToThread maps id, title, slug', () => {
-    const t = mapSearchTopicToThread({ id: 7, slug: 'my-topic', title: 'My Topic' });
+    const t = mapSearchTopicToThread({
+      id: 7,
+      slug: 'my-topic',
+      title: 'My Topic',
+      reply_count: 0,
+      view_count: 0,
+      last_post_at: null,
+      board_id: 1,
+      board_slug: 'general',
+    });
     expect(t).toMatchObject({ id: '7', title: 'My Topic', slug: 'my-topic' });
   });
 
@@ -284,8 +293,46 @@ describe('forumMappers (wagtail_forum contract)', () => {
       id: 99,
       topic_id: 7,
       topic_title: 'My Topic',
+      topic_slug: 'my-topic',
+      board_id: 1,
+      board_slug: 'general',
       excerpt: 'Some excerpt',
     });
     expect(p).toMatchObject({ id: '99', thread: '7', content_raw: 'Some excerpt' });
+  });
+
+  const backendSearchTopic = {
+    id: 31,
+    slug: 'tomato-blight',
+    title: 'Blight-resistant tomatoes',
+    reply_count: 3,
+    view_count: 12,
+    last_post_at: '2026-07-01T10:00:00Z',
+    board_id: 54,
+    board_slug: 'general-discussion',
+  };
+
+  it('mapSearchTopicToThread carries real metadata and board identity', () => {
+    const thread = mapSearchTopicToThread(backendSearchTopic);
+    expect(thread.post_count).toBe(3);
+    expect(thread.view_count).toBe(12);
+    expect(thread.last_activity_at).toBe('2026-07-01T10:00:00Z');
+    expect(thread.category.id).toBe('54');
+    expect(thread.category.slug).toBe('general-discussion');
+  });
+
+  it('mapSearchPostToPost carries topic and board identity for links', () => {
+    const post = mapSearchPostToPost({
+      id: 9,
+      topic_id: 31,
+      topic_title: 'Blight-resistant tomatoes',
+      topic_slug: 'tomato-blight',
+      board_id: 54,
+      board_slug: 'general-discussion',
+      excerpt: 'Mountain Magic is the real answer',
+    });
+    expect(post.topic_slug).toBe('tomato-blight');
+    expect(post.board_id).toBe(54);
+    expect(post.board_slug).toBe('general-discussion');
   });
 });

--- a/web/src/services/forumMappers.ts
+++ b/web/src/services/forumMappers.ts
@@ -76,12 +76,20 @@ export interface BackendSearchTopic {
   id: number;
   slug: string;
   title: string;
+  reply_count: number;
+  view_count: number;
+  last_post_at: string | null;
+  board_id: number;
+  board_slug: string;
 }
 
 export interface BackendSearchPost {
   id: number;
   topic_id: number;
   topic_title: string;
+  topic_slug: string;
+  board_id: number;
+  board_slug: string;
   excerpt: string;
 }
 
@@ -199,10 +207,12 @@ export function mapSearchTopicToThread(t: BackendSearchTopic): Thread {
     id: String(t.id),
     title: t.title,
     slug: t.slug,
-    category: { id: '', name: '', slug: '', created_at: '' },
+    category: { id: String(t.board_id), name: '', slug: t.board_slug, created_at: '' },
     author: authorFromString(null),
-    created_at: '',
-    last_activity_at: '',
+    created_at: t.last_post_at || '',
+    last_activity_at: t.last_post_at || '',
+    post_count: t.reply_count,
+    view_count: t.view_count,
     is_active: true,
   };
 }
@@ -222,5 +232,8 @@ export function mapSearchPostToPost(p: BackendSearchPost): Post {
     can_delete: false,
     can_report: false,
     topic_title: p.topic_title,
+    topic_slug: p.topic_slug,
+    board_id: p.board_id,
+    board_slug: p.board_slug,
   };
 }

--- a/web/src/services/forumMappers.ts
+++ b/web/src/services/forumMappers.ts
@@ -209,7 +209,9 @@ export function mapSearchTopicToThread(t: BackendSearchTopic): Thread {
     slug: t.slug,
     category: { id: String(t.board_id), name: '', slug: t.board_slug, created_at: '' },
     author: authorFromString(null),
-    created_at: t.last_post_at || '',
+    // Search payload carries no creation time; only last activity. Don't alias
+    // last_post_at as created_at (that misrepresents it downstream).
+    created_at: '',
     last_activity_at: t.last_post_at || '',
     post_count: t.reply_count,
     view_count: t.view_count,

--- a/web/src/services/forumService.test.ts
+++ b/web/src/services/forumService.test.ts
@@ -245,8 +245,29 @@ describe('forumService (wagtail_forum API contract)', () => {
   it('searchForum hits /search/?q= and maps topics→threads, posts→posts', async () => {
     fetchMock.mockResolvedValueOnce(
       okJson({
-        topics: [{ id: 12, slug: 'succulent-help', title: 'Succulent help' }],
-        posts: [{ id: 50, topic_id: 12, topic_title: 'Succulent help', excerpt: 'hello' }],
+        topics: [
+          {
+            id: 12,
+            slug: 'succulent-help',
+            title: 'Succulent help',
+            reply_count: 4,
+            view_count: 99,
+            last_post_at: '2026-01-02T00:00:00Z',
+            board_id: 3,
+            board_slug: 'plant-care',
+          },
+        ],
+        posts: [
+          {
+            id: 50,
+            topic_id: 12,
+            topic_title: 'Succulent help',
+            topic_slug: 'succulent-help',
+            board_id: 3,
+            board_slug: 'plant-care',
+            excerpt: 'hello',
+          },
+        ],
       })
     );
     const r = await searchForum({ q: 'succ' });
@@ -264,6 +285,33 @@ describe('forumService (wagtail_forum API contract)', () => {
 
   it('searchForum rejects empty queries', async () => {
     await expect(searchForum({ q: '   ' })).rejects.toThrow('Search query is required');
+  });
+
+  it('searchForum sends the category as ?board= and total_threads matches array length', async () => {
+    fetchMock.mockResolvedValueOnce(
+      okJson({
+        topics: [
+          {
+            id: 31,
+            slug: 'tomato-blight',
+            title: 'Blight-resistant tomatoes',
+            reply_count: 3,
+            view_count: 12,
+            last_post_at: '2026-07-01T10:00:00Z',
+            board_id: 54,
+            board_slug: 'general-discussion',
+          },
+        ],
+        posts: [],
+      })
+    );
+    const r = await searchForum({ q: 'tomato', category: 'general-discussion' });
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining('board=general-discussion'),
+      expect.any(Object)
+    );
+    expect(r.total_threads).toBe(r.threads.length);
+    expect(r.total_threads).toBe(1);
   });
 
   // --- Write functions (structurally intact, Phase 2) -----------------------

--- a/web/src/services/forumService.ts
+++ b/web/src/services/forumService.ts
@@ -304,26 +304,22 @@ export async function uploadPostImage(imageFile: File): Promise<UploadedImage> {
 // ---------------------------------------------------------------------------
 
 export async function searchForum(options: SearchForumOptions): Promise<SearchForumResponse> {
-  // Note: SearchForumOptions includes category/author/date_from/date_to/page/page_size
-  // for backward compat with SearchPage; the backend only supports `q` currently.
-  const { q } = options;
+  const { q, category } = options;
   if (!q || q.trim() === '') throw new Error('Search query is required');
   const params = new URLSearchParams({ q: q.trim() });
+  if (category) params.set('board', category);
   const data = await authenticatedFetch<{
     topics: BackendSearchTopic[];
     posts: BackendSearchPost[];
   }>(`${FORUM_BASE}/search/?${params}`);
   const threads = (data.topics || []).map(mapSearchTopicToThread);
   const posts = (data.posts || []).map(mapSearchPostToPost);
+  // Result sets are server-capped at 50 each; lengths are the real totals up to that cap.
   return {
     query: q.trim(),
     threads,
     posts,
     total_threads: threads.length,
     total_posts: posts.length,
-    has_next_threads: false,
-    has_next_posts: false,
-    page: options.page ?? 1,
-    page_size: options.page_size ?? threads.length + posts.length,
   };
 }

--- a/web/src/types/forum.ts
+++ b/web/src/types/forum.ts
@@ -63,6 +63,10 @@ export interface Post {
    * The topic title is carried so SearchPage can render a link without a PostCard.
    */
   topic_title?: string;
+  /** Search-result-only link identity (mapSearchPostToPost). */
+  topic_slug?: string;
+  board_id?: number;
+  board_slug?: string;
   created_at: string;
   updated_at?: string;
   edited_at?: string;
@@ -214,12 +218,8 @@ export interface Reaction {
  */
 export interface SearchForumOptions {
   q: string;
+  /** Board slug — sent to the backend as ?board= */
   category?: string;
-  author?: string;
-  date_from?: string;
-  date_to?: string;
-  page?: number;
-  page_size?: number;
 }
 
 export interface SearchForumResponse {
@@ -228,10 +228,6 @@ export interface SearchForumResponse {
   posts: Post[];
   total_threads: number;
   total_posts: number;
-  page: number;
-  page_size: number;
-  has_next_threads: boolean;
-  has_next_posts: boolean;
 }
 
 /** Result of toggling a reaction on a post (backend toggle endpoint). */

--- a/web/src/types/notifications.ts
+++ b/web/src/types/notifications.ts
@@ -25,6 +25,8 @@ export interface ForumNotification {
   verb: ForumNotificationVerb;
   actor: NotificationActor | null;
   topic: NotificationTopicRef | null;
+  /** The post this notification is about, for deep links; null for post-less verbs. */
+  post_id: number | null;
   created_at: string;
   read_at: string | null;
 }

--- a/web/src/utils/forumDrafts.test.ts
+++ b/web/src/utils/forumDrafts.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { draftKey, loadDraft, saveDraft, clearDraft } from './forumDrafts';
+
+describe('forumDrafts', () => {
+  beforeEach(() => sessionStorage.clear());
+
+  it('round-trips a draft', () => {
+    const key = draftKey('reply', '28');
+    saveDraft(key, '<p>half-written</p>');
+    expect(loadDraft(key)).toBe('<p>half-written</p>');
+    clearDraft(key);
+    expect(loadDraft(key)).toBeNull();
+  });
+
+  it('saving an empty value removes the draft', () => {
+    const key = draftKey('new-thread', '54');
+    saveDraft(key, '<p>x</p>');
+    saveDraft(key, '');
+    expect(loadDraft(key)).toBeNull();
+  });
+
+  it('swallows storage errors', () => {
+    const spy = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('QuotaExceededError');
+    });
+    expect(() => saveDraft(draftKey('reply', '1'), 'x')).not.toThrow();
+    spy.mockRestore();
+  });
+});

--- a/web/src/utils/forumDrafts.ts
+++ b/web/src/utils/forumDrafts.ts
@@ -1,0 +1,39 @@
+/**
+ * Best-effort composer draft persistence (sessionStorage — survives navigation
+ * within the tab, intentionally not across sessions). All storage failures are
+ * swallowed: drafts are a convenience, never a correctness dependency.
+ */
+
+const PREFIX = 'forum-draft:';
+
+export function draftKey(kind: 'reply' | 'new-thread', id: string): string {
+  return `${PREFIX}${kind}:${id}`;
+}
+
+export function loadDraft(key: string): string | null {
+  try {
+    return sessionStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+export function saveDraft(key: string, value: string): void {
+  try {
+    if (value) {
+      sessionStorage.setItem(key, value);
+    } else {
+      sessionStorage.removeItem(key);
+    }
+  } catch {
+    /* private mode / quota — best-effort only */
+  }
+}
+
+export function clearDraft(key: string): void {
+  try {
+    sessionStorage.removeItem(key);
+  } catch {
+    /* ignore */
+  }
+}

--- a/web/src/utils/forumUrls.test.ts
+++ b/web/src/utils/forumUrls.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { slugifyTitle, parseLeadingId, categoryPath, threadPath } from './forumUrls';
+import { slugifyTitle, parseLeadingId, categoryPath, threadPath, postAnchor } from './forumUrls';
 import type { Category, Thread } from '../types/forum';
 
 describe('forumUrls', () => {
@@ -25,5 +25,10 @@ describe('forumUrls', () => {
     } as Thread;
     expect(categoryPath(category)).toBe('/forum/3-plant-care');
     expect(threadPath(category, thread)).toBe('/forum/3-plant-care/12-succulent-help');
+  });
+
+  it('postAnchor builds a #post-N fragment', () => {
+    expect(postAnchor(42)).toBe('#post-42');
+    expect(postAnchor('42')).toBe('#post-42');
   });
 });

--- a/web/src/utils/forumUrls.ts
+++ b/web/src/utils/forumUrls.ts
@@ -31,3 +31,8 @@ export function threadPath(
   const tSlug = thread.slug || slugifyTitle(thread.title);
   return `${categoryPath(category)}/${thread.id}-${tSlug}`;
 }
+
+/** Fragment identifier for a specific post inside a thread page. */
+export function postAnchor(postId: number | string): string {
+  return `#post-${postId}`;
+}

--- a/web/src/utils/mentions.test.ts
+++ b/web/src/utils/mentions.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { highlightMentions } from './mentions';
+
+describe('highlightMentions', () => {
+  it('wraps a mention in a styled span', () => {
+    expect(highlightMentions('<p>Thanks @bob_botanist!</p>')).toBe(
+      '<p>Thanks <span class="text-primary font-medium">@bob_botanist</span>!</p>'
+    );
+  });
+
+  it('ignores email addresses', () => {
+    expect(highlightMentions('<p>mail me at jdoe@example.com</p>')).toBe(
+      '<p>mail me at jdoe@example.com</p>'
+    );
+  });
+
+  it('does not touch text inside links or code', () => {
+    const html = '<p><a href="https://x.test">@alice</a> and <code>@beta</code></p>';
+    expect(highlightMentions(html)).toBe(html);
+  });
+
+  it('handles multiple mentions in one text node', () => {
+    expect(highlightMentions('<p>@a and @b</p>')).toBe(
+      '<p><span class="text-primary font-medium">@a</span> and <span class="text-primary font-medium">@b</span></p>'
+    );
+  });
+});

--- a/web/src/utils/mentions.ts
+++ b/web/src/utils/mentions.ts
@@ -1,0 +1,48 @@
+/**
+ * Wrap @username mentions in styled spans, matching the composer's mention
+ * styling (forumMentionNode.ts: text-primary font-medium).
+ *
+ * SECURITY: operates on ALREADY-SANITIZED HTML (call after createSafeMarkup),
+ * walks text nodes only, and inserts only a span with a fixed class — it can
+ * never introduce markup from user content.
+ */
+
+// A mention starts the string or follows whitespace/"(" — this skips emails,
+// where "@" follows a word character.
+const MENTION_RE = /(^|[\s(])@([A-Za-z0-9_]+)/g;
+
+export function highlightMentions(sanitizedHtml: string): string {
+  if (!sanitizedHtml.includes('@')) return sanitizedHtml;
+  const doc = new DOMParser().parseFromString(
+    `<div id="__mention_root">${sanitizedHtml}</div>`,
+    'text/html'
+  );
+  const root = doc.getElementById('__mention_root');
+  if (!root) return sanitizedHtml;
+  const walker = doc.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+  const textNodes: Text[] = [];
+  for (let n = walker.nextNode(); n; n = walker.nextNode()) {
+    const parent = (n as Text).parentElement;
+    if (parent && !parent.closest('a, code, pre')) textNodes.push(n as Text);
+  }
+  for (const node of textNodes) {
+    const text = node.textContent || '';
+    MENTION_RE.lastIndex = 0;
+    if (!MENTION_RE.test(text)) continue;
+    const frag = doc.createDocumentFragment();
+    let cursor = 0;
+    MENTION_RE.lastIndex = 0;
+    for (let m = MENTION_RE.exec(text); m; m = MENTION_RE.exec(text)) {
+      const mentionStart = m.index + m[1].length;
+      frag.appendChild(doc.createTextNode(text.slice(cursor, mentionStart)));
+      const span = doc.createElement('span');
+      span.className = 'text-primary font-medium';
+      span.textContent = `@${m[2]}`;
+      frag.appendChild(span);
+      cursor = mentionStart + m[2].length + 1;
+    }
+    frag.appendChild(doc.createTextNode(text.slice(cursor)));
+    node.replaceWith(frag);
+  }
+  return root.innerHTML;
+}


### PR DESCRIPTION
## Summary

Wave 1 of `docs/superpowers/specs/2026-07-17-forum-app-loop-roadmap-design.md` — makes existing forum features findable and truthful before we build the app-loop on top. **No new product features, no migrations.**

- **Search** — results carry real metadata (was fabricated "0 replies • recently") + working thread links (were 404s) + a real board filter (`?board=`); dropped the decorative author/date filter inputs.
- **Notifications** — deep-link to the specific post (`#post-N` + scroll & highlight) instead of the thread top; per-post "🔗 Copy link" affordance. The deep-link now also reaches posts on later cursor pages (bounded on persistent failure, guarded against cross-thread navigation races).
- **@mentions** — rendered as a styled span (was plain text). Injection-safe: post-processes already-DOMPurify-sanitized HTML, text-node-only, allowlist-bounded (no `svg`/`math`/`template`/`style` round-trip vector).
- **Reactions** — counts visible to logged-out readers (read-only pills); the four zero-count buttons replaced with non-zero pills + a single add-reaction picker.
- **Header** — forum search reachable from the nav (desktop icon + mobile menu).
- **Composer drafts** — autosave to `sessionStorage` (per-board for new threads, per-topic for replies); restore on mount, clear on submit. No more silent data loss on navigation.

## Test plan

- **Backend** — package API tests extended (search metadata + board filter, notification `post_id`): **310 pass**; OpenAPI schema builds clean.
- **Web** — new/extended Vitest suites (search mappers/service/page, PostCard reactions, mentions XSS invariants, drafts, deep-link chase + bounded-retry): **642 pass**; `tsc` + ESLint clean.
- **Live walkthrough** — all 9 acceptance items exercised against the running dev stack (backend :8000 + web :5174, seeded users), logged-in and logged-out.
- **Reviews** — per-task spec+quality gates (0 Critical/Important) and a whole-branch review that found the deep-link "misses posts past page 1" gap (I1) — fixed here, with a security sign-off on the mention post-processing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)