### PR TITLE
forum: semantic similar-topics via pgvector (todo 255 slice 4 / H15)

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -99,7 +99,10 @@ jobs:
         # `"test" in sys.argv` Postgres branch at settings.py:303 only fires for
         # `manage.py test`, NOT pytest). Django's test runner then creates
         # `test_plant_community` from this service.
-        image: postgres:16
+        # pgvector image (Postgres 16 + the `vector` extension preinstalled) so
+        # the forum similar-topics `CREATE EXTENSION vector` migration applies in
+        # CI (todo 255 slice 4 / H15). Stock postgres:16 lacks the extension.
+        image: pgvector/pgvector:pg16
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres  # pragma: allowlist secret

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1178,7 +1178,7 @@
         "filename": "backend/plant_community_backend/settings.py",
         "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
         "is_verified": false,
-        "line_number": 1440
+        "line_number": 1460
       }
     ],
     "backend/run_migrations.py": [
@@ -1514,5 +1514,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-21T23:47:44Z"
+  "generated_at": "2026-07-23T01:37:08Z"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -256,6 +256,7 @@ never commit it).
 | `GOOGLE_APPLICATION_CREDENTIALS` | `backend/.env` | Path to Firebase service account JSON (ADC — users-app token exchange) |
 | `FIREBASE_CREDENTIALS_PATH` | `backend/.env` | Same JSON, read by `apps/garden/firebase_config.py` — gates FCM push; unset = push disabled |
 | `WAGTAILFORUM_SPAM_BACKEND` | `backend/.env` | Dotted path to the forum spam backend; unset = heuristic. Set to `apps.forum_host.spam.LLMSpamBackend` to enable the LLM screen (needs `OPENAI_API_KEY`) |
+| `FORUM_VECTOR_SEARCH_ENABLED` | `backend/.env` | `True` enables the forum semantic "similar topics" endpoint (H15); default `False` (endpoint 503s, no embedding spend). Needs `OPENAI_API_KEY` + a built index (`manage.py rebuild_indexes SimilarTopics`). The pgvector apps + `CREATE EXTENSION vector` migration are always active |
 | `VITE_API_URL` | `web/.env` | Backend URL for React app |
 
 ## Cheap-Worker Delegation (Kimi K2.6)

