### PR TITLE
chore: complete + archive todo 255 (forum AI & premium epic)

### DIFF
--- a/docs/LEARNINGS.md
+++ b/docs/LEARNINGS.md
@@ -1554,3 +1554,66 @@ notification` + a screencap.
   the device tray — three delivery test sends showed as three distinct
   `FCM-Notification` records. Collapse-key coalescing is a network/offline-queue
   behavior, not an on-device replace.
+
+## Forum AI features epic — todo 255 (2026-07-22)
+
+### [2026-07-22] HIGH authz bypass: a NEW host-side AI endpoint skipped the forum board-visibility filter
+
+**What broke:** the H14 premium AI thread-summary endpoint
+(`apps/forum_host/summary.py`, `TopicSummaryView` + `generate_topic_summary`)
+fetched the topic with `Topic.objects.filter(pk=topic_id, live=True)` — omitting
+the `board__in=_visible_boards()` guard every other forum topic/post view
+enforces via `_get_visible_topic`. A premium/staff user could summarize a
+thread on a restricted (`PageViewRestriction`) board they cannot otherwise read;
+the summary is built directly from the restricted posts' bodies. Caught by the
+CI "Claude Code Security Review", NOT by the bundled `/code-review` nor the local
+suites.
+
+**Root cause:** `PageViewRestriction` is not auto-enforced in custom views/APIs
+(a known rule in `docs/rules/wagtail.md`), but the write-time JIT trigger that
+would have flagged it (`forum-api-queryset-missing-visibility-filter`) was scoped
+ONLY to the reusable package (`backend/packages/wagtail_forum/wagtail_forum/api/*.py`)
+— it never covered host endpoints in `apps/forum_host/`. A brand-new endpoint
+TYPE (AI summary) in the uncovered directory slipped straight through.
+
+**Fix:** route the lookup through `_get_visible_topic(topic_id)` (endpoint) and
+`board__in=_visible_boards()` (Celery task, defense in depth); both 404/no-op a
+restricted-board topic with no existence leak. Broadened the JIT trigger to
+`backend/apps/forum_host/*.py`. The same guard was applied up-front to the H15
+similar-topics feature, filtering BOTH the vector-index source queryset (never
+embed restricted content) AND the query-time refetch. Lesson: a visibility (or
+any security) trigger scoped to one directory does not protect a sibling
+directory — when a new host-side endpoint type reads shared domain content,
+re-audit which triggers actually cover its path.
+
+### [2026-07-22] django-ai-core + pgvector activation gotchas (Django 6.0)
+
+Activating the dormant `django_ai_core.contrib.index` pgvector stack (H15)
+surfaced four load-bearing gotchas, all verified against installed source:
+
+- **`pgvector==0.4.1` crashes `migrate` on Django 6.0.** Its `VectorExtension`
+  overrides `CreateExtension.__init__` setting only `self.name='vector'`, never
+  `self.hints`, which Django 6.0's `CreateExtension` requires →
+  `AttributeError: 'VectorExtension' object has no attribute 'hints'` at the
+  `CREATE EXTENSION vector` migration. **Pin `pgvector==0.5.0`** — it guards
+  `if VERSION[0] >= 6: super().__init__('vector', hints=hints)`.
+- **`LLMService.create(provider="openai", api_key="")` raises
+  `MissingApiKeyError` at CONSTRUCTION** (not at first call). A `VectorIndex`
+  that builds its embedding transformer as a class attribute therefore fails to
+  IMPORT wherever the key is unset (dev/CI/local tests). Build the transformer
+  (and the source queryset) LAZILY in `__init__` (instance attrs — the base
+  `VectorIndex.__init__` reads `self.*`, so they shadow the class attrs).
+- **django-ai-core has NO autodiscovery.** An index registers only when the
+  module holding its `@registry.register()` class is imported — force it from
+  `AppConfig.ready()`, else `rebuild_indexes` reports "No indexes registered".
+- **CI Postgres must carry the `vector` extension.** GitHub's stock
+  `postgres:16` service image lacks it → the always-run `CREATE EXTENSION vector`
+  migration fails the whole suite. Swap the service image to
+  `pgvector/pgvector:pg16`. (Local PG18 + Railway PG18 already have it — verify
+  with `SELECT * FROM pg_available_extensions WHERE name='vector'` against the
+  target, e.g. Railway's `DATABASE_PUBLIC_URL` proxy.)
+
+Secondary tooling snag: the `detect-secrets` pre-commit hook flags any
+`OPENAI_API_KEY="..."` string literal (keyword detector, value-agnostic) — in a
+TEST, assign the fake key to a named constant with a `# pragma: allowlist secret`
+line and stage the updated `.secrets.baseline`.

--- a/docs/audits/2026-07-11-forum-modernization.md
+++ b/docs/audits/2026-07-11-forum-modernization.md
@@ -301,8 +301,8 @@ Deferred findings converted to todos (Review Doc Tracking convention — the
 - [ ] #H11 mobile-forum-client → todo 260
 - [x] #H12 entitlement-primitive → todo 255 (completed 2026-07-20, slice 1)
 - [x] #H13 llm-spam-prescreen → todo 255 (completed 2026-07-21)
-- [ ] #H14 ai-thread-summarization → todo 255
-- [ ] #H15 semantic-similar-topics → todo 255
+- [x] #H14 ai-thread-summarization → todo 255 (completed 2026-07-22, slice 3)
+- [x] #H15 semantic-similar-topics → todo 255 (completed 2026-07-22, slice 4)
 - [x] #H16 admin-moderation-queue → todo 254 (completed 2026-07-13)
 - [ ] #H18 error-retry-affordance → todo 259
 - [ ] #H21 tombstone-prune-scheduling → todo 261
@@ -318,9 +318,9 @@ Deferred findings converted to todos (Review Doc Tracking convention — the
 - [ ] #M9 block-mute → todo 263
 - [ ] #M10 private-messaging → todo 263
 - [ ] #M11 post-permalinks → todo 256
-- [ ] #M12 semantic-search-upgrade → todo 255
-- [ ] #M13 rag-plant-care → todo 255
-- [ ] #M14 ai-composer-assist → todo 255
+- [ ] #M12 semantic-search-upgrade → todo 275 (re-pointed 2026-07-22; not in 255's AC)
+- [ ] #M13 rag-plant-care → todo 275 (re-pointed 2026-07-22; 255 held it unstarted per gate)
+- [ ] #M14 ai-composer-assist → todo 275 (re-pointed 2026-07-22; not in 255's AC)
 - [x] #M16 preview-support → todo 254 (completed 2026-07-13)
 - [ ] #M17 i18n → todo 262
 - [ ] #M18 package-readme → todo 262

--- a/docs/rules/forum.md
+++ b/docs/rules/forum.md
@@ -51,3 +51,14 @@ Compact checklist auto-injected before edits to the forum code. Long-form:
   `Notification` row that was never persisted). Caught by kimi-review, not the
   domain reviewers, in `forum_host/notifications.py`'s `reply_added` branch
   (todo 253 slice 1) — see `backend/docs/patterns/architecture/services.md`.
+- **HOST-side forum views/tasks reading topic or post content MUST enforce board
+  visibility** — `_get_visible_topic(topic_id)` (404s hidden/restricted, no
+  existence leak) or `Topic.objects.filter(..., board__in=_visible_boards())`
+  (both from `wagtail_forum.api.views`). `PageViewRestriction` is NOT
+  auto-enforced. This applies to NEW endpoint types too: the H14 AI
+  thread-summary endpoint (`apps/forum_host/summary.py`) shipped without it and
+  a CI security review flagged a HIGH authz bypass — a premium user could
+  summarize a restricted board's thread (todo 255 slice 3). The package-only
+  visibility trigger did not cover `apps/forum_host/`; a broadened trigger now
+  does. Filter the SOURCE too (e.g. a vector-index queryset), not just the
+  response — never embed/cache restricted content.

--- a/docs/rules/triggers.json
+++ b/docs/rules/triggers.json
@@ -638,5 +638,22 @@
     "source": "codify: feat/forum-wave1-honesty-polish",
     "added": "2026-07-17",
     "severity": "warn"
+  },
+  {
+    "id": "forum-host-view-missing-visibility-filter",
+    "domains": [
+      "forum",
+      "security"
+    ],
+    "path_glob": [
+      "backend/apps/forum_host/*.py"
+    ],
+    "content_present": "Topic\\.objects\\.(filter|get)\\(",
+    "content_absent": "_visible_boards|_get_visible_topic",
+    "message": "Host-side forum view/task querying Topic must enforce board visibility: use _get_visible_topic(topic_id) or Topic.objects.filter(..., board__in=_visible_boards()) (from wagtail_forum.api.views). PageViewRestriction is NOT auto-enforced — else a restricted board`s content leaks (todo 255 slice 3 HIGH authz bypass). Filter the SOURCE too, not just the response.",
+    "pattern_ref": "docs/rules/forum.md",
+    "source": "codify: chore/complete-todo-255",
+    "added": "2026-07-22",
+    "severity": "warn"
   }
 ]

--- a/todos/275-pending-p2-forum-ai-round2.md
+++ b/todos/275-pending-p2-forum-ai-round2.md
@@ -1,0 +1,61 @@
+---
+status: pending
+priority: p2
+issue_id: "275"
+tags: [forum, ai, premium, wagtail-ai, rag]
+dependencies: []
+source_review: "docs/audits/2026-07-11-forum-modernization.md"
+source_finding: "M12, M13, M14"
+---
+
+# Forum AI features, round 2: semantic search upgrade, composer assist, RAG
+
+## Problem
+
+Todo 255 (forum AI & premium epic) shipped the H15 pgvector "similar topics"
+infra: `django_ai_core.contrib.index` is now active (INSTALLED_APPS + the
+`CREATE EXTENSION vector` migration), a `SimilarTopics` `VectorIndex` over forum
+topics, an OpenAI embedder, and a `find_similar_topics()` helper — all behind
+`FORUM_VECTOR_SEARCH_ENABLED`. Three findings from the 2026-07-11 audit were
+bundled into 255 but fell OUTSIDE its acceptance criteria (M12/M14 deferred; M13
+explicitly gated to stay unstarted until H15 landed). H15 has now landed, so all
+three are unblocked.
+
+## Findings (carried from 255)
+
+- **M12 — Semantic search upgrade (premium):** a marginal add now that the H15
+  infra exists. `SimilarTopics.search_documents()` is generic; blend semantic
+  hits into the existing forum `SearchView` (already Postgres FTS with ranking,
+  per H22) so the value-add is synonym/meaning matching. Premium-gated per audit.
+- **M14 — AI-assisted composer (draft improvement):** wagtail-ai's editor
+  machinery is admin-only, so only the backend `generate_ai_text` substrate
+  applies → a bespoke host endpoint + a TipTap toolbar action in `web`. Least
+  favorable cost profile (interactive, uncacheable) — throttle + gate.
+- **M13 — RAG plant-care answers grounded in the site's plant-ID + blog data:**
+  the long-horizon big bet; a strict superset of the H15 infra (which now
+  exists). Needs citation UX + hallucination guardrails (plant-care advice has
+  real-world consequences). Own design round; do it LAST.
+
+## Recommended Action
+
+1. **Before enabling any of these in prod:** land the todo-255 slice-4
+   pre-enablement follow-up — a **dedicated embedding budget** (separate from the
+   shared `ai_rate_limit:global` completion counter) so query embeddings can't
+   run up unbounded cost. Applies to M12 and M13 too (both embed queries).
+2. **M12** first (thinnest): reuse `find_similar_topics`/`search_documents`.
+3. **M14** (bespoke endpoint + web TipTap action).
+4. **M13** RAG last, with its own design round + guardrails.
+
+## Acceptance Criteria
+
+- [ ] M12 semantic search upgrade shipped (premium-gated) or descoped w/ rationale
+- [ ] M14 composer-assist endpoint + web toolbar action, throttled + gated
+- [ ] M13 RAG: own design round completed; shipped with citations + hallucination
+      guardrails, or explicitly descoped with rationale
+- [ ] Dedicated embedding budget in place before any of these is enabled in prod
+
+## Notes
+
+Spun out of todo 255 at its completion (2026-07-22): 255's AC covered H12–H15 +
+L6/L7 + the M13-unstarted gate; M12/M13/M14 were bundled in `source_finding` but
+not in 255's AC. The 2026-07-11 audit Finding Status re-points M12/M13/M14 here.

--- a/todos/archive/255-completed-p1-forum-ai-premium.md
+++ b/todos/archive/255-completed-p1-forum-ai-premium.md
@@ -1,5 +1,5 @@
 ---
-status: in_progress
+status: completed
 priority: p1
 issue_id: "255"
 tags: [forum, ai, premium, wagtail-ai]
@@ -100,11 +100,19 @@ Sequence (dependency-ordered):
 - [x] LLM spam backend runs behind the one-setting swap with timeout +
       heuristic fallback — publish path never blocks on provider outage (tested)
       — slice 2, 2026-07-21
-- [ ] Premium thread-summary endpoint: Celery-generated, content-hash cached,
-      entitlement-gated
-- [ ] pgvector-on-Railway precheck result recorded; similar-topics endpoint
-      shipped if viable (or descoped with rationale)
-- [ ] M13 RAG remains unstarted until H15 infra lands (explicit gate)
+- [x] Premium thread-summary endpoint: Celery-generated, content-hash cached,
+      entitlement-gated — slice 3 (PR 484), 2026-07-22: `TopicSummaryView`
+      (`IsPremiumUser`) + `generate_topic_summary` Celery task + `AICacheService`
+      content-hash cache; 20 tests
+- [x] pgvector-on-Railway precheck result recorded; similar-topics endpoint
+      shipped if viable (or descoped with rationale) — slice 4 (PR 485),
+      2026-07-22: precheck GREEN (recorded above), endpoint built (viable);
+      `GET /forum/topics/similar/` behind `FORUM_VECTOR_SEARCH_ENABLED`; 11 tests
+      incl. real pgvector build+search
+- [x] M13 RAG remains unstarted until H15 infra lands (explicit gate) — held:
+      slices 3–4 built only the H14 summary + H15 index/endpoint; no RAG. M13
+      (plus the non-AC M12/M14) re-pointed to follow-up todo 275 now that H15
+      infra exists
 
 ## Work Log
 
@@ -272,6 +280,22 @@ PR 484). Spec:
   slice-2 note already flags that sharing as problematic. Add a **dedicated
   embedding budget** (separate key) before enabling, so a distributed query burst
   can't run up unbounded embedding cost.
+
+### 2026-07-22 - Epic COMPLETE (all 6 acceptance criteria met)
+
+All AC satisfied across 4 slices: H12 entitlement (#478), H13 LLM spam (#479),
+H14 summary (#484), H15 similar-topics + pgvector precheck (#485); L6/L7 in
+slice 1; M13 gate held (no RAG built). Each slice: bundled `/code-review` +
+CI "Claude Code Security Review" — the latter caught a real HIGH authz bypass on
+the H14 summary endpoint (missing board-visibility filter), fixed before merge
+and re-applied to H15.
+
+**Scope note (honest closeout):** the `source_finding` frontmatter bundled 9
+findings, but 255's AC covered H12–H15 + L6/L7 + the "M13 stays unstarted" gate.
+**M12** (semantic search upgrade) and **M14** (composer assist) were never AC
+items, and **M13** (RAG) was gated unstarted. All three are now unblocked by the
+H15 infra and are re-pointed to **follow-up todo 275** — they are NOT marked done
+here. The 2026-07-11 audit Finding Status checks off only H14 + H15 for this todo.
 
 ## Notes
 


### PR DESCRIPTION
## Summary

Closes out the **forum AI & premium epic** (todo 255). All 6 acceptance criteria met across 4 merged slices:

- H12 entitlement primitive + L6/L7 (#478)
- H13 LLM spam backend (#479)
- H14 premium thread-summary endpoint (#484)
- H15 semantic similar-topics + pgvector precheck (#485)
- M13 gate held (no RAG built)

## What this PR does (docs-only)

- Flips todo 255's remaining AC boxes with evidence; `status: completed`; `git mv` → `todos/archive/`.
- **Honest scope closure:** 255's `source_finding` bundled 9 findings, but its AC covered H12–H15 + L6/L7 + the "M13 stays unstarted" gate. **M12** (semantic search) and **M14** (composer) were never AC items; **M13** (RAG) was gated unstarted. All three — now unblocked by the H15 infra — are spun into **follow-up todo 275** rather than marked done.
- Audit `Finding Status` checks off H14 + H15 and re-points M12/M13/M14 → todo 275 (review doc stays open).

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)