### PR TITLE
docs: close todo 253 — forum notifications epic complete (AC6 push delivery proven)

### DIFF
--- a/docs/audits/2026-07-11-forum-modernization.md
+++ b/docs/audits/2026-07-11-forum-modernization.md
@@ -288,16 +288,16 @@ Deferred findings converted to todos (Review Doc Tracking convention — the
 1 `false-positive` findings were closed in this audit and have no todo.
 
 - [x] #C1 report-flag-mechanism → todo 254 (completed 2026-07-13)
-- [ ] #C2 notifications-delivery-channel → todo 253
-- [ ] #H1 orphaned-email-notifications → todo 253
-- [ ] #H2 push-event-coverage → todo 253
-- [ ] #H3 subscriptions-watching → todo 253
-- [ ] #H4 mentions → todo 253
+- [x] #C2 notifications-delivery-channel → todo 253 (completed 2026-07-22)
+- [x] #H1 orphaned-email-notifications → todo 253 (completed 2026-07-22)
+- [x] #H2 push-event-coverage → todo 253 (completed 2026-07-22)
+- [x] #H3 subscriptions-watching → todo 253 (completed 2026-07-22)
+- [x] #H4 mentions → todo 253 (completed 2026-07-22)
 - [ ] #H6 solved-accepted-answer → todo 256
 - [ ] #H7 public-user-identity → todo 257
 - [ ] #H8 search-discoverability-filters → todo 256
 - [ ] #H9 seo-surface → todo 256
-- [ ] #H10 unread-indicators → todo 253
+- [x] #H10 unread-indicators → todo 253 (completed 2026-07-22)
 - [ ] #H11 mobile-forum-client → todo 260
 - [x] #H12 entitlement-primitive → todo 255 (completed 2026-07-20, slice 1)
 - [x] #H13 llm-spam-prescreen → todo 255 (completed 2026-07-21)

--- a/plant_community_mobile/tool/fcm_e2e_hold.dart
+++ b/plant_community_mobile/tool/fcm_e2e_hold.dart
@@ -1,0 +1,116 @@
+// Throwaway E2E harness (todo 253 AC6 delivery): registers a FRESH FCM token
+// and KEEPS the app installed + running, so a real reply_added push can be
+// sent from the backend and observed in the emulator's notification tray.
+//
+// Unlike `flutter test integration_test/fcm_registration_e2e_test.dart`, which
+// UNINSTALLS the app on teardown (instantly invalidating the just-minted token
+// as NotRegistered), `flutter run -t tool/fcm_e2e_hold.dart` leaves the app in
+// place. Same programmatic sign-in as the integration test (auth emulator).
+//
+// Run:
+//   flutter run -t tool/fcm_e2e_hold.dart -d emulator-5554 \
+//     --dart-define=API_BASE_URL=http://10.0.2.2:8000/api/v1 \
+//     --dart-define=FIREBASE_API_KEY=... (full set) \
+//     --dart-define=E2E_AUTH_EMAIL=... --dart-define=E2E_AUTH_PASSWORD=... \
+//     --dart-define=E2E_AUTH_EMULATOR_HOST=10.0.2.2:9099
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_core/firebase_core.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:plant_community_mobile/firebase_options.dart';
+import 'package:plant_community_mobile/main.dart';
+
+const _email = String.fromEnvironment('E2E_AUTH_EMAIL');
+const _password = String.fromEnvironment('E2E_AUTH_PASSWORD');
+const _authEmulatorHost = String.fromEnvironment('E2E_AUTH_EMULATOR_HOST');
+
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+
+  if (Firebase.apps.isEmpty) {
+    try {
+      await Firebase.initializeApp(
+        options: DefaultFirebaseOptions.currentPlatform,
+      );
+    } on FirebaseException catch (e) {
+      if (e.code != 'duplicate-app') rethrow;
+      await Firebase.initializeApp();
+    }
+  }
+
+  if (_authEmulatorHost.isNotEmpty) {
+    final (host, port) = _splitHostPort(_authEmulatorHost);
+    await FirebaseAuth.instance.useAuthEmulator(host, port);
+  }
+
+  // Mount the REAL app first so AuthService's auth-state listener is live; it
+  // exchanges the Firebase token for a Django JWT and runs the push-
+  // registration hook exactly as production would.
+  runApp(const ProviderScope(child: MyApp()));
+
+  await _signInAndVerify();
+  debugPrint('[HOLD] sign-in complete — app is registered and staying alive');
+}
+
+Future<void> _signInAndVerify() async {
+  if (FirebaseAuth.instance.currentUser != null) {
+    await FirebaseAuth.instance.signOut();
+  }
+
+  try {
+    await FirebaseAuth.instance.signInWithEmailAndPassword(
+      email: _email,
+      password: _password,
+    );
+  } on FirebaseAuthException catch (e) {
+    if (e.code == 'user-not-found' || e.code == 'invalid-credential') {
+      await FirebaseAuth.instance.createUserWithEmailAndPassword(
+        email: _email,
+        password: _password,
+      );
+    } else {
+      rethrow;
+    }
+  }
+
+  if (_authEmulatorHost.isNotEmpty) {
+    // Backend fails closed on unverified emails (403). Flip emailVerified via
+    // the emulator's credential-free admin API, then re-sign-in so the token
+    // carries the verified claim.
+    final uid = FirebaseAuth.instance.currentUser!.uid;
+    final httpClient = HttpClient();
+    try {
+      final request = await httpClient.postUrl(
+        Uri.parse(
+          'http://$_authEmulatorHost'
+          '/identitytoolkit.googleapis.com/v1/accounts:update',
+        ),
+      );
+      request.headers.set('Authorization', 'Bearer owner');
+      request.headers.contentType = ContentType.json;
+      request.write(jsonEncode({'localId': uid, 'emailVerified': true}));
+      final response = await request.close();
+      await response.drain<void>();
+    } finally {
+      httpClient.close();
+    }
+
+    await FirebaseAuth.instance.signOut();
+    await FirebaseAuth.instance.signInWithEmailAndPassword(
+      email: _email,
+      password: _password,
+    );
+  }
+}
+
+(String, int) _splitHostPort(String value) {
+  final idx = value.lastIndexOf(':');
+  final port = idx < 0 ? null : int.tryParse(value.substring(idx + 1));
+  if (idx < 0 || port == null) {
+    throw ArgumentError.value(value, 'value', 'expected "host:port"');
+  }
+  return (value.substring(0, idx), port);
+}

