### PR TITLE
Batch forum reply-notification fan-out into constant enqueues (todo 268)

### DIFF
--- a/backend/apps/forum_host/notifications.py
+++ b/backend/apps/forum_host/notifications.py
@@ -48,7 +48,7 @@ def dispatch(event, **kwargs):
     """
     from django.db import transaction
 
-    from .tasks import send_forum_email, send_forum_push
+    from .tasks import send_forum_email_batch, send_forum_push, send_forum_push_batch
 
     topic = kwargs.get("topic")
     topic_id = getattr(topic, "id", None)
@@ -73,15 +73,18 @@ def dispatch(event, **kwargs):
     def _enqueue_mention_push_for(mentioned, payload):
         from wagtail_forum.models import NotificationVerb
 
-        for recipient in mentioned:
-            try:
-                send_forum_push.delay(NotificationVerb.MENTION, recipient.pk, payload)
-            except Exception:
-                logger.exception(
-                    "[CELERY] forum_host: failed to enqueue push for event=%s user=%s",
-                    "mention",
-                    recipient.pk,
-                )
+        mentioned_pks = [user.pk for user in mentioned]
+        if not mentioned_pks:
+            return
+        try:
+            # One batched enqueue for all mentioned recipients (todo 268).
+            send_forum_push_batch.delay(
+                NotificationVerb.MENTION, mentioned_pks, payload
+            )
+        except Exception:
+            logger.exception(
+                "[CELERY] forum_host: failed to enqueue mention push batch"
+            )
 
     if event == "reply_added":
         post = kwargs.get("post")
@@ -94,28 +97,34 @@ def dispatch(event, **kwargs):
         payload = _build_payload(post)
 
         def _enqueue_push():
-            for recipient in reply_recipients:
+            # One batched enqueue for all reply recipients + one for mentions
+            # (todo 268) — constant enqueue count regardless of subscriber count,
+            # instead of one .delay() per recipient blocking the request thread.
+            reply_recipient_pks = [user.pk for user in reply_recipients]
+            if reply_recipient_pks:
                 try:
-                    send_forum_push.delay(event, recipient.pk, payload)
+                    send_forum_push_batch.delay(event, reply_recipient_pks, payload)
                 except Exception:
                     logger.exception(
-                        "[CELERY] forum_host: failed to enqueue push for event=%s user=%s",
+                        "[CELERY] forum_host: failed to enqueue reply push batch"
+                        " for event=%s",
                         event,
-                        recipient.pk,
                     )
             _enqueue_mention_push_for(mentioned, payload)
 
         def _enqueue_email():
             # Mentioned users get bell + push only, not email, this slice
-            # (todo 253 slice 4 scope decision) — loop reply_recipients only.
-            for recipient in reply_recipients:
+            # (todo 253 slice 4 scope decision) — reply_recipients only. One
+            # batched enqueue for the whole recipient list (todo 268).
+            reply_recipient_pks = [user.pk for user in reply_recipients]
+            if reply_recipient_pks:
                 try:
-                    send_forum_email.delay(event, recipient.pk, payload)
+                    send_forum_email_batch.delay(event, reply_recipient_pks, payload)
                 except Exception:
                     logger.exception(
-                        "[CELERY] forum_host: failed to enqueue email for event=%s user=%s",
+                        "[CELERY] forum_host: failed to enqueue reply email batch"
+                        " for event=%s",
                         event,
-                        recipient.pk,
                     )
 
         try:

--- a/backend/apps/forum_host/tasks.py
+++ b/backend/apps/forum_host/tasks.py
@@ -79,6 +79,31 @@ def _notification_content(event: str, data: dict) -> tuple[str, str] | None:
     return None
 
 
+def _send_fcm_message(fcm, token: str, str_data: dict, content, event: str):
+    """Build and send one FCM message (data payload + optional tray notification).
+
+    Shared by send_forum_push (single) and send_forum_push_batch (todo 268) so
+    the collapse-key / notification-hybrid construction can never drift between
+    the two shapes. Raises on send failure; the caller classifies transient vs.
+    permanent (see _is_permanent_fcm_error) and decides whether to retry.
+    """
+    message_kwargs = {"data": str_data, "token": token}
+    if content is not None:
+        title, body = content
+        # Stable collapse key: a retry after an accepted-but-timed-out send
+        # REPLACES the tray entry instead of stacking a duplicate. Deliberately
+        # per-EVENT-TYPE, not per-post (FCM keeps at most 4 collapse keys pending
+        # per offline device). See docs/rules/celery.md.
+        collapse_key = f"forum-{event}"
+        message_kwargs["notification"] = fcm.Notification(title=title, body=body)
+        message_kwargs["android"] = fcm.AndroidConfig(collapse_key=collapse_key)
+        message_kwargs["apns"] = fcm.APNSConfig(
+            headers={"apns-collapse-id": collapse_key}
+        )
+    message = fcm.Message(**message_kwargs)
+    return fcm.send(message)
+
+
 @shared_task(bind=True, max_retries=3, default_retry_delay=30)
 def send_forum_push(self, event: str, recipient_user_id: int, data: dict):
     """Send a single FCM data message for a forum event.
@@ -137,26 +162,7 @@ def send_forum_push(self, event: str, recipient_user_id: int, data: dict):
     content = _notification_content(event, data)
 
     try:
-        message_kwargs = {"data": str_data, "token": token}
-        if content is not None:
-            title, body = content
-            # Stable collapse key: a retry after an accepted-but-timed-out
-            # send REPLACES the tray entry instead of stacking a duplicate
-            # visible notification (idempotency, docs/rules/celery.md).
-            # Deliberately per-EVENT-TYPE, not per-post: FCM keeps at most 4
-            # distinct collapse keys pending per offline device, so unique
-            # per-post keys would silently drop all but 4 notifications
-            # accumulated overnight (review sweep). Collapsing multiple
-            # replies into the latest tray entry is the standard tradeoff —
-            # the bell remains the complete record.
-            collapse_key = f"forum-{event}"
-            message_kwargs["notification"] = fcm.Notification(title=title, body=body)
-            message_kwargs["android"] = fcm.AndroidConfig(collapse_key=collapse_key)
-            message_kwargs["apns"] = fcm.APNSConfig(
-                headers={"apns-collapse-id": collapse_key}
-            )
-        message = fcm.Message(**message_kwargs)
-        response = fcm.send(message)
+        response = _send_fcm_message(fcm, token, str_data, content, event)
         logger.info(
             "[FCM] forum.%s sent to user=%s: %s", event, recipient_user_id, response
         )
@@ -186,39 +192,116 @@ def send_forum_push(self, event: str, recipient_user_id: int, data: dict):
 
 
 @shared_task(autoretry_for=(OperationalError,), retry_backoff=True, max_retries=3)
-def send_forum_email(event: str, recipient_user_id: int, data: dict):
-    """Send a single forum notification email via NotificationService.
+def send_forum_push_batch(event: str, recipient_user_ids: list[int], data: dict):
+    """Fan out one forum FCM push to many recipients from a SINGLE enqueue (todo 268).
 
-    Enqueued from forum_host/notifications.py via transaction.on_commit,
-    mirroring send_forum_push, so a rolled-back publish never sends an email.
+    forum_host/notifications.py used to call send_forum_push.delay() once per
+    subscriber inside transaction.on_commit — N sequential broker round-trips
+    blocking the reply request, plus N worker executions each re-fetching the
+    same rows. This variant is enqueued once with the full recipient list: one
+    bulk ForumProfile fetch, then a server-side send loop.
 
