### PR TITLE
Fix SQL LIKE wildcard double-escaping in search (todo 269)

### DIFF
--- a/backend/apps/blog/admin_views.py
+++ b/backend/apps/blog/admin_views.py
@@ -3,7 +3,6 @@ Blog admin views for managing blog content, comments, and settings.
 Provides comprehensive administrative functionality beyond basic Wagtail page management.
 """
 
-from apps.core.utils.query_sanitization import escape_search_query
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.admin.views.decorators import staff_member_required
@@ -79,11 +78,10 @@ def moderate_comments(request):
         pass  # Show all comments
 
     if search_query:
-        safe_query = escape_search_query(search_query)
         comments = comments.filter(
-            Q(content__icontains=safe_query)
-            | Q(author__username__icontains=safe_query)
-            | Q(post__title__icontains=safe_query)
+            Q(content__icontains=search_query)
+            | Q(author__username__icontains=search_query)
+            | Q(post__title__icontains=search_query)
         )
 
     comments = comments.order_by("-created_at")
@@ -279,13 +277,12 @@ def blog_search(request):
     }
 
     if query:
-        safe_query = escape_search_query(query)
         # Search posts
         if content_type in ["all", "posts"]:
             posts = BlogPostPage.objects.live().filter(
-                Q(title__icontains=safe_query)
-                | Q(search_description__icontains=safe_query)
-                | Q(introduction__icontains=safe_query)
+                Q(title__icontains=query)
+                | Q(search_description__icontains=query)
+                | Q(introduction__icontains=query)
             )
 
             if date_from:
@@ -298,15 +295,14 @@ def blog_search(request):
         # Search comments
         if content_type in ["all", "comments"]:
             comments = BlogComment.objects.filter(
-                Q(content__icontains=safe_query)
-                | Q(author__username__icontains=safe_query)
+                Q(content__icontains=query) | Q(author__username__icontains=query)
             )
             results["comments"] = comments[:20]
 
         # Search categories
         if content_type in ["all", "categories"]:
             categories = BlogCategory.objects.filter(
-                Q(name__icontains=safe_query) | Q(description__icontains=safe_query)
+                Q(name__icontains=query) | Q(description__icontains=query)
             )
             results["categories"] = categories[:10]
 

--- a/backend/apps/blog/api/viewsets.py
+++ b/backend/apps/blog/api/viewsets.py
@@ -28,8 +28,6 @@ except ImportError:
     # For Wagtail versions where Query might be located elsewhere
     Query = None
 
-from apps.core.utils.query_sanitization import escape_search_query
-
 from ..constants import (
     POPULAR_POSTS_DEFAULT_DAYS,
     POPULAR_POSTS_DEFAULT_LIMIT,
@@ -475,8 +473,6 @@ class BlogPostPageViewSet(PagesAPIViewSet):
         if not query or len(query) < 2:
             return Response([])
 
-        safe_query = escape_search_query(query)
-
         # Search in titles and tags
         suggestions = []
 
@@ -484,7 +480,7 @@ class BlogPostPageViewSet(PagesAPIViewSet):
         title_matches = (
             BlogPostPage.objects.live()
             .public()
-            .filter(title__icontains=safe_query)
+            .filter(title__icontains=query)
             .values_list("title", flat=True)[:5]
         )
         suggestions.extend(
@@ -496,7 +492,7 @@ class BlogPostPageViewSet(PagesAPIViewSet):
 
         tag_matches = (
             Tag.objects.filter(
-                name__icontains=safe_query,
+                name__icontains=query,
                 taggit_taggeditem_items__content_type__model="blogpostpage",
             )
             .distinct()

--- a/backend/apps/blog/api_views.py
+++ b/backend/apps/blog/api_views.py
@@ -8,8 +8,6 @@ block fields with plant data from various sources.
 import json
 import logging
 
-from apps.core.utils.query_sanitization import escape_search_query
-
 # CSRF protection enabled for all admin endpoints - removed csrf_exempt for security
 from django.contrib.admin.views.decorators import staff_member_required
 from django.core.cache import cache
@@ -136,9 +134,6 @@ class PlantSuggestionsView(View):
             if len(query) < 2:
                 return JsonResponse({"success": True, "suggestions": []})
 
-            # Escape SQL LIKE wildcards before icontains to prevent query-cost abuse.
-            escaped_query = escape_search_query(query)
-
             # Check cache first
             cache_key = f"plant_suggestions_{query.lower().replace(' ', '_')}_{limit}"
             cached_suggestions = cache.get(cache_key)
@@ -153,7 +148,7 @@ class PlantSuggestionsView(View):
 
             # Scientific names
             scientific_matches = PlantSpecies.objects.filter(
-                scientific_name__icontains=escaped_query
+                scientific_name__icontains=query
             ).values_list("scientific_name", flat=True)[: limit // 2]
 
             for name in scientific_matches:
@@ -164,7 +159,7 @@ class PlantSuggestionsView(View):
                 remaining_limit = limit - len(suggestions)
 
                 common_matches = PlantSpecies.objects.filter(
-                    common_names__icontains=escaped_query
+                    common_names__icontains=query
                 ).values_list("common_names", "scientific_name")[:remaining_limit]
 
                 for common_names, scientific in common_matches:

--- a/backend/apps/blog/tests/test_search_wildcards.py
+++ b/backend/apps/blog/tests/test_search_wildcards.py
@@ -1,0 +1,202 @@
+"""SQL LIKE wildcard regression tests for blog search endpoints (todo 269).
+
+`escape_search_query()` was removed from every blog search call site because it
+double-escaped SQL LIKE wildcards on top of Django ORM's own
+``PatternLookup.process_rhs()`` auto-escaping, silently dropping real matches
+(a search for ``Rosa_`` stopped matching the row ``Rosa_care``).
+
+Each test follows the discriminating design pinned by
+``packages/wagtail_forum/.../test_user_search.py::test_search_escapes_sql_wildcards``:
+
+1. The query string contains a literal ``_``.
+2. A REAL target row whose searched field contains that literal substring is
+   asserted RETURNED (this FAILS under the old double-escape bug — the point).
+3. A DECOY row that would match only if ``_`` were a SQL wildcard (``X`` in
+   place of ``_``) is asserted NOT returned (proves ``_`` is literal).
+"""
+
+from datetime import date
+
+from apps.blog.api.viewsets import BlogPostPageViewSet
+from apps.blog.models import BlogCategory, BlogComment, BlogIndexPage, BlogPostPage
+from apps.plant_identification.models import PlantSpecies
+from django.contrib.auth import get_user_model
+from django.core.cache import cache
+from django.test import TestCase
+from django.urls import reverse
+from rest_framework.test import APIRequestFactory
+from wagtail.models import Page
+
+User = get_user_model()
+
+
+def _blog_index():
+    """Return (creating if needed) the BlogIndexPage under the tree root."""
+    try:
+        return BlogIndexPage.objects.get(slug="blog")
+    except BlogIndexPage.DoesNotExist:
+        index = BlogIndexPage(title="Blog", slug="blog")
+        Page.objects.get(id=1).add_child(instance=index)
+        return index
+
+
+def _publish_post(title, slug, author, tags=None):
+    post = BlogPostPage(
+        title=title,
+        slug=slug,
+        author=author,
+        publish_date=date.today(),
+        introduction="<p>Intro.</p>",
+    )
+    _blog_index().add_child(instance=post)
+    post.save_revision().publish()
+    if tags:
+        for tag in tags:
+            post.tags.add(tag)
+        post.save_revision().publish()
+    return post
+
+
+class ModerateCommentsWildcardTests(TestCase):
+    """blog_admin:moderate_comments — content__icontains (staff-only)."""
+
+    def setUp(self):
+        cache.clear()
+        self.admin = User.objects.create_superuser(
+            username="wildcard-mod-admin", email="mod@example.com"
+        )
+        self.client.force_login(self.admin)
+        author = User.objects.create_user(username="commenter")
+        post = _publish_post("Care Guide", "care-guide", author)
+        # Target comment content contains the literal "Rosa_".
+        self.target = BlogComment.objects.create(
+            post=post, author=author, content="Rosa_care advice", is_approved=True
+        )
+        # Decoy matches only if "_" acts as a wildcard.
+        self.decoy = BlogComment.objects.create(
+            post=post, author=author, content="RosaXcare advice", is_approved=True
+        )
+
+    def test_search_treats_underscore_as_literal(self):
+        # status=all so is_approved does not filter the fixtures out.
+        response = self.client.get(
+            reverse("blog_admin:moderate_comments"), {"q": "Rosa_", "status": "all"}
+        )
+        self.assertEqual(response.status_code, 200)
+        ids = {c.id for c in response.context["page_obj"].object_list}
+        self.assertIn(self.target.id, ids)
+        self.assertNotIn(self.decoy.id, ids)
+
+
+class BlogAdminSearchWildcardTests(TestCase):
+    """blog_admin:search — BlogCategory name__icontains (staff-only)."""
+
+    def setUp(self):
+        cache.clear()
+        self.admin = User.objects.create_superuser(
+            username="wildcard-search-admin", email="search@example.com"
+        )
+        self.client.force_login(self.admin)
+        self.target = BlogCategory.objects.create(
+            name="Rosa_pests", slug="rosa-pests", description="Pest guide"
+        )
+        self.decoy = BlogCategory.objects.create(
+            name="RosaXpests", slug="rosax-pests", description="Other guide"
+        )
+
+    def test_search_treats_underscore_as_literal(self):
+        response = self.client.get(reverse("blog_admin:search"), {"q": "Rosa_"})
+        self.assertEqual(response.status_code, 200)
+        names = {c.name for c in response.context["results"]["categories"]}
+        self.assertIn("Rosa_pests", names)
+        self.assertNotIn("RosaXpests", names)
+
+
+class PlantSuggestionsWildcardTests(TestCase):
+    """blog_api:plant_suggestions — scientific_name__icontains (staff-only)."""
+
+    def setUp(self):
+        cache.clear()
+        self.admin = User.objects.create_superuser(
+            username="wildcard-suggest-admin", email="suggest@example.com"
+        )
+        self.client.force_login(self.admin)
+        self.target = PlantSpecies.objects.create(scientific_name="Rosa_alba")
+        self.decoy = PlantSpecies.objects.create(scientific_name="RosaXalba")
+
+    def test_suggestions_treat_underscore_as_literal(self):
+        # Query must be >= 2 chars; "Rosa_" is 5.
+        response = self.client.get(
+            reverse("v1:blog_api:plant_suggestions"), {"q": "Rosa_"}
+        )
+        self.assertEqual(response.status_code, 200)
+        values = {s["value"] for s in response.json()["suggestions"]}
+        self.assertIn("Rosa_alba", values)
+        self.assertNotIn("RosaXalba", values)
+
+
+class BlogPostTagFilterWildcardTests(TestCase):
+    """v1:blog:blog-posts-list ?tag= — tags__name__icontains (anonymous)."""
+
+    def setUp(self):
+        cache.clear()
+        author = User.objects.create_user(username="tag-author")
+        self.target = _publish_post(
+            "Underscore Tagged", "underscore-tagged", author, tags=["rosa_x"]
+        )
+        self.decoy = _publish_post(
+            "Wildcard Tagged", "wildcard-tagged", author, tags=["rosaXx"]
+        )
+
+    def test_tag_filter_treats_underscore_as_literal(self):
+        response = self.client.get(reverse("v1:blog:blog-posts-list"), {"tag": "rosa_"})
+        self.assertEqual(response.status_code, 200)
+        ids = {row["id"] for row in response.data["results"]}
+        self.assertIn(self.target.id, ids)
+        self.assertNotIn(self.decoy.id, ids)
+
+
+class BlogPublicSearchWildcardTests(TestCase):
+    """v1:blog:blog-search — BlogCategory name__icontains (anonymous)."""
+
+    def setUp(self):
+        cache.clear()
+        self.target = BlogCategory.objects.create(
+            name="Rose_disease", slug="rose-disease", description="Disease guide"
+        )
+        self.decoy = BlogCategory.objects.create(
+            name="RoseXdisease", slug="rosex-disease", description="Other guide"
+        )
+
+    def test_empty_query_returns_400(self):
+        response = self.client.get(reverse("v1:blog:blog-search"), {"q": ""})
+        self.assertEqual(response.status_code, 400)
+
+    def test_search_treats_underscore_as_literal(self):
+        response = self.client.get(reverse("v1:blog:blog-search"), {"q": "Rose_"})
+        self.assertEqual(response.status_code, 200)
+        names = {c["name"] for c in response.data["categories"]}
+        self.assertIn("Rose_disease", names)
+        self.assertNotIn("RoseXdisease", names)
+
+
+class SearchSuggestionsActionWildcardTests(TestCase):
+    """BlogPostPageViewSet.search_suggestions — title__icontains.
+
+    Not URL-routed; exercised via a direct action call as instructed.
+    """
+
+    def setUp(self):
+        cache.clear()
+        author = User.objects.create_user(username="suggest-post-author")
+        # Titles contain the literal "ro_" vs the wildcard-only decoy "roX".
+        self.target = _publish_post("Ro_ses at home", "ro-ses-at-home", author)
+        self.decoy = _publish_post("RoXses at home", "rox-ses-at-home", author)
+
+    def test_title_suggestions_treat_underscore_as_literal(self):
+        request = APIRequestFactory().get("/?q=ro_")
+        response = BlogPostPageViewSet.as_view({"get": "search_suggestions"})(request)
+        self.assertEqual(response.status_code, 200)
+        titles = {row["text"] for row in response.data if row["type"] == "title"}
+        self.assertIn("Ro_ses at home", titles)
+        self.assertNotIn("RoXses at home", titles)

--- a/backend/apps/blog/views.py
+++ b/backend/apps/blog/views.py
@@ -7,7 +7,6 @@ Following the existing pattern from plant identification and forum APIs.
 
 import logging
 
-from apps.core.utils.query_sanitization import escape_search_query
 from django.contrib.auth import get_user_model
 from django.db.models import Count, Prefetch, Q
 from django_filters.rest_framework import DjangoFilterBackend
@@ -112,7 +111,7 @@ class BlogPostPageViewSet(viewsets.ReadOnlyModelViewSet):
         # Filter by tag if provided
         tag = self.request.query_params.get("tag")
         if tag:
-            queryset = queryset.filter(tags__name__icontains=escape_search_query(tag))
+            queryset = queryset.filter(tags__name__icontains=tag)
 
         # Filter by author username if provided
         author_username = self.request.query_params.get("author")
@@ -517,18 +516,15 @@ def blog_search(request):
             {"detail": "Search query is required."}, status=status.HTTP_400_BAD_REQUEST
         )
 
-    # Escape SQL LIKE wildcards before icontains to prevent query-cost abuse.
-    escaped_query = escape_search_query(query)
-
     # Search blog posts
     posts = (
         BlogPostPage.objects.live()
         .public()
         .filter(
-            Q(title__icontains=escaped_query)
-            | Q(introduction__icontains=escaped_query)
-            | Q(content_blocks__icontains=escaped_query)
-            | Q(tags__name__icontains=escaped_query)
+            Q(title__icontains=query)
+            | Q(introduction__icontains=query)
+            | Q(content_blocks__icontains=query)
+            | Q(tags__name__icontains=query)
         )
         .distinct()
         .select_related("author")
@@ -537,7 +533,7 @@ def blog_search(request):
 
     # Search categories
     categories = BlogCategory.objects.filter(
-        Q(name__icontains=escaped_query) | Q(description__icontains=escaped_query)
+        Q(name__icontains=query) | Q(description__icontains=query)
     )[:10]
 
     results = {

--- a/backend/apps/core/utils/query_sanitization.py
+++ b/backend/apps/core/utils/query_sanitization.py
@@ -11,44 +11,39 @@ from typing import Optional
 
 def escape_search_query(query: str) -> str:
     """