--- a/backend/apps/forum_host/api_urls.py
+++ b/backend/apps/forum_host/api_urls.py
@@ -35,6 +35,7 @@ from .api import (
 # Host-only AI route (todo 255 slice 3 / H14) — no package counterpart; the
 # summarization logic reuses the blog app's AI helpers, which the package may
 # not import. The route-drift guard allow-lists this one host-only addition.
+from .similar import SimilarTopicsView
 from .summary import TopicSummaryView
 
 app_name = "wagtail_forum_api"
@@ -53,6 +54,11 @@ urlpatterns = [
         "topics/<int:topic_id>/summary/",
         TopicSummaryView.as_view(),
         name="topic-summary",
+    ),
+    path(
+        "topics/similar/",
+        SimilarTopicsView.as_view(),
+        name="topic-similar",
     ),
     path("images/", PostImageUploadView.as_view(), name="image-upload"),
     path("posts/<int:post_id>/", PostWriteView.as_view(), name="post-detail"),

--- a/backend/apps/forum_host/apps.py
+++ b/backend/apps/forum_host/apps.py
@@ -11,4 +11,10 @@ class ForumHostAppConfig(AppConfig):
         from .bootstrap import connect
 
         connect()
+        # Register the H15 similar-topics vector index so `rebuild_indexes` and
+        # the endpoint can find it. django-ai-core has no autodiscovery — an
+        # index exists only once its module is imported. Import-safe: the module
+        # builds no embedding transformer / hits no DB at import (see its
+        # docstring), so this is inert until the feature is enabled + rebuilt.
         from . import signals  # noqa: F401  (registers signal receivers)
+        from . import vector_indexes  # noqa: F401

--- a/backend/apps/forum_host/constants.py
+++ b/backend/apps/forum_host/constants.py
@@ -28,6 +28,9 @@ DEFAULT_FORUM_RATELIMITS = {
     # enqueues one LLM task; generous but bounded so a premium client can't spin
     # up unbounded generations.
     "topic_summary": "30/h",
+    # Semantic similar-topics GET (todo 255 slice 4 / H15). Per-IP, same tier as
+    # `search` — a debounced compose-time box; a cache miss embeds the query.
+    "similar_topics": "30/m",
 }
 
 # Reply-notification email body excerpt length (todo 253 slice 2, H1).
@@ -143,3 +146,28 @@ SUMMARY_PROMPT_TEMPLATE = (
     "{content}\n"
     "----- END THREAD -----"
 )
+
+# ---------------------------------------------------------------------------
+# Semantic "similar topics" (todo 255 slice 4 / H15). Consumed by
+# apps/forum_host/vector_indexes.py + similar.py. Gated behind
+# settings.FORUM_VECTOR_SEARCH_ENABLED. See
+# docs/superpowers/specs/2026-07-22-forum-similar-topics-pgvector-design.md.
+# ---------------------------------------------------------------------------
+
+# Max similar topics returned to a client.
+SIMILAR_TOPICS_LIMIT = 5
+
+# Overfetch factor: vector search returns this * limit documents so the result
+# still fills after the board-visibility refetch drops restricted hits.
+SIMILAR_OVERFETCH = 3
+
+# Per-topic content cap fed into the embedding (title + opening-post excerpt).
+SIMILAR_CONTENT_MAX_CHARS = 2000
+
+# Upper bound on the compose-time query string (caps embedding tokens/cost).
+SIMILAR_QUERY_MAX_CHARS = 500
+
+# Result cache: bounds embedding spend on debounced typing by caching the
+# (query, board) result set briefly.
+SIMILAR_CACHE_PREFIX = "forum_similar_topics"
+SIMILAR_CACHE_TTL_SECONDS = 300

--- a/backend/apps/forum_host/similar.py
+++ b/backend/apps/forum_host/similar.py
@@ -1,0 +1,90 @@
+"""Compose-time semantic "similar topics" endpoint (todo 255 slice 4 / H15).
+
+GET /api/v1/forum/topics/similar/?q=<text>&board=<slug> — public read (the audit
+called this dedupe-for-community-health, not premium-gated), per-IP throttled
+like search. Returns 503 while FORUM_VECTOR_SEARCH_ENABLED is off so no embedding
+spend happens over an empty forum.
+
+See docs/superpowers/specs/2026-07-22-forum-similar-topics-pgvector-design.md.
+"""
+
+import hashlib
+import logging
+
+from apps.core.ratelimit import client_ip_key
+from django.conf import settings
+from django.core.cache import cache
+from drf_spectacular.utils import extend_schema
+from rest_framework import status
+from rest_framework.permissions import AllowAny
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from . import constants
+from .api import _throttled
+from .vector_indexes import find_similar_topics
+
+logger = logging.getLogger(__name__)
+
+
+def _cache_key(query: str, board_slug: str | None) -> str:
+    raw = f"{query}\x1f{board_slug or ''}"
+    digest = hashlib.sha256(raw.encode("utf-8")).hexdigest()[:16]
+    return f"{constants.SIMILAR_CACHE_PREFIX}:{digest}"
+
+
+def _serialize(topic) -> dict:
+    return {
+        "id": topic.id,
+        "slug": topic.slug,
+        "title": topic.title,
+        "board_slug": topic.board.slug,
+        "reply_count": topic.reply_count,
+    }
+
+
+@_throttled("similar_topics", "GET", key=client_ip_key)
+class SimilarTopicsView(APIView):
+    """Semantic similar-topics search over live, visible forum topics."""
+
+    permission_classes = [AllowAny]
+    versioning_class = None  # opt out of NamespaceVersioning, like package views
+
+    @extend_schema(
+        responses={200: dict, 400: dict, 503: dict},
+        description=(
+            "Compose-time semantic 'similar topics'. Query params: q (required), "
+            "board (optional board-slug filter). 503 when the feature is "
+            "disabled; 400 for a blank q; 200 {results: [...]} otherwise."
+        ),
+    )
+    def get(self, request):
+        if not settings.FORUM_VECTOR_SEARCH_ENABLED:
+            return Response(
+                {"detail": "Similar-topics search is not enabled."},
+                status=status.HTTP_503_SERVICE_UNAVAILABLE,
+            )
+
+        query = request.query_params.get("q", "").strip()
+        if not query:
+            return Response(
+                {"detail": "Query parameter 'q' is required."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        query = query[: constants.SIMILAR_QUERY_MAX_CHARS]
+        board_slug = request.query_params.get("board", "").strip() or None
+
+        # Cache the (query, board) result set briefly so debounced compose-time
+        # typing doesn't re-embed the same near-identical query repeatedly.
+        cache_key = _cache_key(query, board_slug)
+        cached = cache.get(cache_key)
+        if cached is not None:
+            return Response({"results": cached})
+
+        topics = find_similar_topics(query, board_slug=board_slug)
+        results = [_serialize(t) for t in topics]
+        try:
+            cache.set(cache_key, results, constants.SIMILAR_CACHE_TTL_SECONDS)
+        except Exception:
+            logger.warning("[ERROR] similar-topics result-cache write failed")
+        return Response({"results": results})

--- a/backend/apps/forum_host/tests/test_ratelimits.py
+++ b/backend/apps/forum_host/tests/test_ratelimits.py
@@ -36,6 +36,7 @@ def _board():
 # guard so they do not read as package drift.
 HOST_ONLY_ROUTES = {
     ("topics/<int:topic_id>/summary/", "topic-summary"),  # H14 AI thread summary
+    ("topics/similar/", "topic-similar"),  # H15 semantic similar topics
 }
 
 

--- a/backend/apps/forum_host/tests/test_schema_429.py
+++ b/backend/apps/forum_host/tests/test_schema_429.py
@@ -22,6 +22,7 @@ THROTTLED_OPERATIONS = [
     ("/forum/topics/{topic_id}/subscription/", "post"),
     ("/forum/topics/{topic_id}/subscription/", "delete"),
     ("/forum/topics/{topic_id}/summary/", "get"),  # H14 premium AI summary
+    ("/forum/topics/similar/", "get"),  # H15 semantic similar topics
 ]
 
 

--- a/backend/apps/forum_host/tests/test_similar.py
+++ b/backend/apps/forum_host/tests/test_similar.py
@@ -1,0 +1,210 @@
+"""Tests for the forum semantic "similar topics" feature (todo 255 slice 4 / H15):
+the gated GET endpoint, the find_similar_topics helper, and an end-to-end
+pgvector build+search using a deterministic fake embedder (no OpenAI call).
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from apps.forum_host.vector_indexes import SimilarTopics, find_similar_topics
+from django.contrib.auth import get_user_model
+from django.core.cache import cache
+from django.test import override_settings
+from django_ai_core.llm import LLMService
+from freezegun import freeze_time
+from rest_framework.test import APIClient
+from wagtail.models import Page, PageViewRestriction
+from wagtail_forum.models import ForumBoard, ForumIndex, Post, Topic
+
+User = get_user_model()
+
+SIMILAR_URL = "/api/v1/forum/topics/similar/"
+FIND = "apps.forum_host.similar.find_similar_topics"
+
+# Any non-empty value satisfies LLMService.create's presence check; the real
+# embedding call is patched out, so no OpenAI request is ever made.
+_FAKE_OPENAI_KEY = "unit-test-key"  # pragma: allowlist secret
+
+# Deterministic fake embedding: an 8-dim keyword-presence vector. Similar text →
+# similar vector → meaningful cosine ranking, with zero network/OpenAI calls.
+KEYWORDS = ["tomato", "blight", "rose", "prune", "soil", "compost", "water", "seed"]
+
+
+def _fake_vector(text: str) -> list[float]:
+    t = (text or "").lower()
+    v = [1.0 if kw in t else 0.0 for kw in KEYWORDS]
+    if not any(v):  # avoid a zero vector (cosine distance is undefined)
+        v[-1] = 1e-6
+    return v
+
+
+def _fake_embedding(self, inputs, *args, **kwargs):
+    items = [inputs] if isinstance(inputs, str) else list(inputs)
+    return SimpleNamespace(
+        data=[SimpleNamespace(embedding=_fake_vector(t)) for t in items]
+    )
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    cache.clear()
+    yield
+    cache.clear()
+
+
+def _board(suffix="", restricted=False):
+    root = Page.objects.get(id=1)
+    index = root.add_child(
+        instance=ForumIndex(title=f"Forum{suffix}", slug=f"forum{suffix}")
+    )
+    board = index.add_child(
+        instance=ForumBoard(title=f"General{suffix}", slug=f"general{suffix}")
+    )
+    if restricted:
+        PageViewRestriction.objects.create(page=board, restriction_type="login")
+    return board
+
+
+def _topic(title, body_text, *, suffix="", board=None):
+    author = User.objects.create_user(username=f"a{suffix}{title[:4]}".replace(" ", ""))
+    board = board or _board(suffix)
+    topic = Topic.objects.create(
+        board=board,
+        title=title,
+        slug=f"t{suffix}{title[:6]}".replace(" ", ""),
+        author=author,
+    )
+    Post.objects.create(
+        topic=topic,
+        author=author,
+        is_opening_post=True,
+        body=[{"type": "paragraph", "value": f"<p>{body_text}</p>"}],
+    )
+    return topic
+
+
+# --------------------------------------------------------------------------- #
+# Endpoint — gating / validation / serialization (find_similar_topics mocked)  #
+# --------------------------------------------------------------------------- #
+
+
+@override_settings(FORUM_VECTOR_SEARCH_ENABLED=False)
+@pytest.mark.django_db
+def test_disabled_returns_503():
+    with patch(FIND) as mock_find:
+        resp = APIClient().get(SIMILAR_URL, {"q": "tomato"})
+    assert resp.status_code == 503
+    mock_find.assert_not_called()
+
+
+@override_settings(FORUM_VECTOR_SEARCH_ENABLED=True)
+@pytest.mark.django_db
+def test_blank_query_returns_400():
+    with patch(FIND) as mock_find:
+        resp = APIClient().get(SIMILAR_URL, {"q": "   "})
+    assert resp.status_code == 400
+    mock_find.assert_not_called()
+
+
+@override_settings(FORUM_VECTOR_SEARCH_ENABLED=True)
+@pytest.mark.django_db
+def test_returns_serialized_ranked_results():
+    topic = _topic("Tomato blight", "tomato blight on leaves")
+    with patch(FIND, return_value=[topic]) as mock_find:
+        resp = APIClient().get(SIMILAR_URL, {"q": "tomato"})
+    assert resp.status_code == 200
+    results = resp.json()["results"]
+    assert len(results) == 1
+    assert results[0]["id"] == topic.id
+    assert results[0]["slug"] == topic.slug
+    assert results[0]["board_slug"] == topic.board.slug
+    mock_find.assert_called_once()
+
+
+@override_settings(FORUM_VECTOR_SEARCH_ENABLED=True)
+@pytest.mark.django_db
+def test_board_filter_is_passed_through():
+    with patch(FIND, return_value=[]) as mock_find:
+        APIClient().get(SIMILAR_URL, {"q": "tomato", "board": "general"})
+    assert mock_find.call_args.kwargs.get("board_slug") == "general"
+
+
+@override_settings(FORUM_VECTOR_SEARCH_ENABLED=True)
+@pytest.mark.django_db
+def test_result_cache_hit_skips_second_search():
+    topic = _topic("Tomato blight", "tomato blight")
+    with patch(FIND, return_value=[topic]) as mock_find:
+        first = APIClient().get(SIMILAR_URL, {"q": "tomato"})
+        second = APIClient().get(SIMILAR_URL, {"q": "tomato"})
+    assert first.status_code == second.status_code == 200
+    # Second identical query is served from the result cache — no re-embed.
+    mock_find.assert_called_once()
+
+
+@override_settings(
+    FORUM_VECTOR_SEARCH_ENABLED=True, FORUM_RATELIMITS={"similar_topics": "1/m"}
+)
+@pytest.mark.django_db
+def test_similar_get_is_throttled_per_ip():
+    with freeze_time("2026-07-22 12:00:00"), patch(FIND, return_value=[]):
+        first = APIClient().get(SIMILAR_URL, {"q": "tomato"})
+        second = APIClient().get(SIMILAR_URL, {"q": "rose"})
+    assert first.status_code == 200
+    assert second.status_code == 429
+
+
+# --------------------------------------------------------------------------- #
+# find_similar_topics — gating                                                 #
+# --------------------------------------------------------------------------- #
+
+
+@override_settings(FORUM_VECTOR_SEARCH_ENABLED=False)
+@pytest.mark.django_db
+def test_find_returns_empty_when_feature_disabled():
+    assert find_similar_topics("tomato") == []
+
+
+@override_settings(FORUM_VECTOR_SEARCH_ENABLED=True)
+@pytest.mark.django_db
+def test_find_returns_empty_for_blank_query():
+    assert find_similar_topics("   ") == []
+
+
+# --------------------------------------------------------------------------- #
+# End-to-end pgvector build + search (deterministic fake embedder)             #
+# --------------------------------------------------------------------------- #
+
+
+@override_settings(FORUM_VECTOR_SEARCH_ENABLED=True, OPENAI_API_KEY=_FAKE_OPENAI_KEY)
+@pytest.mark.django_db
+def test_similar_topics_ranks_by_semantic_similarity():
+    tomato = _topic("Tomato blight help", "my tomato has blight", suffix="tom")
+    _topic("Rose pruning", "how to prune a rose", suffix="ros")
+    _topic("Compost and soil", "best compost for soil", suffix="soi")
+
+    with patch.object(LLMService, "embedding", _fake_embedding):
+        SimilarTopics().build()  # real pgvector store
+        results = find_similar_topics("tomato blight", limit=2)
+
+    assert results, "expected at least one similar topic"
+    assert results[0].id == tomato.id  # closest by keyword-vector cosine
+
+
+@override_settings(FORUM_VECTOR_SEARCH_ENABLED=True, OPENAI_API_KEY=_FAKE_OPENAI_KEY)
+@pytest.mark.django_db
+def test_similar_topics_excludes_restricted_board():
+    public = _topic("Tomato blight", "tomato blight", suffix="pub")
+    secret_board = _board(suffix="secret", restricted=True)
+    secret = _topic(
+        "Tomato secret", "tomato blight classified", suffix="sec", board=secret_board
+    )
+
+    with patch.object(LLMService, "embedding", _fake_embedding):
+        SimilarTopics().build()
+        results = find_similar_topics("tomato blight")
+
+    ids = {t.id for t in results}
+    assert public.id in ids
+    # A restricted-board topic is never embedded nor returned (authz boundary).
+    assert secret.id not in ids

--- a/backend/apps/forum_host/tests/test_similar.py
+++ b/backend/apps/forum_host/tests/test_similar.py
@@ -208,3 +208,20 @@ def test_similar_topics_excludes_restricted_board():
     assert public.id in ids
     # A restricted-board topic is never embedded nor returned (authz boundary).
     assert secret.id not in ids
+
+
+@override_settings(FORUM_VECTOR_SEARCH_ENABLED=True, OPENAI_API_KEY=_FAKE_OPENAI_KEY)
+@pytest.mark.django_db
+def test_board_filter_narrows_results_to_that_board():
+    board_a = _board(suffix="a")
+    board_b = _board(suffix="b")
+    ta = _topic("Tomato A", "tomato blight", suffix="ta", board=board_a)
+    _topic("Tomato B", "tomato blight", suffix="tb", board=board_b)
+
+    with patch.object(LLMService, "embedding", _fake_embedding):
+        SimilarTopics().build()
+        results = find_similar_topics("tomato blight", board_slug=board_a.slug)
+
+    ids = {t.id for t in results}
+    assert ta.id in ids
+    assert all(t.board_id == board_a.id for t in results)

--- a/backend/apps/forum_host/vector_indexes.py
+++ b/backend/apps/forum_host/vector_indexes.py
@@ -134,7 +134,13 @@ def find_similar_topics(
         pk__in=ordered_pks, live=True, board__in=_visible_boards()
     ).select_related("board")
     if board_slug:
-        qs = qs.filter(board__slug=board_slug)
+        # Resolve the slug to visible board ids (Wagtail slugs are unique only
+        # among siblings, so two boards can share one) and filter on board_id —
+        # mirrors SearchView, avoiding a cross-board over-match.
+        board_ids = list(
+            _visible_boards().filter(slug=board_slug).values_list("id", flat=True)
+        )
+        qs = qs.filter(board_id__in=board_ids)
     by_pk = {t.pk: t for t in qs}
     ranked = [by_pk[pk] for pk in ordered_pks if pk in by_pk]
     return ranked[:limit]

--- a/backend/apps/forum_host/vector_indexes.py
+++ b/backend/apps/forum_host/vector_indexes.py
@@ -1,0 +1,140 @@
+"""Semantic "similar topics" vector index for the forum (todo 255 slice 4 / H15).
+
+Host-side (not the wagtail_forum package) so it may reach the forum models and
+the visibility predicate. Registers a django-ai-core ``VectorIndex`` over live,
+publicly-visible forum topics, backed by pgvector storage + OpenAI embeddings.
+
+Import-safety contract (this module is imported at ``AppConfig.ready()``):
+- NOTHING at module/class-definition scope may need ``OPENAI_API_KEY`` or hit the
+  DB. ``LLMService.create`` raises ``MissingApiKeyError`` with an empty key, so
+  the embedding transformer AND the source queryset are built lazily in
+  ``SimilarTopics.__init__`` (instance attrs, read by the base ``__init__``).
+- ``storage_provider = PgVectorProvider()`` is safe at class-def (no key/DB).
+
+The feature gates on ``settings.FORUM_VECTOR_SEARCH_ENABLED`` (default False):
+``find_similar_topics`` short-circuits to ``[]`` when off, so no embedding API
+call ever fires in dev/CI. Populate the index with
+``python manage.py rebuild_indexes SimilarTopics``.
+
+See docs/superpowers/specs/2026-07-22-forum-similar-topics-pgvector-design.md.
+"""
+
+import logging
+
+from django.conf import settings
+from django_ai_core.contrib.index import (
+    CoreEmbeddingTransformer,
+    ModelSource,
+    VectorIndex,
+    registry,
+)
+from django_ai_core.contrib.index.embedding_cache import CachedEmbeddingTransformer
+from django_ai_core.contrib.index.storage.pgvector.provider import PgVectorProvider
+from django_ai_core.llm import LLMService
+from wagtail_forum.api.views import _visible_boards, plain_text_excerpt
+from wagtail_forum.models import Topic
+
+from . import constants
+
+logger = logging.getLogger(__name__)
+
+
+def _build_embedding_transformer():
+    """Build the OpenAI-backed, content-hash-caching embedding transformer.
+
+    Reads ``OPENAI_API_KEY`` — call only at index instantiation (never import),
+    and only when the feature is enabled. The cache wrapper means a rebuild
+    re-embeds only changed topics.
+    """
+    llm = LLMService.create(
+        provider="openai",
+        model=settings.FORUM_EMBED_MODEL,
+        api_key=settings.OPENAI_API_KEY,
+    )
+    return CachedEmbeddingTransformer(CoreEmbeddingTransformer(llm))
+
+
+class TopicSource(ModelSource):
+    """Vectorize a topic's title + opening-post plaintext.
+
+    Overrides ``get_content`` because ``Post.body`` is a Wagtail StreamField —
+    the default ``str()`` extraction would embed block-HTML junk. ``plain_text_excerpt``
+    pulls clean text via ``raw_data`` (no per-post image bulk-fetch).
+    """
+
+    def get_content(self, obj) -> str:
+        parts = [obj.title]
+        opening = obj.posts.filter(live=True, is_opening_post=True).first()
+        if opening is not None:
+            parts.append(
+                plain_text_excerpt(opening.body, constants.SIMILAR_CONTENT_MAX_CHARS)
+            )
+        return "\n".join(p for p in parts if p)
+
+
+@registry.register()
+class SimilarTopics(VectorIndex):
+    storage_provider = PgVectorProvider()
+    sources = []  # set lazily in __init__ (see module docstring)
+    embedding_transformer = None  # set lazily in __init__
+
+    def __init__(self):
+        # Both deferred to instantiation, never class-def/import:
+        #  - source queryset filtered through _visible_boards() so restricted-
+        #    board content is NEVER embedded (defense in depth).
+        #  - transformer built here so LLMService's empty-key error can't fire
+        #    at import (dev/CI have no key).
+        self.sources = [
+            TopicSource(
+                queryset=Topic.objects.filter(live=True, board__in=_visible_boards())
+            )
+        ]
+        self.embedding_transformer = _build_embedding_transformer()
+        super().__init__()
+
+
+def find_similar_topics(
+    query: str, board_slug: str | None = None, limit: int | None = None
+):
+    """Return live, visible topics semantically similar to ``query``.
+
+    Returns ``[]`` when the feature is disabled, the query is blank, the index is
+    empty, or the provider errors — never raises to the caller. Results are
+    refetched through ``_visible_boards()`` (board privacy) in vector-score order.
+    """
+    if not getattr(settings, "FORUM_VECTOR_SEARCH_ENABLED", False):
+        return []
+    query = (query or "").strip()
+    if not query:
+        return []
+    limit = limit or constants.SIMILAR_TOPICS_LIMIT
+
+    try:
+        docs = list(
+            SimilarTopics().search_documents(query)[
+                : limit * constants.SIMILAR_OVERFETCH
+            ]
+        )
+    except Exception:
+        logger.exception("[ERROR] similar-topics vector search failed")
+        return []
+
+    # pks in vector-score order (search_documents returns ordered by distance).
+    ordered_pks: list = []
+    for doc in docs:
+        pk = (doc.metadata or {}).get("pk")
+        if pk is not None and pk not in ordered_pks:
+            ordered_pks.append(pk)
+    if not ordered_pks:
+        return []
+
+    # Refetch through the visibility predicate — the index may contain a topic
+    # whose board was restricted AFTER indexing; never leak it.
+    qs = Topic.objects.filter(
+        pk__in=ordered_pks, live=True, board__in=_visible_boards()
+    ).select_related("board")
+    if board_slug:
+        qs = qs.filter(board__slug=board_slug)
+    by_pk = {t.pk: t for t in qs}
+    ranked = [by_pk[pk] for pk in ordered_pks if pk in by_pk]
+    return ranked[:limit]

--- a/backend/plant_community_backend/settings.py
+++ b/backend/plant_community_backend/settings.py
@@ -175,6 +175,14 @@ THIRD_PARTY_APPS = [
     "allauth.socialaccount",
     "allauth.socialaccount.providers.google",
     "allauth.socialaccount.providers.github",
+    # django-ai-core vector index for the forum "similar topics" feature
+    # (todo 255 slice 4 / H15). The pgvector storage app ships the
+    # `CREATE EXTENSION vector` migration; the index app owns the embedding +
+    # embedding-cache tables. Always installed (the migration runs wherever the
+    # vector extension is available — local/CI-pgvector-image/Railway); the
+    # feature itself gates on FORUM_VECTOR_SEARCH_ENABLED (below).
+    "django_ai_core.contrib.index",
+    "django_ai_core.contrib.index.storage.pgvector",
 ]
 
 # Local Apps
@@ -786,6 +794,18 @@ WAGTAILFORUM_SPAM_BACKEND = config(
     "WAGTAILFORUM_SPAM_BACKEND",
     default="wagtail_forum.spam.heuristic.HeuristicSpamBackend",
 )
+
+# Forum semantic "similar topics" (todo 255 slice 4 / H15). The pgvector index
+# apps are always installed (the CREATE EXTENSION migration runs wherever the
+# vector extension is present), but the endpoint + any embedding API spend gate
+# on this flag. Default OFF: no accidental embedding cost over an empty forum;
+# enable in prod (with a working OPENAI_API_KEY + a rebuilt index) when there is
+# a corpus worth searching. Embeddings use FORUM_EMBED_MODEL via the openai
+# provider (reuses OPENAI_API_KEY).
+FORUM_VECTOR_SEARCH_ENABLED = config(
+    "FORUM_VECTOR_SEARCH_ENABLED", default=False, cast=bool
+)
+FORUM_EMBED_MODEL = config("FORUM_EMBED_MODEL", default="text-embedding-3-small")
 
 # Firebase Admin SDK service-account JSON path — the CANONICAL credentials
 # setting: both the auth token exchange (apps/users) and the FCM sender

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -136,6 +136,7 @@ parso==0.8.5
 pathspec==1.1.1
 pexpect==4.9.0
 pilkit==3.0
+pgvector==0.5.0
 pillow==12.3.0
 pillow_heif==1.3.0
 pluggy==1.6.0

--- a/docs/superpowers/specs/2026-07-22-forum-similar-topics-pgvector-design.md
+++ b/docs/superpowers/specs/2026-07-22-forum-similar-topics-pgvector-design.md
@@ -1,0 +1,172 @@
+# Design — Forum semantic "similar topics" via pgvector (todo 255, slice 4 / H15)
+
+Branch `todo-255-slice4-similar-topics` (off fresh `main` AFTER slice 3 merges).
+Epic todo `todos/255-in_progress-p1-forum-ai-premium.md`. Source finding H15.
+User decision 2026-07-22: **build H15 now** (precheck GREEN — see slice-3 spec).
+
+## Problem
+
+H15 = semantic "similar topics" using django-ai-core's dormant pgvector index.
+Precheck confirmed Railway PG18 exposes `vector 0.8.2` and the app role is
+superuser, so `CREATE EXTENSION vector` succeeds at deploy. This slice activates
+the vector index over forum Topics and ships a compose-time similar-topics
+endpoint.
+
+## Substrate (verified against installed source, django-ai-core 0.1.5)
+
+- **No settings read, NO autodiscovery** — an index registers only when the
+  module defining its `@registry.register()` class is imported. We force the
+  import from `ForumHostConfig.ready()`.
+- `VectorIndex` subclass with class attrs `sources`, `embedding_transformer`,
+  `storage_provider`. `search_documents(q)` → scored `BaseStorageDocument`s
+  (`score = 1 - cosine_distance`, `metadata["pk"]`); `find_similar(obj)` →
+  model instances (no score, INCLUDES the query object). Default page size 20 →
+  slice to limit.
+- `ModelSource(queryset=..., content_fields=...)`; `str()`s each field →
+  StreamField renders junk, so we **override `get_content`** to emit
+  `title + first-post plaintext`.
+- `CoreEmbeddingTransformer(LLMService.create(provider="openai",
+  model="text-embedding-3-small", api_key=...))` — 1536-dim. `PgVectorProvider()`
+  (no dim kwarg; `VectorField()` is unbounded → accepts 1536 unchanged).
+- **`LLMService.create` RAISES `MissingApiKeyError` at construction with an empty
+  key** (verified) → the transformer must be built LAZILY (at index
+  instantiation), never at class-def/import.
+- Latent package bug: `find_similar` `UnboundLocalError` if the passed object's
+  exact type isn't a registered source — we use `search_documents(query_str)`
+  (string query), which avoids it and fits the compose use case.
+
+## Environments — pgvector availability (verified 2026-07-22)
+
+| Env | vector ext | action |
+|-----|-----------|--------|
+| Local dev/test | 0.8.1 available | none (migration works) |
+| CI `backend-tests` | `postgres:16` → **lacks vector** | **swap service image → `pgvector/pgvector:pg16`** |
+| CI `backend-checks` | SQLite, no migrate | none (imports only; pgvector pip pkg present) |
+| Prod (Railway) | 0.8.2, superuser | none (migration works) |
+
+The `CREATE EXTENSION vector` migration (shipped by the pgvector storage app)
+runs at every migrated test-DB creation, so CI's Postgres MUST have vector →
+the one-line image swap is mandatory, independent of any feature flag.
+
+## Gating — `FORUM_VECTOR_SEARCH_ENABLED` (default False)
+
+The apps + migration are **always installed** (all envs have vector; CI tested).
+The **endpoint + any embedding spend** gate behind
+`FORUM_VECTOR_SEARCH_ENABLED = config(..., default=False, cast=bool)`:
+
+- Off (dev/CI default): endpoint returns `503 {"detail":"not enabled"}`; no
+  embedding API call ever fires → zero accidental spend over the empty forum.
+- On (prod, when there's a corpus + a real `OPENAI_API_KEY`): live.
+
+This mirrors slice-2's "ship the capability, enable by one setting" posture. The
+index is registered regardless (import is key-free via lazy transformer), so
+`rebuild_indexes` works wherever a key + flag are set.
+
+## Architecture
+
+### `apps/forum_host/vector_indexes.py`
+
+```python
+@registry.register()
+class SimilarTopics(VectorIndex):
+    storage_provider = PgVectorProvider()
+    sources = []                          # set in __init__ (see below)
+    embedding_transformer = None          # lazy — set in __init__, NOT import
+
+    def __init__(self):
+        # BOTH deferred to instantiation, never class-def/import:
+        #  - source queryset filtered through _visible_boards() so restricted-
+        #    board content is NEVER embedded (defense in depth, not just a
+        #    query-time refetch filter — mirrors the slice-3 authz lesson).
+        #  - transformer built here so LLMService.create's empty-key
+        #    MissingApiKeyError can't fire at import (dev/CI have no key).
+        self.sources = [TopicSource(
+            queryset=Topic.objects.filter(live=True, board__in=_visible_boards())
+        )]
+        self.embedding_transformer = _build_embedding_transformer()  # reads key
+        super().__init__()
+
+class TopicSource(ModelSource):
+    def get_content(self, obj) -> str:
+        # title + first live post's StreamField body as plaintext
+        ...
+```
+
+> **Spikes PASSED 2026-07-22** (both required before building, per advisor):
+>
+> - `VectorIndex.__init__` reads `self.storage_provider/sources/embedding_transformer`
+>   (all instance access, `base.py:31-44`), so setting `self.sources` +
+>   `self.embedding_transformer` before `super().__init__()` wires the instance
+>   values — verified by a runtime spike (sentinel transformer arrived in the
+>   QueryHandler; `index_name` resolved). `storage_provider = PgVectorProvider()`
+>   stays a class attr (no key/DB at construction).
+> - App labels `index`, `pgvector`, `django_ai_core` are all free (no collision
+>   among the 52 installed apps).
+
+`_build_embedding_transformer()` = `CachedEmbeddingTransformer(CoreEmbeddingTransformer(
+LLMService.create(provider="openai", model=EMBED_MODEL, api_key=settings.OPENAI_API_KEY)))`
+— cached-embeddings so a rebuild only re-embeds changed content (content-hash
+cache table). Reads the key at instantiation only.
+
+`find_similar_topics(query, board_slug=None, limit=K) -> list[Topic]`:
+
+- returns `[]` if `not FORUM_VECTOR_SEARCH_ENABLED`.
+- `docs = SimilarTopics().search_documents(query)`, take pks from
+  `metadata["pk"]` in score order, refetch **through `_visible_boards()`** (board
+  privacy — the slice-3 authz lesson), optional board-slug filter, exclude none,
+  cap at `limit`. Never raises to the caller (log + `[]` on any provider fault).
+
+### `apps/forum_host/similar.py` — `SimilarTopicsView(APIView)`
+
+- `GET /api/v1/forum/topics/similar/?q=<text>&board=<slug>` — compose-time.
+- Auth: `IsAuthenticatedOrReadOnly`-style public read (audit: "arguably
+  free-for-all"); throttled per-IP `_throttled("similar_topics","GET",key=client_ip_key)`
+  like `search`. Result cached by `(q, board)` hash (short TTL) to bound
+  embedding spend on debounced typing.
+- `503` when the flag is off; `200 {"results":[{id,slug,title,board_slug,...}]}`
+  otherwise. `q` required (400 if blank), bounded length.
+
+### Registration — `apps/forum_host/apps.py`
+
+`ForumHostConfig.ready()` imports `vector_indexes` unconditionally (import is
+key-free), so `rebuild_indexes SimilarTopics` sees it. (If `apps.py` has no
+AppConfig yet, add one + set `default_app_config`/`INSTALLED_APPS` entry.)
+
+### Rebuild
+
+Ships with the package command: `python manage.py rebuild_indexes SimilarTopics`
+(re-embeds via the cached transformer — unchanged topics are free). NOT wired to
+Celery beat (empty corpus → no schedule yet); documented as the operator step.
+A thin `forum_host` management passthrough is out of scope (YAGNI).
+
+## Files changed
+
+- `backend/requirements.txt` — add `pgvector==0.4.1`.
+- `backend/plant_community_backend/settings.py` — 2 INSTALLED_APPS
+  (`django_ai_core.contrib.index`, `...storage.pgvector`); `FORUM_VECTOR_SEARCH_ENABLED`;
+  `FORUM_EMBED_MODEL` default; watch the index app's bare label `index` for collision.
+- `.github/workflows/backend-ci.yml` — `postgres:16` → `pgvector/pgvector:pg16`.
+- `apps/forum_host/vector_indexes.py`, `similar.py` (new); `apps.py` (ready());
+  `api.py` (+`_throttled` wrapper or reuse), `api_urls.py` (route),
+  `constants.py` (rate + K + TTL + model + cache prefix + max chars).
+- Tests `tests/test_similar.py`; drift-guard `HOST_ONLY_ROUTES` += similar route;
+  `test_schema_429` += similar GET.
+- `CLAUDE.md` env table += `FORUM_VECTOR_SEARCH_ENABLED`.
+
+## Testing
+
+- **View tests** (mock `find_similar_topics`): flag-off → 503; blank q → 400;
+  ranked results serialized; throttle fires; board filter passed through.
+- **Integration test** (real pgvector, MOCK only the embedding transformer to
+  return deterministic vectors; flag on via `override_settings` + a fake key):
+  build a 3-topic index, `search_documents("...")` returns them ranked; a
+  restricted-board topic is excluded from `find_similar_topics` (authz).
+- Never calls the real OpenAI embeddings API. `makemigrations --check` clean
+  (apps own their migrations); `spectacular` OK; full `apps/forum_host` +
+  `apps/blog` green on local pgvector.
+
+## Acceptance criteria satisfied (epic AC #5, #6)
+
+- #5: precheck recorded GREEN (slice 3) + similar-topics endpoint SHIPPED.
+- #6: M13 RAG stays unstarted — this slice builds only the H15 index+endpoint,
+  no retrieval-augmented generation.

--- a/todos/255-in_progress-p1-forum-ai-premium.md
+++ b/todos/255-in_progress-p1-forum-ai-premium.md
@@ -232,6 +232,47 @@ consumer until Waves 3/4, recurring embeddings cost), surfaced to the user.
 main after slice 3 merges). See
 `docs/superpowers/specs/2026-07-22-forum-similar-topics-pgvector-design.md`.
 
+### 2026-07-22 - Slice 4: semantic similar-topics via pgvector (H15) DONE
+
+Branch `todo-255-slice4-similar-topics` (off fresh main, after slice 3 merged as
+PR 484). Spec:
+`docs/superpowers/specs/2026-07-22-forum-similar-topics-pgvector-design.md`.
+
+- **H15** — activated django-ai-core's dormant vector index. `GET
+  /api/v1/forum/topics/similar/?q=&board=` (`apps/forum_host/similar.py`) →
+  compose-time semantic search over live, **visible** topics; public read,
+  per-IP throttled (`30/m`), result-cached by `(q, board)`. Gated behind
+  `FORUM_VECTOR_SEARCH_ENABLED` (default False → `503`, zero embedding spend over
+  the empty forum). `SimilarTopics` `VectorIndex` (`vector_indexes.py`) over
+  Topic title + opening-post plaintext, lazy OpenAI embedder (`text-embedding-3-small`)
+  - `PgVectorProvider`; registered in `apps.py` `ready()`. `find_similar_topics`
+  filters the **source queryset AND the refetch** through `_visible_boards()`
+  (the slice-3 authz lesson — restricted-board content is never embedded nor
+  returned), and never raises to the caller.
+  - **Infra:** 2 INSTALLED_APPS + the shipped `CREATE EXTENSION vector` migration
+    (local PG18 + Railway PG18 have `vector`; CI Postgres swapped
+    `postgres:16` → `pgvector/pgvector:pg16`). `pgvector==0.5.0` — 0.4.1's
+    `VectorExtension` predates Django 6.0's `hints` requirement and crashes
+    `migrate`. Populate with `manage.py rebuild_indexes SimilarTopics`.
+  - **Design traps handled:** `LLMService.create` raises `MissingApiKeyError` on
+    an empty key → transformer + source queryset built lazily in `__init__`
+    (instance attrs, verified read by the base `__init__`); no autodiscovery →
+    forced import in `ready()`; the `find_similar` UnboundLocalError bug avoided
+    by using `search_documents(query_str)`.
+- Verified: `manage.py check` (Postgres + SQLite) clean; `makemigrations --check`
+  no changes (apps own their migrations); `spectacular` OK (similar GET documents
+  200/400/503/429); `pytest apps/forum_host --create-db` → 150 passed (11 new in
+  `test_similar.py`, incl. real pgvector build+search with a deterministic fake
+  embedder + restricted-board exclusion); `apps/blog apps/users` → 329 passed.
+- **Pre-enablement follow-up (NOT blocking the dormant merge; before the flag is
+  ever set True in prod):** the query-embedding path has no *aggregate* AI-budget
+  cap — only per-IP throttle + result cache. The summary/spam paths check
+  `AIRateLimiter.check_global_limit()`; similar-topics does not, because that
+  counter (`ai_rate_limit:global`) is shared with blog/forum *completions* and the
+  slice-2 note already flags that sharing as problematic. Add a **dedicated
+  embedding budget** (separate key) before enabling, so a distributed query burst
+  can't run up unbounded embedding cost.
+
 ## Notes
 
 p1 by user triage decision. All research verdicts for H13/H14/H15/M12/M14 were


### PR DESCRIPTION
## Summary

Final slice of the forum AI/premium epic (todo 255). Activates django-ai-core's dormant pgvector index to ship semantic **"similar topics"** (finding H15). Precheck (slice 3) confirmed GREEN; user chose to build it fully.

`GET /api/v1/forum/topics/similar/?q=<text>&board=<slug>`:
- **Compose-time semantic search** over live, **visible** topics; public read, per-IP throttled (`30/m`), result-cached by `(q, board)`.
- **Gated behind `FORUM_VECTOR_SEARCH_ENABLED`** (default `False` → `503`, zero embedding spend over the empty forum). Enable in prod (with `OPENAI_API_KEY` + a built index) when there's a corpus.
- `find_similar_topics()` filters the **source queryset AND the refetch** through `_visible_boards()` — restricted-board content is never embedded nor returned (the slice-3 authz lesson) — and never raises to the caller.

## Infra
- 2 INSTALLED_APPS + the shipped `CREATE EXTENSION vector` migration. Local PG18 + Railway PG18 have `vector`; **CI Postgres swapped `postgres:16` → `pgvector/pgvector:pg16`** so the migration applies in CI.
- `pgvector==0.5.0` — 0.4.1's `VectorExtension` predates Django 6.0's `hints` requirement and crashes `migrate`.
- `SimilarTopics` `VectorIndex` over Topic title + opening-post plaintext, **lazy** OpenAI embedder (`LLMService.create` raises on an empty key, so it's built at instantiation, not import) + `PgVectorProvider`; registered in `apps.py` `ready()` (no autodiscovery). Populate: `manage.py rebuild_indexes SimilarTopics`.

## Test plan
- `pytest apps/forum_host --create-db` → **150 passed** (11 new in `test_similar.py`: gating/503, blank-q/400, serialization, board-filter narrowing, throttle, and **real pgvector build+search** with a deterministic fake embedder + restricted-board exclusion).
- `manage.py check` (Postgres + SQLite) clean; `makemigrations --check` no changes; `spectacular` OK (similar GET documents 200/400/503/429); `apps/blog apps/users` → 329 passed.

## Pre-enablement follow-up (documented, non-blocking; feature ships dormant)
The query-embedding path has no *aggregate* AI-budget cap (only per-IP throttle + result cache). Before flipping the flag True in prod, add a **dedicated embedding budget** — the shared `ai_rate_limit:global` completion counter must not absorb embeddings.

Closes the H15/M13 acceptance criteria of todo 255 (M13 RAG remains correctly unstarted — this builds only the H15 index+endpoint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)