-    Retry is narrowly scoped to OperationalError (a transient DB error during
-    the User/Post fetches below), not a broad catch-all: unlike push's
-    fcm.send() (which raises on a transient FCM error), this task's actual
-    send call — NotificationService.send_forum_reply_notification() ->
-    EmailService.send_email() — swallows every send/render failure internally
-    (ConnectionError, TemplateDoesNotExist, a blanket Exception) and returns a
-    bool, so it can never raise; wrapping IT in retry would be untested dead
-    code. The DB fetches below CAN genuinely raise OperationalError on a
-    connection blip, and per docs/rules/celery.md ("every task declares
-    retry config... never leave a network-touching task with default no
-    retries") that failure must not silently drop the notification — the
-    DoesNotExist/ValueError/TypeError branches return early first, so
-    autoretry only ever fires on the one real transient-failure class.
+    Per-recipient transient FCM failures are handed off to the single-recipient
+    send_forum_push task (which owns the backoff/retry logic) rather than
+    retrying the whole batch — a batch-level retry would re-send to EVERY
+    recipient (the collapse key dedupes the tray, not the wasted work). Only the
+    rare failure path re-enqueues; the common all-success path stays at one
+    enqueue. autoretry_for=(OperationalError,) covers only the pre-send bulk
+    fetch.
 
     Args:
-        event: forum event name. Only "reply_added" is wired (todo 253 slice
-               2, H1); mention/moderation/digest are later slices.
-        recipient_user_id: pk of the User to email.
-        data: the same payload dict shared with send_forum_push — carries
-              "post_id" (str). The reply Post is re-fetched here (rather than
-              embedding rendered content in the FCM-shared payload) so push's
-              data stays minimal and the email reflects the post at send time.
+        event: forum event name (see send_forum_push).
+        recipient_user_ids: pks of the Users to notify.
+        data: FCM data payload (values coerced to str).
+    """
+    from apps.garden.firebase_config import get_fcm_client, is_firebase_available
+    from wagtail_forum.models import ForumProfile
+
+    if not recipient_user_ids:
+        return
+
+    if not is_firebase_available():
+        logger.debug("[FCM] Firebase not configured — skipping forum push (%s)", event)
+        return
+
+    fcm = get_fcm_client()
+    if fcm is None:
+        logger.error("[FCM] FCM client unavailable — cannot send forum push")
+        return
+
+    # One bulk fetch instead of N: the profile row carries both the recipient
+    # (forum_notifications) and the fcm_token. A user with no ForumProfile has
+    # no token, so the single-task path would skip them too — omitting them
+    # here is equivalent.
+    profiles = ForumProfile.objects.filter(
+        user_id__in=recipient_user_ids
+    ).select_related("user")
+
+    str_data = {k: str(v) for k, v in data.items()}
+    str_data["event"] = event
+    content = _notification_content(event, data)
+
+    for profile in profiles:
+        user = profile.user
+        if getattr(user, "forum_notifications", True) is not True:
+            continue
+        if not profile.fcm_token:
+            continue
+        try:
+            response = _send_fcm_message(
+                fcm, profile.fcm_token, str_data, content, event
+            )
+            logger.info("[FCM] forum.%s sent to user=%s: %s", event, user.pk, response)
+        except Exception as exc:
+            if _is_permanent_fcm_error(exc):
+                logger.warning(
+                    "[FCM] forum.%s send failed permanently (user=%s): %s"
+                    " — not retrying",
+                    event,
+                    user.pk,
+                    exc,
+                )
+                continue
+            # Transient: hand off to the retry-capable single-recipient task
+            # rather than retrying (and re-sending) the whole batch.
+            logger.warning(
+                "[FCM] forum.%s send failed (user=%s): %s — re-enqueuing single",
+                event,
+                user.pk,
+                exc,
+            )
+            send_forum_push.delay(event, user.pk, data)
+
+
+@shared_task(autoretry_for=(OperationalError,), retry_backoff=True, max_retries=3)
+def send_forum_email_batch(event: str, recipient_user_ids: list[int], data: dict):
+    """Send forum reply-notification emails to many recipients from a SINGLE
+    enqueue (todo 268), replacing the per-recipient send_forum_email fan-out.
+
+    The Post and all recipient Users are fetched ONCE up front, then the loop
+    only calls NotificationService — whose send path
+    (EmailService.send_email()) swallows every send/render failure and returns a
+    bool, so it can never raise. This ordering is load-bearing: email has no
+    collapse-key dedup, so autoretry_for=(OperationalError,) must be able to
+    fire ONLY before any email is sent, or a transient-DB retry would
+    double-email everyone. All OperationalError-raising DB access happens in the
+    up-front fetch; the send loop does none.
+
+    Args:
+        event: only "reply_added" is wired (todo 253 slice 2, H1); mention/
+               moderation/digest are later slices.
+        recipient_user_ids: pks of the Users to email.
+        data: the shared payload dict — carries "post_id" (str). The reply Post
+              is fetched here (once for the batch) so push's data stays minimal
+              and the email reflects the post at send time.
     """
     if event != "reply_added":
         logger.debug(
             "[EMAIL] forum email skipped — event=%s not implemented yet", event
         )
+        return
+
+    if not recipient_user_ids:
         return
 
     from apps.core.services.notification_service import NotificationService
@@ -230,27 +313,6 @@ def send_forum_email(event: str, recipient_user_id: int, data: dict):
     from .constants import FORUM_EMAIL_EXCERPT_MAX_CHARS
 
     User = get_user_model()
-
-    try:
-        user = User.objects.get(pk=recipient_user_id)
-    except User.DoesNotExist:
-        logger.warning(
-            "[EMAIL] forum email skipped — user %s not found", recipient_user_id
-        )
-        return
-
-    if not user.email:
-        # EmailService.send_email() silently no-ops for a blank recipient
-        # (Django's EmailMessage.recipients() filters out falsy addresses,
-        # send() then returns 0) but still logs "sent successfully" and
-        # returns True — it does not surface the 0-recipients case as a
-        # failure. Guard here so a user with no email on file gets a clear
-        # skip log instead of a misleading success one.
-        logger.warning(
-            "[EMAIL] forum email skipped — user %s has no email on file",
-            recipient_user_id,
-        )
-        return
 
     try:
         post_id = int(data.get("post_id", ""))
@@ -265,18 +327,30 @@ def send_forum_email(event: str, recipient_user_id: int, data: dict):
         logger.warning("[EMAIL] forum email skipped — post %s not found", post_id)
         return
 
+    # Materialize up front so a transient OperationalError can only fire here,
+    # before any email is sent (see the docstring's retry-safety note).
+    users = list(User.objects.filter(pk__in=recipient_user_ids))
+
     topic = post.topic
     topic_url = f"{settings.SITE_URL}{topic.get_absolute_url()}"
     author_name = post.author.display_name if post.author else "[deleted]"
     excerpt = plain_text_excerpt(post.body, FORUM_EMAIL_EXCERPT_MAX_CHARS)
+    service = NotificationService()
 
-    sent = NotificationService().send_forum_reply_notification(
-        user=user,
-        topic_title=topic.title,
-        reply_author=author_name,
-        reply_excerpt=excerpt,
-        topic_url=topic_url,
-    )
-    logger.info(
-        "[EMAIL] forum.%s email to user=%s: sent=%s", event, recipient_user_id, sent
-    )
+    for user in users:
+        if not user.email:
+            # EmailService.send_email() silently no-ops for a blank recipient
+            # but still returns True (todo 267) — skip explicitly so a user with
+            # no email on file gets a clear skip log, not a misleading success.
+            logger.warning(
+                "[EMAIL] forum email skipped — user %s has no email on file", user.pk
+            )
+            continue
+        sent = service.send_forum_reply_notification(
+            user=user,
+            topic_title=topic.title,
+            reply_author=author_name,
+            reply_excerpt=excerpt,
+            topic_url=topic_url,
+        )
+        logger.info("[EMAIL] forum.%s email to user=%s: sent=%s", event, user.pk, sent)

--- a/backend/apps/forum_host/tests/test_signals.py
+++ b/backend/apps/forum_host/tests/test_signals.py
@@ -65,11 +65,11 @@ def test_reply_added_enqueues_push_for_topic_author(django_capture_on_commit_cal
     TopicSubscription.subscribe(topic_author, topic)
 
     with (
-        patch("apps.forum_host.tasks.send_forum_push.delay") as mock_delay,
+        patch("apps.forum_host.tasks.send_forum_push_batch.delay") as mock_delay,
         # The reply_added success path also enqueues an email (todo 253 slice
         # 2, H1) via the same on_commit mechanism; mock it so this push-only
         # test doesn't attempt a real broker publish.
-        patch("apps.forum_host.tasks.send_forum_email.delay"),
+        patch("apps.forum_host.tasks.send_forum_email_batch.delay"),
     ):
         from apps.forum_host.notifications import dispatch
 
@@ -84,7 +84,9 @@ def test_reply_added_enqueues_push_for_topic_author(django_capture_on_commit_cal
     mock_delay.assert_called_once()
     call_args = mock_delay.call_args
     assert call_args.args[0] == "reply_added"
-    assert call_args.args[1] == topic_author.pk
+    # The recipient arg is now a BATCH list (todo 268): one enqueue for the
+    # whole reply fan-out, not one .delay() per subscriber.
+    assert call_args.args[1] == [topic_author.pk]
     # actor_name feeds the FCM tray body line (todo 253 slice 6), resolved
     # via the host User model's display_name — the same naming policy the
     # email channel already uses.
@@ -113,8 +115,8 @@ def test_reply_added_enqueues_email_for_topic_author(
     TopicSubscription.subscribe(topic_author, topic)
 
     with (
-        patch("apps.forum_host.tasks.send_forum_push.delay"),
-        patch("apps.forum_host.tasks.send_forum_email.delay") as mock_delay,
+        patch("apps.forum_host.tasks.send_forum_push_batch.delay"),
+        patch("apps.forum_host.tasks.send_forum_email_batch.delay") as mock_delay,
     ):
         from apps.forum_host.notifications import dispatch
 
@@ -125,7 +127,8 @@ def test_reply_added_enqueues_email_for_topic_author(
     mock_delay.assert_called_once()
     call_args = mock_delay.call_args
     assert call_args.args[0] == "reply_added"
-    assert call_args.args[1] == topic_author.pk
+    # One batched email enqueue for the whole reply fan-out (todo 268).
+    assert call_args.args[1] == [topic_author.pk]
     assert call_args.args[2]["post_id"] == str(post.pk)
 
 
@@ -152,8 +155,8 @@ def test_reply_added_fans_out_to_all_subscribers_excluding_replier(
     TopicSubscription.subscribe(replier, topic)
 
     with (
-        patch("apps.forum_host.tasks.send_forum_push.delay") as mock_push,
-        patch("apps.forum_host.tasks.send_forum_email.delay") as mock_email,
+        patch("apps.forum_host.tasks.send_forum_push_batch.delay") as mock_push,
+        patch("apps.forum_host.tasks.send_forum_email_batch.delay") as mock_email,
     ):
         from apps.forum_host.notifications import dispatch
 
@@ -166,10 +169,18 @@ def test_reply_added_fans_out_to_all_subscribers_excluding_replier(
     )
     assert notified == {topic_author.pk, subscriber_b.pk}
 
-    pushed = {c.args[1] for c in mock_push.call_args_list}
-    emailed = {c.args[1] for c in mock_email.call_args_list}
+    # The reply fan-out is now a SINGLE batched enqueue each (todo 268): the
+    # whole recipient set rides in one list arg, not one .delay() per user.
+    mock_push.assert_called_once()
+    mock_email.assert_called_once()
+    pushed = set(mock_push.call_args.args[1])
+    emailed = set(mock_email.call_args.args[1])
     assert pushed == {topic_author.pk, subscriber_b.pk}
     assert emailed == {topic_author.pk, subscriber_b.pk}
+    # The replier is excluded from their OWN reply's fan-out even though they
+    # subscribed — the discriminating property this test exists to pin.
+    assert replier.pk not in pushed
+    assert replier.pk not in emailed
 
 
 @pytest.mark.django_db
@@ -196,8 +207,8 @@ def test_reply_added_notifies_subscribers_when_topic_author_is_deleted(
     assert topic.author_id is None
 
     with (
-        patch("apps.forum_host.tasks.send_forum_push.delay") as mock_push,
-        patch("apps.forum_host.tasks.send_forum_email.delay"),
+        patch("apps.forum_host.tasks.send_forum_push_batch.delay") as mock_push,
+        patch("apps.forum_host.tasks.send_forum_email_batch.delay"),
     ):
         from apps.forum_host.notifications import dispatch
 
@@ -207,7 +218,7 @@ def test_reply_added_notifies_subscribers_when_topic_author_is_deleted(
 
     assert Notification.objects.filter(recipient=subscriber, post=post).exists()
     mock_push.assert_called_once()
-    assert mock_push.call_args.args[1] == subscriber.pk
+    assert mock_push.call_args.args[1] == [subscriber.pk]
 
 
 @pytest.mark.django_db
@@ -226,8 +237,8 @@ def test_reply_added_auto_subscribes_the_replier(django_capture_on_commit_callba
     )
 
     with (
-        patch("apps.forum_host.tasks.send_forum_push.delay"),
-        patch("apps.forum_host.tasks.send_forum_email.delay"),
+        patch("apps.forum_host.tasks.send_forum_push_batch.delay"),
+        patch("apps.forum_host.tasks.send_forum_email_batch.delay"),
     ):
         from apps.forum_host.notifications import dispatch
 
@@ -290,8 +301,8 @@ def test_reply_added_marks_the_repliers_own_topic_as_read(
     )
 
     with (
-        patch("apps.forum_host.tasks.send_forum_push.delay"),
-        patch("apps.forum_host.tasks.send_forum_email.delay"),
+        patch("apps.forum_host.tasks.send_forum_push_batch.delay"),
+        patch("apps.forum_host.tasks.send_forum_email_batch.delay"),
     ):
         from apps.forum_host.notifications import dispatch
 
@@ -384,8 +395,8 @@ def test_reply_added_read_marker_keeps_pace_with_real_publish_timing(
     topic.save_revision().publish()
 
     with (
-        patch("apps.forum_host.tasks.send_forum_push.delay"),
-        patch("apps.forum_host.tasks.send_forum_email.delay"),
+        patch("apps.forum_host.tasks.send_forum_push_batch.delay"),
+        patch("apps.forum_host.tasks.send_forum_email_batch.delay"),
     ):
         reply = Post.objects.create(topic=topic, author=replier)
         with django_capture_on_commit_callbacks(execute=True):
@@ -430,8 +441,8 @@ def test_reply_added_write_path_query_count_is_independent_of_subscriber_count(
         post = Post.objects.create(topic=topic, author=replier)
 
         with (
-            patch("apps.forum_host.tasks.send_forum_push.delay"),
-            patch("apps.forum_host.tasks.send_forum_email.delay"),
+            patch("apps.forum_host.tasks.send_forum_push_batch.delay"),
+            patch("apps.forum_host.tasks.send_forum_email_batch.delay"),
         ):
             from apps.forum_host.notifications import dispatch
 
@@ -461,8 +472,8 @@ def test_reply_added_does_not_notify_for_self_reply(django_capture_on_commit_cal
     TopicSubscription.subscribe(author, topic)
 
     with (
-        patch("apps.forum_host.tasks.send_forum_push.delay") as mock_push,
-        patch("apps.forum_host.tasks.send_forum_email.delay") as mock_email,
+        patch("apps.forum_host.tasks.send_forum_push_batch.delay") as mock_push,
+        patch("apps.forum_host.tasks.send_forum_email_batch.delay") as mock_email,
     ):
         from apps.forum_host.notifications import dispatch
 
@@ -540,13 +551,13 @@ def test_reply_added_swallows_push_delay_failure(
 
     with (
         patch(
-            "apps.forum_host.tasks.send_forum_push.delay",
+            "apps.forum_host.tasks.send_forum_push_batch.delay",
             side_effect=RuntimeError("broker unavailable"),
         ) as mock_delay,
         # The reply_added success path also enqueues an email (todo 253 slice
         # 2, H1) via the same on_commit mechanism; mock it so this push-only
         # test doesn't attempt a real broker publish.
-        patch("apps.forum_host.tasks.send_forum_email.delay"),
+        patch("apps.forum_host.tasks.send_forum_email_batch.delay"),
     ):
         from apps.forum_host.notifications import dispatch
 
@@ -558,7 +569,9 @@ def test_reply_added_swallows_push_delay_failure(
                 dispatch("reply_added", topic=topic, post=post)  # must not raise
 
     mock_delay.assert_called_once()
-    assert "failed to enqueue push" in caplog.text
+    # The batch enqueue logs a batch-specific message now (todo 268) — the
+    # single-recipient "failed to enqueue push" wording is gone from this path.
+    assert "failed to enqueue reply push batch" in caplog.text
 
 
 @pytest.mark.django_db
@@ -578,11 +591,11 @@ def test_reply_added_persists_notification_row(django_capture_on_commit_callback
     post = Post.objects.create(topic=topic, author=replier)
 
     with (
-        patch("apps.forum_host.tasks.send_forum_push.delay"),
+        patch("apps.forum_host.tasks.send_forum_push_batch.delay"),
         # The reply_added success path also enqueues an email (todo 253 slice
         # 2, H1) via the same on_commit mechanism; mock it so this
         # notification-row test doesn't attempt a real broker publish.
-        patch("apps.forum_host.tasks.send_forum_email.delay"),
+        patch("apps.forum_host.tasks.send_forum_email_batch.delay"),
     ):
         from apps.forum_host.notifications import dispatch
 
@@ -712,8 +725,8 @@ def test_reply_mentioning_a_user_creates_mention_notification(
     )
 
     with (
-        patch("apps.forum_host.tasks.send_forum_push.delay") as mock_push,
-        patch("apps.forum_host.tasks.send_forum_email.delay") as mock_email,
+        patch("apps.forum_host.tasks.send_forum_push_batch.delay") as mock_push,
+        patch("apps.forum_host.tasks.send_forum_email_batch.delay") as mock_email,
     ):
         from apps.forum_host.notifications import dispatch
 
@@ -728,7 +741,9 @@ def test_reply_mentioning_a_user_creates_mention_notification(
     notification = Notification.objects.get(recipient=mentioned, post=post)
     assert notification.verb == NotificationVerb.MENTION
 
-    mention_pushes = [c for c in mock_push.call_args_list if c.args[1] == mentioned.pk]
+    # The mention push is now a batched enqueue (todo 268): args[1] is a
+    # recipient LIST, so membership replaces the scalar-pk equality check.
+    mention_pushes = [c for c in mock_push.call_args_list if mentioned.pk in c.args[1]]
     assert len(mention_pushes) == 1
     assert mention_pushes[0].args[0] == "mention"
     # No other subscribers exist in this fixture, and mentioned users get
@@ -761,8 +776,8 @@ def test_reply_mention_suppresses_duplicate_subscriber_notification(
     TopicSubscription.subscribe(plain_subscriber, topic)
 
     with (
-        patch("apps.forum_host.tasks.send_forum_push.delay") as mock_push,
-        patch("apps.forum_host.tasks.send_forum_email.delay") as mock_email,
+        patch("apps.forum_host.tasks.send_forum_push_batch.delay") as mock_push,
+        patch("apps.forum_host.tasks.send_forum_email_batch.delay") as mock_email,
     ):
         from apps.forum_host.notifications import dispatch
 
@@ -782,12 +797,17 @@ def test_reply_mention_suppresses_duplicate_subscriber_notification(
         == NotificationVerb.REPLY
     )
 
-    pushes_to_both = [c for c in mock_push.call_args_list if c.args[1] == both.pk]
+    # args[1] is a batched recipient LIST now (todo 268) — `both` must appear
+    # in exactly one enqueue and it must be the mention one.
+    pushes_to_both = [c for c in mock_push.call_args_list if both.pk in c.args[1]]
     assert len(pushes_to_both) == 1
     assert pushes_to_both[0].args[0] == "mention"
     # `both` is suppressed into the mention-only path (no email); the plain
-    # subscriber is untouched by suppression and still gets emailed.
-    emailed = {c.args[1] for c in mock_email.call_args_list}
+    # subscriber is untouched by suppression and still gets emailed. The reply
+    # email is one batched enqueue, so union its recipient list(s).
+    emailed = set()
+    for c in mock_email.call_args_list:
+        emailed.update(c.args[1])
     assert emailed == {plain_subscriber.pk}
 
 
@@ -803,8 +823,8 @@ def test_reply_mention_excludes_self_mention(django_capture_on_commit_callbacks)
     )
 
     with (
-        patch("apps.forum_host.tasks.send_forum_push.delay"),
-        patch("apps.forum_host.tasks.send_forum_email.delay"),
+        patch("apps.forum_host.tasks.send_forum_push_batch.delay"),
+        patch("apps.forum_host.tasks.send_forum_email_batch.delay"),
     ):
         from apps.forum_host.notifications import dispatch
 
@@ -843,8 +863,8 @@ def test_reply_mention_on_restricted_board_does_not_notify(
     )
 
     with (
-        patch("apps.forum_host.tasks.send_forum_push.delay") as mock_push,
-        patch("apps.forum_host.tasks.send_forum_email.delay"),
+        patch("apps.forum_host.tasks.send_forum_push_batch.delay") as mock_push,
+        patch("apps.forum_host.tasks.send_forum_email_batch.delay"),
     ):
         from apps.forum_host.notifications import dispatch
 
@@ -859,7 +879,10 @@ def test_reply_mention_on_restricted_board_does_not_notify(
     assert not Notification.objects.filter(
         recipient=mentioned, post=post, verb=NotificationVerb.MENTION
     ).exists()
-    assert all(c.args[1] != mentioned.pk for c in mock_push.call_args_list)
+    # args[1] is a batched recipient LIST now (todo 268) — the mentioned user
+    # must not appear in ANY enqueued batch's recipient list. (A `!=` scalar
+    # check would be trivially true against a list and silently gut this test.)
+    assert all(mentioned.pk not in c.args[1] for c in mock_push.call_args_list)
 
 
 @pytest.mark.django_db
@@ -878,7 +901,7 @@ def test_topic_created_mentioning_a_user_notifies_via_opening_post(
         board=board, title="TM5", slug="t-m5", author=topic_author
     )
 
-    with patch("apps.forum_host.tasks.send_forum_push.delay") as mock_push:
+    with patch("apps.forum_host.tasks.send_forum_push_batch.delay") as mock_push:
         from apps.forum_host.notifications import dispatch
 
         opening = Post.objects.create(
@@ -892,7 +915,9 @@ def test_topic_created_mentioning_a_user_notifies_via_opening_post(
 
     notification = Notification.objects.get(recipient=mentioned, post=opening)
     assert notification.verb == NotificationVerb.MENTION
-    mention_pushes = [c for c in mock_push.call_args_list if c.args[1] == mentioned.pk]
+    # The mention push is a batched enqueue (todo 268): args[1] is a recipient
+    # LIST, so membership replaces the scalar-pk equality check.
+    mention_pushes = [c for c in mock_push.call_args_list if mentioned.pk in c.args[1]]
     assert len(mention_pushes) == 1
     assert mention_pushes[0].args[0] == "mention"
 
@@ -937,8 +962,8 @@ def test_mention_resolution_query_count_is_independent_of_mention_count(
         )
 
         with (
-            patch("apps.forum_host.tasks.send_forum_push.delay"),
-            patch("apps.forum_host.tasks.send_forum_email.delay"),
+            patch("apps.forum_host.tasks.send_forum_push_batch.delay"),
+            patch("apps.forum_host.tasks.send_forum_email_batch.delay"),
         ):
             from apps.forum_host.notifications import dispatch
 
@@ -950,3 +975,85 @@ def test_mention_resolution_query_count_is_independent_of_mention_count(
     few = _dispatch_mentions(1, "mqc-few")
     many = _dispatch_mentions(5, "mqc-many")
     assert few == many
+
+
+# ---- batch fan-out invariant (todo 268, AC3) --------------------------------
+
+
+@pytest.mark.django_db
+def test_reply_added_enqueue_count_is_constant_regardless_of_subscriber_count(
+    django_capture_on_commit_callbacks,
+):
+    """AC3 (todo 268): the reply fan-out must enqueue a CONSTANT number of
+    Celery tasks — exactly one push-batch + one email-batch — no matter how
+    many subscribers the topic has. This pins the whole todo: the pre-batch
+    code enqueued one .delay() per recipient, so the enqueue count scaled
+    linearly with N and blocked the reply request thread on N broker
+    round-trips. Proven by dispatching an identical reply against N=1 and
+    N=50 subscribers and asserting the enqueue counts are identical (and 1) —
+    AND that the single recipient-list arg for N=50 carries all 50 pks, so the
+    collapse is a genuine batch, not a silent drop of recipients."""
+
+    def _dispatch_reply(n_subscribers, slug):
+        topic_author = User.objects.create_user(username=f"const-author-{slug}")
+        root = Page.objects.get(id=1)
+        index = root.add_child(
+            instance=ForumIndex(title=f"ForumConst{slug}", slug=f"forum-const-{slug}")
+        )
+        board = index.add_child(
+            instance=ForumBoard(
+                title=f"GeneralConst{slug}", slug=f"general-const-{slug}"
+            )
+        )
+        topic = Topic.objects.create(
+            board=board, title="TC", slug=f"t-const-{slug}", author=topic_author
+        )
+        # Exactly N recipients: subscribe only these fresh users. topic_author
+        # is deliberately NOT subscribed, and the replier is auto-subscribed
+        # but excluded from their own reply — so the recipient set is precisely
+        # the N subscribers.
+        subscriber_pks = set()
+        for i in range(n_subscribers):
+            sub = User.objects.create_user(username=f"const-sub-{slug}-{i}")
+            TopicSubscription.subscribe(sub, topic)
+            subscriber_pks.add(sub.pk)
+        replier = User.objects.create_user(username=f"const-replier-{slug}")
+        # A plain reply with NO @mentions — a mention would fire a SECOND
+        # push-batch (NotificationVerb.MENTION) and break the "exactly one
+        # push-batch" invariant this test pins.
+        post = Post.objects.create(topic=topic, author=replier)
+
+        with (
+            patch(
+                "apps.forum_host.tasks.send_forum_push_batch.delay"
+            ) as mock_push_batch,
+            patch(
+                "apps.forum_host.tasks.send_forum_email_batch.delay"
+            ) as mock_email_batch,
+        ):
+            from apps.forum_host.notifications import dispatch
+
+            with django_capture_on_commit_callbacks(execute=True):
+                dispatch("reply_added", topic=topic, post=post)
+
+        return mock_push_batch, mock_email_batch, subscriber_pks
+
+    push_1, email_1, _ = _dispatch_reply(1, "one")
+    push_50, email_50, subscriber_pks_50 = _dispatch_reply(50, "fifty")
+
+    # Enqueue count is CONSTANT across N — exactly one push-batch + one
+    # email-batch for the reply fan-out, never scaling with subscriber count.
+    assert push_1.call_count == 1
+    assert email_1.call_count == 1
+    assert push_50.call_count == 1
+    assert email_50.call_count == 1
+    # ...and identical between N=1 and N=50 (the invariant stated as equality,
+    # not just as a fixed literal).
+    assert push_1.call_count == push_50.call_count
+    assert email_1.call_count == email_50.call_count
+
+    # The batch did NOT drop recipients to hit a constant count: the single
+    # recipient-list arg for N=50 must contain all 50 subscriber pks — batched,
+    # not lost.
+    assert set(push_50.call_args.args[1]) == subscriber_pks_50
+    assert set(email_50.call_args.args[1]) == subscriber_pks_50

--- a/backend/apps/forum_host/tests/test_tasks.py
+++ b/backend/apps/forum_host/tests/test_tasks.py
@@ -1,5 +1,6 @@
-"""Unit tests for forum_host.tasks.send_forum_push (Issue 14) and
-send_forum_email (todo 253 slice 2, H1).
+"""Unit tests for forum_host.tasks: send_forum_push (Issue 14),
+send_forum_push_batch and send_forum_email_batch (todo 268 batched fan-out,
+replacing the removed per-recipient send_forum_email).
 
 All tests mock the FCM client and Firebase availability check so they
 run without Firebase credentials in CI.
@@ -330,7 +331,13 @@ def test_send_forum_push_backoff_countdown_values(prior_retries, expected_countd
     assert mock_retry.call_args.kwargs["countdown"] == expected_countdown
 
 
-# ---- send_forum_email tests (todo 253 slice 2, H1) ---------------------------
+# ---- send_forum_email_batch tests (todo 268 batched fan-out; behavior H1) ----
+#
+# The single-recipient send_forum_email was removed (todo 268): the reply
+# fan-out now enqueues ONE send_forum_email_batch(event, [pks], data) instead
+# of N send_forum_email.delay() calls. These tests call the batch task directly
+# with a single-element recipient list, preserving each original test's
+# discriminating intent.
 #
 # Unlike push, these assert on RENDERED EMAIL CONTENT (mail.outbox[0].subject /
 # .body), not just "an email was sent" — this is the one thing that catches
@@ -386,12 +393,12 @@ def _make_reply(slug_prefix, author=None):
 
 @pytest.mark.django_db
 def test_send_forum_email_sends_reply_notification():
-    from apps.forum_host.tasks import send_forum_email
+    from apps.forum_host.tasks import send_forum_email_batch
     from django.core import mail
 
     topic_author, board, topic, post = _make_reply("emailok")
 
-    send_forum_email("reply_added", topic_author.pk, {"post_id": str(post.pk)})
+    send_forum_email_batch("reply_added", [topic_author.pk], {"post_id": str(post.pk)})
 
     assert len(mail.outbox) == 1
     sent = mail.outbox[0]
@@ -424,33 +431,33 @@ def test_send_forum_email_sends_reply_notification():
 
 @pytest.mark.django_db
 def test_send_forum_email_skips_when_forum_notifications_off():
-    from apps.forum_host.tasks import send_forum_email
+    from apps.forum_host.tasks import send_forum_email_batch
     from django.core import mail
 
     topic_author, _, _, post = _make_reply("emailoptout")
     topic_author.forum_notifications = False
     topic_author.save()
 
-    send_forum_email("reply_added", topic_author.pk, {"post_id": str(post.pk)})
+    send_forum_email_batch("reply_added", [topic_author.pk], {"post_id": str(post.pk)})
 
     assert mail.outbox == []
 
 
 @pytest.mark.django_db
 def test_send_forum_email_skips_for_nonexistent_user():
-    from apps.forum_host.tasks import send_forum_email
+    from apps.forum_host.tasks import send_forum_email_batch
     from django.core import mail
 
     _, _, _, post = _make_reply("emailnouser")
 
-    send_forum_email("reply_added", 999999, {"post_id": str(post.pk)})
+    send_forum_email_batch("reply_added", [999999], {"post_id": str(post.pk)})
 
     assert mail.outbox == []
 
 
 @pytest.mark.django_db
 def test_send_forum_email_skips_when_recipient_has_no_email():
-    from apps.forum_host.tasks import send_forum_email
+    from apps.forum_host.tasks import send_forum_email_batch
     from django.core import mail
 
     topic_author, _, _, post = _make_reply("emailnoaddr")
@@ -461,26 +468,26 @@ def test_send_forum_email_skips_when_recipient_has_no_email():
     # case EmailService.send_email() itself gets wrong — recipients() filters
     # the blank address to zero, email.send() returns 0, but the caller logs
     # "sent successfully" anyway since it never checks the return value).
-    send_forum_email("reply_added", topic_author.pk, {"post_id": str(post.pk)})
+    send_forum_email_batch("reply_added", [topic_author.pk], {"post_id": str(post.pk)})
 
     assert mail.outbox == []
 
 
 @pytest.mark.django_db
 def test_send_forum_email_skips_when_post_not_found():
-    from apps.forum_host.tasks import send_forum_email
+    from apps.forum_host.tasks import send_forum_email_batch
     from django.core import mail
 
     topic_author, _, _, _ = _make_reply("emailnopost")
 
-    send_forum_email("reply_added", topic_author.pk, {"post_id": "999999"})
+    send_forum_email_batch("reply_added", [topic_author.pk], {"post_id": "999999"})
 
     assert mail.outbox == []
 
 
 @pytest.mark.django_db
 def test_send_forum_email_skips_when_post_id_invalid():
-    from apps.forum_host.tasks import send_forum_email
+    from apps.forum_host.tasks import send_forum_email_batch
     from django.core import mail
 
     topic_author, _, _, _ = _make_reply("emailbadid")
@@ -492,30 +499,34 @@ def test_send_forum_email_skips_when_post_id_invalid():
     # int("") raises ValueError; a key present with value None -> int(None)
     # raises TypeError (dict.get's default only applies when the key is
     # ABSENT, not when its value is None).
-    send_forum_email("reply_added", topic_author.pk, {})
-    send_forum_email("reply_added", topic_author.pk, {"post_id": "not-a-number"})
-    send_forum_email("reply_added", topic_author.pk, {"post_id": None})
+    send_forum_email_batch("reply_added", [topic_author.pk], {})
+    send_forum_email_batch(
+        "reply_added", [topic_author.pk], {"post_id": "not-a-number"}
+    )
+    send_forum_email_batch("reply_added", [topic_author.pk], {"post_id": None})
 
     assert mail.outbox == []
 
 
 @pytest.mark.django_db
 def test_send_forum_email_skips_unimplemented_event():
-    from apps.forum_host.tasks import send_forum_email
+    from apps.forum_host.tasks import send_forum_email_batch
     from django.core import mail
 
     topic_author, _, _, post = _make_reply("emailunimpl")
 
     # mention/moderation/digest emails are later slices of todo 253 — the
     # task must no-op, not crash, until they're wired.
-    send_forum_email("mention_added", topic_author.pk, {"post_id": str(post.pk)})
+    send_forum_email_batch(
+        "mention_added", [topic_author.pk], {"post_id": str(post.pk)}
+    )
 
     assert mail.outbox == []
 
 
 @pytest.mark.django_db
 def test_send_forum_email_deleted_author_renders_bracket_deleted():
-    from apps.forum_host.tasks import send_forum_email
+    from apps.forum_host.tasks import send_forum_email_batch
     from django.core import mail
 
     topic_author, _, _, post = _make_reply("emaildeleted")
@@ -524,7 +535,7 @@ def test_send_forum_email_deleted_author_renders_bracket_deleted():
     post.author = None
     post.save()
 
-    send_forum_email("reply_added", topic_author.pk, {"post_id": str(post.pk)})
+    send_forum_email_batch("reply_added", [topic_author.pk], {"post_id": str(post.pk)})
 
     assert len(mail.outbox) == 1
     assert "[deleted]" in mail.outbox[0].body
@@ -540,7 +551,7 @@ def test_send_forum_email_retries_on_transient_db_error():
     isn't dead config, the exact gap flagged when the original broad
     try/except/self.retry() wrapper (which only ever wrapped the swallow-all
     send call) was removed as untested dead code."""
-    from apps.forum_host.tasks import send_forum_email
+    from apps.forum_host.tasks import send_forum_email_batch
     from django.db import OperationalError
 
     topic_author, _, _, post = _make_reply("emaildberror")
@@ -548,10 +559,191 @@ def test_send_forum_email_retries_on_transient_db_error():
     with patch.object(
         Post.objects, "select_related", side_effect=OperationalError("connection lost")
     ) as mock_select_related:
-        result = send_forum_email.apply(
-            args=("reply_added", topic_author.pk, {"post_id": str(post.pk)})
+        result = send_forum_email_batch.apply(
+            args=("reply_added", [topic_author.pk], {"post_id": str(post.pk)})
         )
 
     assert mock_select_related.call_count == 4  # initial attempt + max_retries=3
     assert result.status == "FAILURE"
     assert isinstance(result.result, OperationalError)
+
+
+# ---- send_forum_push_batch tests (todo 268 batched fan-out) ------------------
+#
+# The batch variant fans one FCM push out to many recipients from a SINGLE
+# enqueue: one bulk ForumProfile fetch, then a server-side send loop. A
+# per-recipient TRANSIENT failure is handed off to the retry-capable
+# single-recipient send_forum_push task (not a whole-batch retry, which would
+# re-send to everyone); a PERMANENT failure is dropped, same as the single task.
+
+
+@pytest.mark.django_db
+def test_send_forum_push_batch_sends_to_each_recipient_from_one_bulk_fetch():
+    """One enqueue → one FCM send per recipient, and the DB fetch does NOT
+    scale with recipient count (the whole point of batching: a single
+    select_related profile fetch instead of N per-recipient lookups). Proven
+    by comparing N=1 vs N=5 — sends scale with N, DB queries do not."""
+    from django.db import connection
+    from django.test.utils import CaptureQueriesContext
+
+    def _run_batch(n, slug):
+        recipient_pks = []
+        for i in range(n):
+            u = User.objects.create_user(username=f"batchsend-{slug}-{i}")
+            profile = ForumProfile.for_user(u)
+            profile.fcm_token = f"token-{slug}-{i}"
+            profile.save()
+            recipient_pks.append(u.pk)
+
+        mock_fcm = MagicMock()
+        mock_fcm.send.return_value = "ok"
+
+        with patch(
+            "apps.garden.firebase_config.is_firebase_available", return_value=True
+        ), patch("apps.garden.firebase_config.get_fcm_client", return_value=mock_fcm):
+            from apps.forum_host.tasks import send_forum_push_batch
+
+            with CaptureQueriesContext(connection) as ctx:
+                send_forum_push_batch(
+                    "reply_added",
+                    recipient_pks,
+                    {"topic_id": "1", "topic_title": "Hi"},
+                )
+
+        sent_tokens = {c.kwargs["token"] for c in mock_fcm.Message.call_args_list}
+        return mock_fcm.send.call_count, len(ctx.captured_queries), sent_tokens
+
+    sends_1, queries_1, tokens_1 = _run_batch(1, "one")
+    sends_5, queries_5, tokens_5 = _run_batch(5, "five")
+
+    # One FCM send per recipient — sends scale with the recipient list.
+    assert sends_1 == 1
+    assert sends_5 == 5
+    assert tokens_1 == {"token-one-0"}
+    assert tokens_5 == {f"token-five-{i}" for i in range(5)}
+    # ...but the DB fetch is a single bulk query regardless of N (select_related
+    # on the profile's user; no per-recipient lookup).
+    assert queries_1 == queries_5
+
+
+@pytest.mark.django_db
+def test_send_forum_push_batch_skips_recipients_without_token():
+    """A recipient with no FCM token is silently skipped inside the batch loop
+    — only the tokened recipient gets a send."""
+    with_token = User.objects.create_user(username="batch-hastoken")
+    profile = ForumProfile.for_user(with_token)
+    profile.fcm_token = "real-token"
+    profile.save()
+
+    no_token = User.objects.create_user(username="batch-notoken")
+    ForumProfile.for_user(no_token)  # fcm_token="" by default
+
+    mock_fcm = MagicMock()
+    mock_fcm.send.return_value = "ok"
+
+    with patch(
+        "apps.garden.firebase_config.is_firebase_available", return_value=True
+    ), patch("apps.garden.firebase_config.get_fcm_client", return_value=mock_fcm):
+        from apps.forum_host.tasks import send_forum_push_batch
+
+        send_forum_push_batch(
+            "reply_added", [with_token.pk, no_token.pk], {"topic_id": "1"}
+        )
+
+    mock_fcm.send.assert_called_once()
+    assert mock_fcm.Message.call_args.kwargs["token"] == "real-token"
+
+
+@pytest.mark.django_db
+def test_send_forum_push_batch_skips_forum_notifications_off_recipients():
+    """A recipient who has turned forum_notifications off is skipped inside the
+    batch loop even though they have a token — only the opted-in user gets a
+    send (mirrors the single task's gate, applied per-recipient in the batch)."""
+    opted_in = User.objects.create_user(username="batch-optin")
+    profile_in = ForumProfile.for_user(opted_in)
+    profile_in.fcm_token = "optin-token"
+    profile_in.save()
+
+    opted_out = User.objects.create_user(username="batch-optout")
+    opted_out.forum_notifications = False
+    opted_out.save()
+    profile_out = ForumProfile.for_user(opted_out)
+    profile_out.fcm_token = "optout-token"
+    profile_out.save()
+
+    mock_fcm = MagicMock()
+    mock_fcm.send.return_value = "ok"
+
+    with patch(
+        "apps.garden.firebase_config.is_firebase_available", return_value=True
+    ), patch("apps.garden.firebase_config.get_fcm_client", return_value=mock_fcm):
+        from apps.forum_host.tasks import send_forum_push_batch
+
+        send_forum_push_batch(
+            "reply_added", [opted_in.pk, opted_out.pk], {"topic_id": "1"}
+        )
+
+    mock_fcm.send.assert_called_once()
+    assert mock_fcm.Message.call_args.kwargs["token"] == "optin-token"
+
+
+@pytest.mark.django_db
+def test_send_forum_push_batch_re_enqueues_single_on_transient_error():
+    """A per-recipient TRANSIENT FCM failure must be handed off to the
+    retry-capable single-recipient send_forum_push task — NOT retried as a
+    whole batch (which would re-send to every recipient). The re-enqueue must
+    target the failed user's pk and carry the ORIGINAL data dict (send_forum_push
+    coerces to str itself)."""
+    from firebase_admin import exceptions as fb_exceptions
+
+    user = User.objects.create_user(username="batch-transient")
+    profile = ForumProfile.for_user(user)
+    profile.fcm_token = "live-token"
+    profile.save()
+
+    data = {"topic_id": "1", "topic_title": "Hi"}
+
+    mock_fcm = MagicMock()
+    mock_fcm.send.side_effect = fb_exceptions.UnavailableError("FCM backend down")
+
+    with patch(
+        "apps.garden.firebase_config.is_firebase_available", return_value=True
+    ), patch(
+        "apps.garden.firebase_config.get_fcm_client", return_value=mock_fcm
+    ), patch(
+        "apps.forum_host.tasks.send_forum_push.delay"
+    ) as mock_single:
+        from apps.forum_host.tasks import send_forum_push_batch
+
+        send_forum_push_batch("reply_added", [user.pk], data)
+
+    mock_single.assert_called_once_with("reply_added", user.pk, data)
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("exc", _permanent_fcm_errors(), ids=lambda e: type(e).__name__)
+def test_send_forum_push_batch_does_not_re_enqueue_on_permanent_error(exc):
+    """A per-recipient PERMANENT FCM failure (stale token, malformed message)
+    can never succeed on retry — the batch drops it and must NOT re-enqueue the
+    single-recipient task (uses the same permanent-error classes as the single
+    task's permanent-error test)."""
+    user = User.objects.create_user(username=f"batch-perm-{type(exc).__name__.lower()}")
+    profile = ForumProfile.for_user(user)
+    profile.fcm_token = "dead-token"
+    profile.save()
+
+    mock_fcm = MagicMock()
+    mock_fcm.send.side_effect = exc
+
+    with patch(
+        "apps.garden.firebase_config.is_firebase_available", return_value=True
+    ), patch(
+        "apps.garden.firebase_config.get_fcm_client", return_value=mock_fcm
+    ), patch(
+        "apps.forum_host.tasks.send_forum_push.delay"
+    ) as mock_single:
+        from apps.forum_host.tasks import send_forum_push_batch
+
+        send_forum_push_batch("reply_added", [user.pk], {"topic_id": "1"})
+
+    mock_single.assert_not_called()

--- a/todos/archive/268-completed-p2-forum-notification-fanout-batching.md
+++ b/todos/archive/268-completed-p2-forum-notification-fanout-batching.md
@@ -1,5 +1,5 @@
 ---
-status: pending
+status: completed
 priority: p2
 issue_id: "268"
 tags: [backend, celery, forum, notifications, performance]
@@ -56,10 +56,10 @@ Deliberately deferred out of the slice-3 diff rather than fixed inline: a proper
 
 ## Acceptance Criteria
 
-- [ ] A reply to a topic with N subscribers enqueues a constant number of Celery tasks (not 2N)
-- [ ] Worker-side batch handlers do one bulk fetch per event, not one per recipient
-- [ ] A test pins the enqueue-call-count invariant across varying subscriber counts (e.g., 1 vs. 50)
-- [ ] `moderation_decided`'s task-call shape is either left as-is (documented why) or migrated to the same batch tasks
+- [x] A reply to a topic with N subscribers enqueues a constant number of Celery tasks (not 2N)
+- [x] Worker-side batch handlers do one bulk fetch per event, not one per recipient
+- [x] A test pins the enqueue-call-count invariant across varying subscriber counts (e.g., 1 vs. 50)
+- [x] `moderation_decided`'s task-call shape is either left as-is (documented why) or migrated to the same batch tasks
 
 ## Work Log
 
@@ -72,6 +72,71 @@ Deliberately deferred out of the slice-3 diff rather than fixed inline: a proper
   `send_forum_email` signatures shared with the untouched `moderation_decided`
   path, which is out of proportion for a slice scoped to fan-out
   *correctness*, not delivery-path performance.
+
+### 2026-07-20 - Implemented (completing-todos run 2026-07-20-1615)
+
+- Branch `todo-268-notification-fanout-batching` off fresh `main` (@c89c99e,
+  after todo 269 / PR #475 merged).
+- **AC1** — added `send_forum_push_batch(event, recipient_user_ids, data)` and
+  `send_forum_email_batch(...)` to `apps/forum_host/tasks.py`; `dispatch()`'s
+  `reply_added` branch (and the shared mention path, reused by `topic_created`)
+  now enqueues ONE `send_forum_push_batch.delay` for reply recipients, ONE for
+  mentions, and ONE `send_forum_email_batch.delay` — constant enqueue count
+  regardless of subscriber count, instead of one `.delay()` per recipient
+  blocking the request thread. Pinned by
+  `test_reply_added_enqueue_count_is_constant_regardless_of_subscriber_count`
+  (N=1 vs N=50 → identical `call_count == 1`, and the single recipient-list arg
+  carries all 50 pks — batched, not dropped).
+- **AC2** — the batch tasks do one bulk fetch: push does a single
+  `ForumProfile.objects.filter(user_id__in=…).select_related("user")`; email
+  fetches the Post once + one `User.objects.filter(pk__in=…)`. Pinned by
+  `test_send_forum_push_batch_sends_to_each_recipient_from_one_bulk_fetch`
+  (`CaptureQueriesContext`: `queries_1 == queries_5` while `sends` scale 1→5).
+- **AC3** — the invariant test above (N-independent enqueue count) is the
+  load-bearing pin.
+- **AC4 — `moderation_decided` left as-is on the single-recipient
+  `send_forum_push`** (a single author recipient — no fan-out to batch). This
+  keeps `send_forum_push` (single) a live task, which also serves as the
+  batch's transient-FCM-error re-enqueue target (per-recipient transient
+  failures hand off to the retry-capable single task rather than retrying — and
+  re-sending — the whole batch). The now-callerless `send_forum_email` (single)
+  was REMOVED and its coverage migrated to `send_forum_email_batch`.
+- Retry safety: `send_forum_email_batch` fetches Post + users up front so
+  `autoretry_for=(OperationalError,)` can only fire pre-send — email has no
+  collapse-key dedup, so a partial-send retry would double-email. (Note: this
+  leans on `EmailService.send_email()` never raising — the exact behavior todo
+  267 changes next; flagged so 267 doesn't silently break this.)
+- Extracted `_send_fcm_message()` so the collapse-key/notification-hybrid build
+  can't drift between the single and batch push tasks.
+- Tests: migrated 17 `test_signals.py` tests + 9 `test_tasks.py` email tests to
+  the batch shape (recipient arg is now a pk LIST; moderation tests untouched),
+  added the invariant test + 5 `send_forum_push_batch` unit tests. Full
+  `apps/forum_host/` suite: **103 passed** on a fresh DB; `manage.py check`
+  clean.
+
+### 2026-07-20 - Reviewed (code-review-orchestrator, run 2026-07-20-1615)
+
+- All four focus areas PASS (retry correctness, behavior parity, on_commit/txn
+  semantics, test quality). 0 blocking. 2 low/info, both accepted:
+  - Batch variants drop the per-recipient debug skip logs the single task
+    emitted (no-token / notifications-off / user-not-found). No functional
+    impact; per-recipient debug logging in a batch would be noise. Accepted.
+  - The batch push reads only EXISTING `ForumProfile` rows
+    (`filter(user_id__in=…)`) rather than calling `ForumProfile.for_user()`
+    per recipient (get-or-create). A tokenless user is skipped either way (no
+    push lost), but the batch no longer creates an empty profile as a
+    push-delivery side effect — which is actually the exact side effect todo
+    271 #1 flags (profile creation on push delivery stamps `read_watermark_at`
+    and collapses the user's unread backlog). Neutral-to-positive, documented.
+
+### 2026-07-20 - Completed by completing-todos skill (run 2026-07-20-1615)
+
+- Verification: all 4 acceptance criteria passed with quoted evidence above
+  (103 forum_host tests pass on a fresh DB; invariant + bulk-fetch tests pin
+  the batching).
+- Review: code-review-orchestrator — 0 blocking, 2 low/info accepted.
+- Landing on branch `todo-268-notification-fanout-batching`; per-todo PR to
+  follow.
 
 ## Notes
 


### PR DESCRIPTION
## Summary

`dispatch()`'s `reply_added` branch enqueued `send_forum_push.delay()` / `send_forum_email.delay()` **once per subscriber** inside `transaction.on_commit` — 2N sequential broker round-trips blocking the reply request, plus N worker executions each re-fetching the same `Post`/`User`/`ForumProfile` rows. A popular thread (hundreds of subscribers via auto-subscribe-on-reply) meant hundreds of blocking round-trips on a single "post a reply" request.

Added `send_forum_push_batch(event, recipient_user_ids, data)` and `send_forum_email_batch(...)`: enqueued **once** with the full recipient list, each doing one bulk fetch and a server-side loop.

## Changes

- **Constant enqueue count** — a reply now enqueues 1 push-batch + 1 mention-batch + 1 email-batch, regardless of subscriber count (was 2N). Pinned by an N=1-vs-N=50 invariant test.
- **Batch push** — one `ForumProfile.filter(user_id__in=…).select_related("user")` fetch. A per-recipient *transient* FCM failure re-enqueues the retry-capable single `send_forum_push` rather than retrying the whole batch (which would re-send to everyone; the collapse key dedupes the tray, not the wasted work).
- **Batch email** — fetches the `Post` + all users **up front** so `autoretry_for=(OperationalError,)` can only fire pre-send: email has no collapse-key dedup, so a partial-send retry would double-email.
- **AC4** — `moderation_decided` left on the single-recipient `send_forum_push` (one author, no fan-out; keeps it live as the batch's re-enqueue target). The now-callerless `send_forum_email` (single) was removed and its coverage migrated to the batch.
- Extracted `_send_fcm_message()` so the collapse-key / notification-hybrid build can't drift between the single and batch push tasks.

## Tests

- Migrated 26 existing tests to the batch shape — the recipient arg is now a pk **list**; assertions pin `args[1] == [pk]` / `set(args[1]) == {…}` / `pk in args[1]` (moderation tests left untouched on the single task).
- Added the load-bearing **invariant test** (N=1 vs N=50 → identical `call_count == 1`, and the single recipient-list arg carries all 50 pks — batched, not dropped), a **bulk-fetch query-count test** (`queries_1 == queries_5` while sends scale 1→5), and 5 `send_forum_push_batch` unit tests (multi-recipient, no-token skip, notifications-off skip, transient re-enqueue, permanent no-re-enqueue).

**Full `apps/forum_host/` suite: 103 passed on a fresh DB.**

## Review

code-review-orchestrator: all 4 focus areas PASS, 0 blocking, 2 low/info accepted (reduced per-recipient debug logging; batch no longer creates an empty `ForumProfile` as a push-delivery side effect — which is neutral-to-positive, since that side effect is exactly todo 271 #1's `read_watermark_at`-stamping concern).

> Note: batch-email's retry-safety leans on `EmailService.send_email()` never raising — the exact behavior **todo 267** (next in this sweep) changes. Flagged in the todo so 267 preserves it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)