-    Escape SQL wildcard characters in search queries.
+    Escape SQL LIKE wildcards (``%`` and ``_``) in a search string.
 
-    Prevents unintended pattern matching from user input containing SQL wildcard
-    characters that are interpreted by Django ORM's icontains, istartswith, and
-    iendswith operations when using PostgreSQL's ILIKE operator.
+    ⚠️  Do NOT call this before a Django ORM ``icontains`` / ``istartswith`` /
+    ``iendswith`` / ``contains`` lookup. Those run through
+    ``PatternLookup.process_rhs()``, which ALREADY escapes ``%`` / ``_`` / ``\\``
+    for you, so a user's literal ``%`` / ``_`` is matched as a literal
+    character. Escaping first double-escapes and silently drops real matches —
+    e.g. searching ``dave_`` stops matching the row ``dave_1``. This class of
+    bug is what todo 269 removed from 13 call sites; the write-time trigger
+    ``escape-search-query-before-orm-wildcard-lookup`` guards against
+    reintroducing it. See ``docs/patterns/security/input-validation.md``.
 
-    SQL Wildcards:
-        % - Matches zero or more characters
-        _ - Matches exactly one character
-
-    Without escaping, user input like "test%" would match "test", "testing",
-    "test123", etc., which may not be the intended behavior.
+    This helper is retained ONLY for the narrow case of a LIKE pattern that
+    bypasses the ORM's pattern-lookup machinery and therefore gets no
+    auto-escaping — raw SQL, ``QuerySet.extra()``, or a custom ``Lookup``. As
+    of todo 269 (2026-07-20) the codebase has no such caller; it is kept as a
+    correct primitive for that case rather than deleted.
 
     Args:
-        query: User-provided search query string
+        query: User-provided search query string.
 
     Returns:
-        Sanitized query with escaped wildcards
+        The query with ``%`` and ``_`` backslash-escaped.
 
     Examples:
-        >>> escape_search_query("test%data")
-        'test\\\\%data'
-        >>> escape_search_query("user_name")
-        'user\\\\_name'
-        >>> escape_search_query("normal text")
-        'normal text'
-        >>> escape_search_query("test%_both")
-        'test\\\\%\\\\_both'
+        >>> escape_search_query("50% off")
+        '50\\\\% off'
+        >>> escape_search_query("plant_name")
+        'plant\\\\_name'
 
     Note:
-        This function only escapes SQL wildcards. It does not protect against
-        SQL injection (Django ORM handles that). This is specifically for
-        preventing unintended pattern matching in ILIKE queries.
-
-    See Also:
-        - PHASE_6_PATTERNS_CODIFIED.md, Pattern 2
-        - SECURITY_PATTERNS_CODIFIED.md
-        - Django docs: https://docs.djangoproject.com/en/5.2/ref/models/querysets/#icontains
+        Escaping wildcards is unrelated to SQL-injection safety — the Django
+        ORM parameterises values regardless.
     """
     if not query:
         return query

--- a/backend/apps/plant_identification/api/endpoints.py
+++ b/backend/apps/plant_identification/api/endpoints.py
@@ -2,7 +2,6 @@
 Wagtail API endpoints for plant identification snippets and pages.
 """
 