--- a/todos/253-completed-p1-forum-notifications-engagement.md
+++ b/todos/253-completed-p1-forum-notifications-engagement.md
@@ -1,5 +1,5 @@
 ---
-status: in_progress
+status: completed
 priority: p1
 issue_id: "253"
 tags: [forum, notifications, product-ux, celery]
@@ -101,21 +101,20 @@ Sequenced so each step ships value alone:
       server-side read-state (`TopicRead` + `ForumProfile.read_watermark_at`)
       badges both never-opened and previously-read-but-newly-replied topics,
       via a zero-added-query queryset annotation.
-- [ ] At least one real client (web or mobile) registers an FCM token and
-      receives a push end-to-end — REGISTRATION half done and live-verified
-      since slice 6 (Android emulator → real FCM token → real dev backend →
-      `ForumProfile.fcm_token` row; repeatable via
-      `integration_test/fcm_registration_e2e_test.dart`). The
-      "receives a push" half is gated on the one input only the user can
-      provide: the Firebase service-account JSON (drop at
-      `firebase/firebase-adminsdk-credentials.json`, set
-      `FIREBASE_CREDENTIALS_PATH` in backend/.env, then the slice-6 work
-      log's 5-step delivery runbook).
-      (UPDATE 2026-07-20: JSON now placed + credential PROVEN functional —
-      firebase_admin authenticates to FCM with the real Certificate and
-      messaging.send() round-trips. The remaining gate is no longer the JSON
-      but a live mobile token to deliver to; the mobile build was deleted this
-      session, so deferred to todo 260. See Work Log 2026-07-20.)
+- [x] At least one real client (web or mobile) registers an FCM token and
+      receives a push end-to-end — SATISFIED 2026-07-22 (see Work Log). Both
+      halves proven on an Android emulator against the real dev backend and
+      real FCM: (1) a FRESH 142-char token registered via the real auth+PATCH
+      chain; (2) a genuine `reply_added` publish fanned out through
+      `send_forum_push_batch` → `firebase_admin.messaging.send()` with the real
+      Certificate, returning a real FCM message id
+      (`projects/plant-community-prod/messages/0:1784745052544517%1b32106f1b32106f`,
+      NOT `NotRegistered`); (3) the notification was RECEIVED and rendered in
+      the device's system tray — `dumpsys notification` shows a live
+      `NotificationRecord` (pkg=com.plantcommunity.plant_community_mobile,
+      channel=fcm_fallback_notification_channel) with the exact copy
+      `New reply in "AC6 delivery 7b0e27"` / `fcm-e2e-253-replier replied`,
+      confirmed by screenshot. Completing this also satisfies todo 260's FCM AC.
 
 ## Work Log
 
@@ -1438,6 +1437,65 @@ low-priority "considerations," not just the top-billed suggestions.
   scaffolding. Correction to the entry above: **todo 272 does NOT track this
   delivery test** — 272 is slice-6 code-hardening residue only (iOS
   entitlements, throttle sharing, init arbitration, copy consolidation).
+
+### 2026-07-22 - AC6 delivery PROVEN end-to-end (tray notification received) — epic COMPLETE
+
+- **The prior "blocked" framing no longer held.** Re-checked the environment
+  this session and found every prerequisite present: the Flutter **source tree
+  was intact** (the 2026-07-20 "build deleted" meant the installed APK, not the
+  code), Flutter + the Android SDK (`adb`/`emulator`, just off PATH) + a
+  Google-Play AVD (`Medium_Phone_API_36.1`, `PlayStore.enabled=true` — required
+  for FCM `getToken`) were installed, the Firebase service-account JSON was
+  placed + set in `backend/.env`, and Redis was up. User approved running the
+  full on-device delivery E2E ("Run it all now").
+- **Stack stood up locally:** Android emulator (`emulator-5554`), Firebase
+  **Auth** emulator (`127.0.0.1:9099`, reachable from the device as
+  `10.0.2.2:9099`), Django `runserver 0.0.0.0:8000` with
+  `FIREBASE_AUTH_EMULATOR_HOST=127.0.0.1:9099` + `CELERY_TASK_ALWAYS_EAGER=True`
+  (push runs inline, no separate worker). FCM messaging still uses the real
+  Certificate — auth-emulator and real-messaging coexist in one
+  `firebase_admin` app.
+- **One real blocker found + fixed:** the local dev DB was one migration behind
+  (`users.0010_user_is_premium`, from todo 255 slice 1 / PR #478) — the token
+  exchange 500'd with `column auth_user.is_premium does not exist`. Applied the
+  migration; exchange then succeeded. (Stale-dev-DB-vs-merged-migration, same
+  class as the prior `--reuse-db`/`wagtail_forum` gaps.)
+- **`flutter test` is the WRONG vehicle for delivery** — the integration test
+  registered a fresh 142-char token, but its teardown **UNINSTALLS the app**,
+  which instantly invalidated that token (`NotRegistered` on the first send
+  attempt). This is the same stale-token wall every prior run hit. Fix: a small
+  throwaway `flutter run` harness (`plant_community_mobile/tool/fcm_e2e_hold.dart`)
+  that reuses the integration test's programmatic auth-emulator sign-in + mounts
+  the real `MyApp` (so `AuthService` → `syncAfterLogin()` → PATCH registers the
+  token), but leaves the app **installed and running**. Backgrounded the app
+  (HOME) so a `notification`-hybrid FCM message renders in the tray rather than
+  firing in-foreground `onMessage`.
+- **Delivery via the REAL path, not a direct send:** a rolled-into-`atomic()`
+  `manage.py shell` script (mirrors `apps/forum_host/tests/test_signals.py`)
+  creates a board/topic authored+subscribed by the E2E user, then a DIFFERENT
+  user (`fcm-e2e-253-replier`) posts a reply via the genuine
+  `save_revision().publish()` chain → fires `reply_added` → subscription fan-out
+  → `send_forum_push_batch` (eager) → `messaging.send()`.
+- **Evidence (both halves):**
+  - SEND: `INFO forum_host.tasks [FCM] forum.reply_added sent to user=60:
+    projects/plant-community-prod/messages/0:1784745052544517%1b32106f1b32106f`
+    — a real FCM message id, authenticated with the real cert (contrast the
+    earlier `NotRegistered` on the stale token).
+  - RECEIVE: `adb shell dumpsys notification --noredact` shows a live
+    `NotificationRecord(pkg=com.plantcommunity.plant_community_mobile,
+    channel=fcm_fallback_notification_channel, tag=FCM-Notification:…)` with
+    `android.title="New reply in \"AC6 delivery 7b0e27\""` /
+    `android.text="fcm-e2e-253-replier replied"` — exactly what
+    `tasks._notification_content("reply_added", …)` produces. Screenshot of the
+    expanded notification shade captured as durable proof.
+- **AC boxes:** AC6 flipped — the epic's final open criterion. All 6 ACs now
+  satisfied. Todo 260's FCM AC line updated to record delivery proven (its
+  other ACs — native browse, delta sync, idempotent writes — remain open; the
+  mobile forum client itself is still todo 260's scope).
+- Throwaway artifacts this session (NOT product changes): the `flutter run`
+  hold harness (`tool/fcm_e2e_hold.dart`) and two `manage.py shell` delivery
+  scripts. The AC6 feature code all shipped in slice 6; this session was the
+  manual-QA delivery pass slice 6 deferred.
 
 ## Notes
 

--- a/todos/260-pending-p2-forum-mobile-client.md
+++ b/todos/260-pending-p2-forum-mobile-client.md
@@ -67,15 +67,18 @@ Phased to ship value early:
 - [ ] Delta sync consumes `/sync/` including tombstoned deletions (test with
       fake backend fixtures)
 - [ ] Reply/create retries are idempotent; pending-moderation surfaced in UI
-- [ ] Device registers an FCM token and receives a forum push end-to-end
-      — registration half DONE by todo 253 slice 6 (live-verified); the
-      Firebase service-account key is now PLACED and the credential PROVEN
-      (2026-07-20, see todo 253 work log — firebase_admin authenticates to
-      FCM with the real Certificate and messaging.send() round-trips). The
-      receives-a-push half now needs only this rebuilt mobile client to mint
-      a FRESH token (the slice-6 test tokens have gone stale/NotRegistered),
-      then the slice-6 runbook delivers. Completing this AC here also
-      satisfies todo 253's AC6.
+- [x] Device registers an FCM token and receives a forum push end-to-end
+      — PROVEN 2026-07-22 (see todo 253 Work Log 2026-07-22). On an Android
+      emulator: a fresh 142-char token registered via the real auth+PATCH
+      chain, a genuine `reply_added` publish sent through
+      `send_forum_push_batch` → `messaging.send()` (real Certificate,
+      returned a real FCM message id, not `NotRegistered`), and the
+      notification was RECEIVED + rendered in the device tray (`dumpsys
+      notification` record + screenshot). This also satisfied todo 253's AC6.
+      NB: verified with a throwaway `flutter run` harness
+      (`tool/fcm_e2e_hold.dart`) since `flutter test` uninstalls the app on
+      teardown and invalidates the token; this todo's own native forum UI +
+      push-tap deep-linking are still open below.
 - [ ] `flutter analyze` + `flutter test` green including regenerated codegen
 
 ## Work Log


### PR DESCRIPTION
## What

Closes the **forum notifications & engagement epic (todo 253)** — its final open criterion, **AC6 (a real client registers an FCM token and *receives* a push end-to-end)**, is now proven. All 6 ACs satisfied.

## Why now

The prior 3 sessions left 253 `in_progress` because AC6's *delivery* half was blocked (credential, then a stale/absent mobile token). This session found the blocker gone — intact Flutter source, installed Android SDK + a Google-Play AVD, and the proven Firebase cert — and ran the delivery E2E on-device.

## Evidence (both halves, same send)

- **SEND** — real `reply_added` publish → `send_forum_push_batch` → `firebase_admin.messaging.send()` with the real Certificate:
  `[FCM] forum.reply_added sent to user=60: projects/plant-community-prod/messages/0:1784745052544517%1b32106f1b32106f` (a real message id, **not** `NotRegistered`).
- **RECEIVE** — `adb shell dumpsys notification` shows a live `NotificationRecord` (pkg=`com.plantcommunity.plant_community_mobile`, channel=`fcm_fallback_notification_channel`) titled **`New reply in "AC6 delivery 7b0e27"`** / `fcm-e2e-253-replier replied` — captured by screenshot of the device notification shade.

## Changes (docs + one tooling file)

- **todos/253** — AC6 flipped, 2026-07-22 Work Log added, archived (`status: completed` + rename).
- **todos/260** — FCM-delivery AC marked proven (its native forum-client ACs stay open).
- **docs/audits/2026-07-11-forum-modernization.md** — Finding Status: C2/H1/H2/H3/H4/H10 checked off.
- **plant_community_mobile/tool/fcm_e2e_hold.dart** — reusable `flutter run` delivery-E2E harness. Needed because `flutter test` uninstalls the app on teardown, instantly invalidating the freshly-minted token (`NotRegistered`) — this harness keeps the app installed so a push can actually be delivered. `flutter analyze` clean.

No product code changed — the AC6 feature all shipped in slice 6; this is the manual-QA delivery pass slice 6 deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)