-from apps.core.utils.query_sanitization import escape_search_query
 from django.db.models import Count
 from rest_framework.decorators import action
 from rest_framework.response import Response
@@ -86,7 +85,7 @@ class PlantSpeciesAPIViewSet(BaseAPIViewSet):
         # Family filtering
         family = self.request.GET.get("family")
         if family:
-            queryset = queryset.filter(family__icontains=escape_search_query(family))
+            queryset = queryset.filter(family__icontains=family)
 
         # Care requirements filtering
         light_requirements = self.request.GET.get("light_requirements")
@@ -332,9 +331,7 @@ class PlantSpeciesPageViewSet(PagesAPIViewSet):
 
         family = self.request.GET.get("family")
         if family:
-            queryset = queryset.filter(
-                plant_species__family__icontains=escape_search_query(family)
-            )
+            queryset = queryset.filter(plant_species__family__icontains=family)
 
         light_requirements = self.request.GET.get("light_requirements")
         if light_requirements:

--- a/backend/apps/plant_identification/tests/test_search_wildcards.py
+++ b/backend/apps/plant_identification/tests/test_search_wildcards.py
@@ -1,0 +1,279 @@
+r"""SQL LIKE wildcard regression tests for plant_identification search endpoints
+(todo 269).
+
+``escape_search_query()`` was removed from every search call site because it
+double-escaped SQL LIKE wildcards on top of Django ORM's own
+``PatternLookup.process_rhs()`` auto-escaping. The double escape silently
+dropped real matches: a search for ``Rosa_`` stopped matching the row
+``Rosa_damascena`` (``escape_search_query("Rosa_")`` -> ``Rosa\_``, which the
+ORM escaped again, so the LIKE pattern only matched a literal backslash that
+was never stored).
+
+Each test below follows the discriminating design pinned by
+``packages/wagtail_forum/.../test_user_search.py::test_search_escapes_sql_wildcards``:
+
+1. The query string contains a literal ``_``.
+2. A REAL target row whose searched field contains that literal substring is
+   created and asserted to be RETURNED. Under the old double-escape bug this
+   assertion FAILS -- that is the regression these tests pin. (Verified: with
+   the old ``escape_search_query`` applied, ``...__icontains`` returned 0 rows
+   for every field exercised here.)
+3. A DECOY row that would match ONLY if ``_`` were treated as a SQL wildcard
+   (``X`` where the target has ``_``) is created and asserted NOT returned.
+   This proves ``_`` is treated as a literal, not a wildcard.
+"""
+
+from apps.plant_identification.api.endpoints import (
+    PlantSpeciesAPIViewSet,
+    PlantSpeciesPageViewSet,
+)
+from apps.plant_identification.models import (
+    PlantDiseaseDatabase,
+    PlantSpecies,
+    PlantSpeciesPage,
+)
+from django.core.cache import cache
+from django.urls import reverse
+from rest_framework.test import APIRequestFactory, APITestCase
+from wagtail.models import Page
+
+
+def _unwrap(response_data):
+    """Return the row list whether or not the response is paginated."""
+    if isinstance(response_data, dict) and "results" in response_data:
+        return response_data["results"]
+    return response_data
+
+
+class PlantSpeciesViewSetSearchWildcardTests(APITestCase):
+    """GET /api/v1/plant-identification/species/ ?search= and ?family=."""
+
+    def setUp(self):
+        cache.clear()
+        self.url = reverse("v1:plant_identification:species-list")
+        # Target: literal "Rosa_" appears in scientific_name AND family.
+        self.target = PlantSpecies.objects.create(
+            scientific_name="Rosa_damascena",
+            common_names="Damask rose",
+            family="Rosa_family",
+        )
+        # Decoy: only matches if "_" acts as a single-char SQL wildcard.
+        self.decoy = PlantSpecies.objects.create(
+            scientific_name="RosaXdamascena",
+            common_names="Imposter rose",
+            family="RosaXfamily",
+        )
+
+    def test_search_treats_underscore_as_literal(self):
+        response = self.client.get(self.url, {"search": "Rosa_"})
+        self.assertEqual(response.status_code, 200)
+        names = {row["scientific_name"] for row in _unwrap(response.data)}
+        # Target returned (fails under the old double-escape bug).
+        self.assertIn("Rosa_damascena", names)
+        # Decoy excluded (proves "_" is literal, not a wildcard).
+        self.assertNotIn("RosaXdamascena", names)
+
+    def test_family_filter_treats_underscore_as_literal(self):
+        response = self.client.get(self.url, {"family": "Rosa_"})
+        self.assertEqual(response.status_code, 200)
+        names = {row["scientific_name"] for row in _unwrap(response.data)}
+        self.assertIn("Rosa_damascena", names)
+        self.assertNotIn("RosaXdamascena", names)
+
+
+class DiseaseDatabaseViewSetSearchWildcardTests(APITestCase):
+    """GET /api/v1/plant-identification/disease-database/ ?search=."""
+
+    def setUp(self):
+        cache.clear()
+        self.url = reverse("v1:plant_identification:disease-database-list")
+        # Base queryset filters diagnosis_count__gte=1; default is 1.
+        self.target = PlantDiseaseDatabase.objects.create(
+            disease_name="Rosa_rot",
+            disease_type="fungal",
+            confidence_score=0.8,
+            diagnosis_count=1,
+        )
+        self.decoy = PlantDiseaseDatabase.objects.create(
+            disease_name="RosaXrot",
+            disease_type="fungal",
+            confidence_score=0.8,
+            diagnosis_count=1,
+        )
+
+    def test_search_treats_underscore_as_literal(self):
+        response = self.client.get(self.url, {"search": "Rosa_"})
+        self.assertEqual(response.status_code, 200)
+        names = {row["disease_name"] for row in _unwrap(response.data)}
+        self.assertIn("Rosa_rot", names)
+        self.assertNotIn("RosaXrot", names)
+
+
+class SearchLocalPlantsWildcardTests(APITestCase):
+    """GET /api/v1/plant-identification/search/plants/ ?q= (rate-limited)."""
+
+    def setUp(self):
+        cache.clear()
+        self.url = reverse("v1:plant_identification:search_local_plants")
+        self.target = PlantSpecies.objects.create(
+            scientific_name="Fern_ales",
+            common_names="Underscore fern",
+        )
+        self.decoy = PlantSpecies.objects.create(
+            scientific_name="FernXales",
+            common_names="Wildcard fern",
+        )
+
+    def test_search_treats_underscore_as_literal(self):
+        # Endpoint is rate-limited -- issue exactly one request.
+        response = self.client.get(self.url, {"q": "Fern_"})
+        self.assertEqual(response.status_code, 200)
+        names = {row["scientific_name"] for row in response.data["results"]}
+        self.assertIn("Fern_ales", names)
+        self.assertNotIn("FernXales", names)
+
+
+class SearchLocalDiseasesWildcardTests(APITestCase):
+    """GET /api/v1/plant-identification/search/diseases/ ?q= (rate-limited)."""
+
+    def setUp(self):
+        cache.clear()
+        self.url = reverse("v1:plant_identification:search_local_diseases")
+        # No diagnosis_count gate on this endpoint.
+        self.target = PlantDiseaseDatabase.objects.create(
+            disease_name="Mildew_spot",
+            disease_type="fungal",
+            confidence_score=0.7,
+        )
+        self.decoy = PlantDiseaseDatabase.objects.create(
+            disease_name="MildewXspot",
+            disease_type="fungal",
+            confidence_score=0.7,
+        )
+
+    def test_search_treats_underscore_as_literal(self):
+        # Endpoint is rate-limited -- issue exactly one request.
+        response = self.client.get(self.url, {"q": "Mildew_"})
+        self.assertEqual(response.status_code, 200)
+        names = {row["disease_name"] for row in response.data["results"]}
+        self.assertIn("Mildew_spot", names)
+        self.assertNotIn("MildewXspot", names)
+
+
+class PlantSpeciesAPIViewSetWildcardTests(APITestCase):
+    """Wagtail v2 API PlantSpeciesAPIViewSet -- family__icontains.
+
+    Exercised via a direct ``get_queryset()`` call rather than an HTTP request:
+    over HTTP, Wagtail's ``FieldsFilter`` applies an EXACT ``family=`` match
+    (``family`` is an available db field), which intersects with and shadows
+    the viewset's own ``family__icontains`` -- so ``?family=Rosa_`` returns 0
+    rows even after the fix and could not honestly assert the target is
+    returned. Calling ``get_queryset()`` runs the exact production line the
+    fix touched (``family__icontains``) with no filter-backend interference.
+    """
+
+    def setUp(self):
+        cache.clear()
+        self.target = PlantSpecies.objects.create(
+            scientific_name="Snippet target species",
+            family="Rosa_snippet",
+        )
+        self.decoy = PlantSpecies.objects.create(
+            scientific_name="Snippet decoy species",
+            family="RosaXsnippet",
+        )
+
+    def test_family_filter_treats_underscore_as_literal(self):
+        view = PlantSpeciesAPIViewSet()
+        view.request = APIRequestFactory().get("/?family=Rosa_")
+        view.args = ()
+        view.kwargs = {}
+        ids = set(view.get_queryset().values_list("id", flat=True))
+        # Target returned (fails under the old double-escape bug).
+        self.assertIn(self.target.id, ids)
+        # Decoy excluded (proves "_" is literal, not a wildcard).
+        self.assertNotIn(self.decoy.id, ids)
+
+
+class PlantSpeciesPageViewSetWildcardTests(APITestCase):
+    """Wagtail v2 API PlantSpeciesPageViewSet -- plant_species__family__icontains.
+
+    Exercised via a direct ``get_queryset()`` call rather than an HTTP request:
+    ``/api/v2/plants/`` 404s under the project's DRF ``NamespaceVersioning``
+    because this ``PagesAPIViewSet`` subclass does not set
+    ``versioning_class = None`` (unlike the snippet viewsets). Calling
+    ``get_queryset()`` runs the exact production line the fix touched
+    (``plant_species__family__icontains`` traversal) over the
+    ``.live().public().specific()`` base queryset.
+    """
+
+    def setUp(self):
+        cache.clear()
+        root = Page.objects.get(id=1)
+
+        self.target_species = PlantSpecies.objects.create(
+            scientific_name="Page target species",
+            family="Rosa_page",
+        )
+        self.decoy_species = PlantSpecies.objects.create(
+            scientific_name="Page decoy species",
+            family="RosaXpage",
+        )
+
+        self.target_page = PlantSpeciesPage(
+            title="Rosa underscore page",
+            slug="rosa-underscore-page",
+            plant_species=self.target_species,
+            introduction="<p>Target intro.</p>",
+            content_blocks=[],
+        )
+        root.add_child(instance=self.target_page)
+        self.target_page.save_revision().publish()
+
+        self.decoy_page = PlantSpeciesPage(
+            title="Rosa wildcard page",
+            slug="rosa-wildcard-page",
+            plant_species=self.decoy_species,
+            introduction="<p>Decoy intro.</p>",
+            content_blocks=[],
+        )
+        root.add_child(instance=self.decoy_page)
+        self.decoy_page.save_revision().publish()
+
+    def test_family_filter_treats_underscore_as_literal(self):
+        view = PlantSpeciesPageViewSet()
+        view.request = APIRequestFactory().get("/?family=Rosa_")
+        view.args = ()
+        view.kwargs = {}
+        ids = set(view.get_queryset().values_list("id", flat=True))
+        self.assertIn(self.target_page.id, ids)
+        self.assertNotIn(self.decoy_page.id, ids)
+
+
+class PlantSpeciesSearchPercentWildcardTests(APITestCase):
+    """Parity coverage for the OTHER SQL LIKE wildcard, ``%`` (todo 269 review).
+
+    The removed ``escape_search_query`` escaped BOTH ``%`` and ``_``, so ``%``
+    had the identical silent-drop bug. ``_`` is covered per-endpoint above; this
+    pins the ``%`` case for the shared ``__icontains`` mechanism via one
+    representative endpoint. (``\\`` is intentionally not tested separately: the
+    removed util only ever escaped ``%`` and ``_``, never backslash, so ``\\``
+    was never a double-escape vector for this fix.)
+    """
+
+    def setUp(self):
+        cache.clear()
+        self.url = reverse("v1:plant_identification:species-list")
+        # Target contains a literal "%"; the decoy would match only if "%"
+        # acted as a "zero-or-more-chars" SQL wildcard.
+        self.target = PlantSpecies.objects.create(scientific_name="Rosa%alba")
+        self.decoy = PlantSpecies.objects.create(scientific_name="RosaZZalba")
+
+    def test_search_treats_percent_as_literal(self):
+        response = self.client.get(self.url, {"search": "Rosa%"})
+        self.assertEqual(response.status_code, 200)
+        names = {row["scientific_name"] for row in _unwrap(response.data)}
+        # Target returned (fails under the old double-escape bug).
+        self.assertIn("Rosa%alba", names)
+        # Decoy excluded (proves "%" is literal, not a wildcard).
+        self.assertNotIn("RosaZZalba", names)

--- a/backend/apps/plant_identification/views.py
+++ b/backend/apps/plant_identification/views.py
@@ -32,8 +32,6 @@ except ImportError:
 
 import logging
 
-from apps.core.utils.query_sanitization import escape_search_query
-
 from . import constants
 from .models import (
     DiseaseCareInstructions,
@@ -84,7 +82,6 @@ class PlantSpeciesViewSet(viewsets.ReadOnlyModelViewSet):
         # Filter by search query
         search = self.request.query_params.get("search")
         if search:
-            search = escape_search_query(search)
             queryset = queryset.filter(
                 models.Q(scientific_name__icontains=search)
                 | models.Q(common_names__icontains=search)
@@ -94,7 +91,7 @@ class PlantSpeciesViewSet(viewsets.ReadOnlyModelViewSet):
         # Filter by family
         family = self.request.query_params.get("family")
         if family:
-            queryset = queryset.filter(family__icontains=escape_search_query(family))
+            queryset = queryset.filter(family__icontains=family)
 
         return queryset.order_by("scientific_name")
 
@@ -1018,9 +1015,7 @@ class PlantDiseaseDatabaseViewSet(viewsets.ReadOnlyModelViewSet):
 
         search = self.request.query_params.get("search")
         if search:
-            queryset = queryset.filter(
-                disease_name__icontains=escape_search_query(search)
-            )
+            queryset = queryset.filter(disease_name__icontains=search)
 
         return queryset
 
@@ -1189,8 +1184,6 @@ def search_local_plants(request):
     if not query:
         return Response({"error": "Search query (q) is required"}, status=400)
 
-    query = escape_search_query(query)
-
     try:
         # Search auto-stored plants first (highest priority)
         auto_stored = PlantSpecies.objects.filter(
@@ -1247,8 +1240,6 @@ def search_local_diseases(request):
 
     if not query:
         return Response({"error": "Search query (q) is required"}, status=400)
-
-    query = escape_search_query(query)
 
     try:
         # Build query

--- a/todos/archive/269-completed-p2-search-wildcard-double-escaping.md
+++ b/todos/archive/269-completed-p2-search-wildcard-double-escaping.md
@@ -1,5 +1,5 @@
 ---
-status: pending
+status: completed
 priority: p2
 issue_id: "269"
 tags: [backend, database, search, blog, plant_identification]
@@ -103,12 +103,12 @@ first.
 
 ## Acceptance Criteria
 
-- [ ] All 13 listed call sites no longer call `escape_search_query()` ahead
+- [x] All 13 listed call sites no longer call `escape_search_query()` ahead
       of an `icontains`/`istartswith` lookup
-- [ ] Each affected view/endpoint has a test proving a literal `%`/`_`/`\`
+- [x] Each affected view/endpoint has a test proving a literal `%`/`_`/`\`
       in the query still matches the real target row
-- [ ] `apps.blog` and `apps.plant_identification` test suites pass
-- [ ] Decision recorded on whether `escape_search_query()`/
+- [x] `apps.blog` and `apps.plant_identification` test suites pass
+- [x] Decision recorded on whether `escape_search_query()`/
       `escape_search_query_optional()` are still needed anywhere, or should
       be removed
 
@@ -125,6 +125,89 @@ first.
   themselves are intentionally NOT touched here — a code-fix task, not a
   documentation correction, and larger than the docs-only commit it was
   found alongside.
+
+### 2026-07-20 - Started by completing-todos skill (run 2026-07-20-1409)
+
+- Picked up by automated todo-sweep (branch `todo-269-search-wildcard-escaping`,
+  cut off fresh `main` at 3f38157 after PR #474 merged).
+
+### 2026-07-20 - Implemented (run 2026-07-20-1409)
+
+- **AC1** — removed `escape_search_query()` from all 13 call sites across the 6
+  files; passed the (already-stripped, where applicable) raw query straight to
+  the `icontains`/`istartswith` filter. Inline sites → dropped the wrapper;
+  assignment/reassignment sites (`escaped_query`/`safe_query`/`query =
+  escape_search_query(...)`) → removed the intermediate and used the source var.
+  All 6 now-unused `from apps.core.utils.query_sanitization import
+  escape_search_query` imports removed (4 auto-stripped by the formatter, 2
+  removed by hand). `grep escape_search_query apps/` now hits only the util and
+  its own test. `manage.py check` → "System check identified no issues".
+  - Side fix surfaced en route: `search_local_plants` (`views.py:~1192`) had
+    been returning the *escaped* string back to the client as the response's
+    `search_query` field; dropping the reassignment fixes that too.
+- **AC2** — added discriminating regression tests, one per distinct affected
+  view (15 test methods total, incl. a `%`-parity test added during review):
+  `apps/plant_identification/tests/test_search_wildcards.py` (species search +
+  family, disease-db search, search_local_plants, search_local_diseases, the two
+  Wagtail-v2 `endpoints.py` viewsets) and
+  `apps/blog/tests/test_search_wildcards.py` (moderate_comments, admin search,
+  plant suggestions, post-list `?tag=`, public blog-search, the unrouted
+  `search_suggestions` action). Each stores a target row whose field contains a
+  literal `_` (e.g. `Rosa_damascena`) + a decoy (`RosaXdamascena`), searches the
+  `_` literal, and asserts target-returned + decoy-excluded — the shape from
+  `wagtail_forum/.../test_user_search.py::test_search_escapes_sql_wildcards`.
+  - Independently verified the tests are discriminating (not decorative): against
+    real Postgres, `scientific_name__icontains="ZZZ_"` matches the row while
+    `__icontains=escape_search_query("ZZZ_")` (== `"ZZZ\\_"`) matches **0** — so
+    every target-returned assertion genuinely fails under the pre-fix code.
+  - Two Wagtail-v2 endpoints (`/api/v2/plant-species/`, `/api/v2/plants/`) are
+    exercised via a direct `get_queryset()` call rather than HTTP: over HTTP
+    Wagtail's `FieldsFilter` applies an EXACT `family=` match that shadows the
+    viewset's `family__icontains`, and `/api/v2/plants/` 404s under the project's
+    `NamespaceVersioning` (the page viewset doesn't set `versioning_class=None`).
+    Both are pre-existing endpoint quirks unrelated to this fix; `get_queryset()`
+    runs the exact line the fix touched. Noted for a possible future follow-up,
+    NOT changed here (out of scope).
+- **AC3** — `pytest apps/blog/tests/ apps/plant_identification/tests/ --create-db`
+  → **230 passed, 7 skipped** on a fresh test DB (215-test clean baseline + the 15
+  new tests). No pre-existing test regressed (the client-facing `search_query`
+  change touched no existing assertion). Caveat: the Wagtail-page-creating tests
+  read the migration-seeded root via `Page.objects.get(id=1)` (same convention as
+  `apps/blog/tests/test_models.py`); with `--reuse-db` a prior `TransactionTestCase`
+  in the suite truncates that root, so a partial re-run can `DoesNotExist` — run
+  page tests with `--create-db` (CI always runs fresh). Not a defect in this fix.
+
+### 2026-07-20 - Reviewed (code-review-orchestrator, run 2026-07-20-1409)
+
+- 0 critical / 0 high / 0 medium / 1 low. Verification notes all PASS: no dangling
+  `escaped_query`/`safe_query` refs, complete call-site removal, Wagtail-v2
+  `get_queryset()` tests legitimately exercise the fixed line, whitespace-strip
+  behavior unchanged per call site, fix correctness independently reproduced.
+- LOW (test-coverage): tests exercised `_` but not `%`, which had the identical
+  double-escape. **Addressed** (not deferred) — added
+  `PlantSpeciesSearchPercentWildcardTests` (target `Rosa%alba` / decoy `RosaZZalba`,
+  search `Rosa%`). `\\` intentionally NOT tested: the removed util only escaped
+  `%`/`_`, never backslash, so `\\` was never a double-escape vector for this fix.
+- **AC4 — decision: KEEP `escape_search_query()` / `escape_search_query_optional()`,
+  with a corrected docstring.** No production caller remains (only the util + its
+  own `test_query_sanitization.py`). Rationale for keeping over deleting: it is a
+  correct, tested primitive for the genuinely-still-valid case the todo names — a
+  LIKE pattern that BYPASSES the ORM's `PatternLookup` auto-escaping (raw SQL,
+  `.extra()`, a custom `Lookup`); deleting it + its ~200-line test suite is a
+  larger diff for a "fix the double-escape" PR and would force error-prone
+  re-implementation if raw-LIKE escaping is ever needed. The write-time trigger
+  `escape-search-query-before-orm-wildcard-lookup` already guards against
+  reintroducing the misuse. The util's docstring (which previously *taught* the
+  bug — "for Django ORM's icontains, istartswith… ILIKE") was rewritten to warn
+  against that exact usage and document the narrow remaining purpose.
+
+### 2026-07-20 - Completed by completing-todos skill (run 2026-07-20-1409)
+
+- Verification: all 4 acceptance criteria passed with quoted evidence above.
+- Review: code-review-orchestrator — 1 low finding, addressed in-slice (not
+  deferred); 0 blocking.
+- Landing on branch `todo-269-search-wildcard-escaping` (off fresh `main`
+  @3f38157); per-todo PR to follow.
 
 ## Notes
 


### PR DESCRIPTION
## Summary

`escape_search_query()` was called before an `icontains`/`istartswith` filter at **13 call sites across 6 files**. Django's ORM already auto-escapes `%`/`_`/`\` for these lookups (`PatternLookup.process_rhs()`), so escaping first **double-escaped** and silently dropped real matches — a search for `dave_` stopped matching the row `dave_1` (worst case: zero results, no error). This is the follow-up to the 2026-07-14 doc/convention correction (todo 253 slice 4 codification); it fixes the pre-existing call sites the docs-only commit didn't touch.

The removed wrapper was a **no-op for queries without wildcards**, so normal-query behavior is unchanged.

## Changes

- Removed `escape_search_query()` at all 13 sites + the 6 now-unused imports (`apps/blog/{admin_views,api_views,views,api/viewsets}.py`, `apps/plant_identification/{views,api/endpoints}.py`).
- **Side fix:** `search_local_plants` no longer returns the *escaped* string back to the client as the response `search_query` field.
- **AC4 decision:** kept `escape_search_query()`/`escape_search_query_optional()` (no caller remains) as a correct primitive for the non-`PatternLookup` case (raw SQL / `.extra()` / custom `Lookup`); rewrote its docstring, which previously *taught* the bug, to warn against the `icontains` misuse. The `escape-search-query-before-orm-wildcard-lookup` write-time trigger already guards reintroduction.

## Tests

- Added **15 discriminating regression tests** (`apps/{blog,plant_identification}/tests/test_search_wildcards.py`), one per affected view: each stores a target row with a literal `_`/`%` (e.g. `Rosa_damascena`) + a decoy that would match only under wildcard semantics, and asserts target-returned + decoy-excluded — the shape from `wagtail_forum/.../test_user_search.py::test_search_escapes_sql_wildcards`.
- Verified discriminating against real Postgres: `__icontains="ZZZ_"` matches; `__icontains=escape_search_query("ZZZ_")` (`"ZZZ\_"`) matches **0** — so every target assertion genuinely fails under the pre-fix code.
- Two Wagtail-v2 endpoints are exercised via a direct `get_queryset()` call (documented in-file): over HTTP, Wagtail's `FieldsFilter` applies an exact `family=` match that shadows the viewset's `family__icontains`, and `/api/v2/plants/` 404s under `NamespaceVersioning` — both pre-existing quirks unrelated to this fix.

**Both suites pass on a fresh DB: 230 passed, 7 skipped.**

## Review

code-review-orchestrator: 0 critical/high/medium, 1 low (test breadth — only `_` covered) which was **addressed in-slice** by adding a `%`-parity test (`\` was never a double-escape vector — the util only escaped `%`/`_`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)