### PR TITLE
forum: SEO surface — per-route meta + sitemap + RSS (todo 256 H9, slice 2)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1178,7 +1178,7 @@
         "filename": "backend/plant_community_backend/settings.py",
         "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
         "is_verified": false,
-        "line_number": 1460
+        "line_number": 1461
       }
     ],
     "backend/run_migrations.py": [
@@ -1514,5 +1514,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-23T01:37:08Z"
+  "generated_at": "2026-07-23T03:55:59Z"
 }

--- a/backend/apps/forum_host/constants.py
+++ b/backend/apps/forum_host/constants.py
@@ -171,3 +171,6 @@ SIMILAR_QUERY_MAX_CHARS = 500
 # (query, board) result set briefly.
 SIMILAR_CACHE_PREFIX = "forum_similar_topics"
 SIMILAR_CACHE_TTL_SECONDS = 300
+
+# Max items in the public forum RSS feed (todo 256 H9).
+FORUM_RSS_MAX_ITEMS = 50

--- a/backend/apps/forum_host/feeds.py
+++ b/backend/apps/forum_host/feeds.py
@@ -1,0 +1,46 @@
+"""RSS feed of the forum's live topics (todo 256 H9).
+
+Items link to the SPA canonical topic URLs (``settings.SITE_URL`` +
+``get_absolute_url``) — the same convention as the sitemap and the
+reply-notification emails. Only live topics on live + **public** boards are
+included; a hidden/view-restricted board's topics never leak (shares the
+``_visible_boards`` boundary).
+"""
+
+from django.conf import settings
+from django.contrib.syndication.views import Feed
+from django.utils.feedgenerator import Rss201rev2Feed
+from wagtail_forum.api.views import _visible_boards
+from wagtail_forum.models import Topic
+
+_SITE_URL = settings.SITE_URL.rstrip("/")
+
+
+class ForumTopicsFeed(Feed):
+    feed_type = Rss201rev2Feed
+    title = "Plant Community — forum topics"
+    description = "The latest topics from the Plant Community forum."
+    MAX_ITEMS = 50
+
+    def link(self):
+        return f"{_SITE_URL}/forum"
+
+    def items(self):
+        return (
+            Topic.objects.filter(live=True, board__in=_visible_boards())
+            .select_related("board")
+            .order_by("-last_post_at", "-id")[: self.MAX_ITEMS]
+        )
+
+    def item_title(self, item):
+        return item.title
+
+    def item_description(self, item):
+        return f"A topic in {item.board.title}."
+
+    def item_link(self, item):
+        # Full frontend URL — Django leaves an already-absolute link untouched.
+        return f"{_SITE_URL}{item.get_absolute_url()}"
+
+    def item_pubdate(self, item):
+        return item.last_post_at or item.updated_at

--- a/backend/apps/forum_host/feeds.py
+++ b/backend/apps/forum_host/feeds.py
@@ -13,23 +13,28 @@ from django.utils.feedgenerator import Rss201rev2Feed
 from wagtail_forum.api.views import _visible_boards
 from wagtail_forum.models import Topic
 
-_SITE_URL = settings.SITE_URL.rstrip("/")
+from .constants import FORUM_RSS_MAX_ITEMS
+
+
+def _site_url():
+    # Read SITE_URL at CALL time (matches tasks.py's email deep-link convention)
+    # so a misconfigured or test-overridden value is always honored.
+    return settings.SITE_URL.rstrip("/")
 
 
 class ForumTopicsFeed(Feed):
     feed_type = Rss201rev2Feed
     title = "Plant Community — forum topics"
     description = "The latest topics from the Plant Community forum."
-    MAX_ITEMS = 50
 
     def link(self):
-        return f"{_SITE_URL}/forum"
+        return f"{_site_url()}/forum"
 
     def items(self):
         return (
             Topic.objects.filter(live=True, board__in=_visible_boards())
             .select_related("board")
-            .order_by("-last_post_at", "-id")[: self.MAX_ITEMS]
+            .order_by("-last_post_at", "-id")[:FORUM_RSS_MAX_ITEMS]
         )
 
     def item_title(self, item):
@@ -40,7 +45,7 @@ class ForumTopicsFeed(Feed):
 
     def item_link(self, item):
         # Full frontend URL — Django leaves an already-absolute link untouched.
-        return f"{_SITE_URL}{item.get_absolute_url()}"
+        return f"{_site_url()}{item.get_absolute_url()}"
 
     def item_pubdate(self, item):
         return item.last_post_at or item.updated_at

--- a/backend/apps/forum_host/sitemaps.py
+++ b/backend/apps/forum_host/sitemaps.py
@@ -1,0 +1,71 @@
+"""Forum sitemap: the /forum landing, boards, and live topics (todo 256 H9).
+
+Every ``<loc>`` is emitted at the SPA **frontend** canonical URL
+(``settings.SITE_URL`` + path) — the SAME base the reply-notification emails use
+(``apps/forum_host/tasks.py``). The backend Wagtail board pages are only a
+minimal crawler fallback (audit H17: "the SPA remains the real forum UI"), so the
+frontend origin is canonical, not the backend host that serves this sitemap.
+
+Security: only live topics on live + **public** boards are listed — a hidden or
+view-restricted board's topics never leak into the sitemap. Mirrors the API's
+visibility boundary.
+"""
+
+from django.conf import settings
+from django.contrib.sitemaps import Sitemap
+from wagtail_forum.api.views import _visible_boards
+from wagtail_forum.models import ForumIndex, Topic
+
+_PROTOCOL, _, _DOMAIN = settings.SITE_URL.partition("://")
+_DOMAIN = _DOMAIN.rstrip("/")
+
+
+class _FrontendSitemap(Sitemap):
+    """Build every ``<loc>`` against the SPA frontend origin (SITE_URL), not the
+    backend host this sitemap is served from."""
+
+    def get_protocol(self, protocol=None):
+        return _PROTOCOL or "https"
+
+    def get_domain(self, site=None):
+        return _DOMAIN
+
+
+class ForumBoardSitemap(_FrontendSitemap):
+    changefreq = "daily"
+    priority = 0.6
+
+    def items(self):
+        # The /forum landing (ForumIndex) plus every public board.
+        return list(ForumIndex.objects.live().public()) + list(_visible_boards())
+
+    def location(self, obj):
+        # Frontend routes: /forum (index) and /forum/{id}-{slug} (board).
+        if isinstance(obj, ForumIndex):
+            return "/forum"
+        return f"/forum/{obj.id}-{obj.slug}"
+
+
+class ForumTopicSitemap(_FrontendSitemap):
+    changefreq = "daily"
+    priority = 0.5
+
+    def items(self):
+        return (
+            Topic.objects.filter(live=True, board__in=_visible_boards())
+            .select_related("board")
+            .order_by("-last_post_at", "-id")
+        )
+
+    def location(self, obj):
+        # Topic.get_absolute_url() -> /forum/{board_id}-{slug}/{id}-{slug}
+        return obj.get_absolute_url()
+
+    def lastmod(self, obj):
+        return obj.last_post_at or obj.updated_at
+
+
+forum_sitemaps = {
+    "forum-boards": ForumBoardSitemap,
+    "forum-topics": ForumTopicSitemap,
+}

--- a/backend/apps/forum_host/sitemaps.py
+++ b/backend/apps/forum_host/sitemaps.py
@@ -16,8 +16,13 @@ from django.contrib.sitemaps import Sitemap
 from wagtail_forum.api.views import _visible_boards
 from wagtail_forum.models import ForumIndex, Topic
 
-_PROTOCOL, _, _DOMAIN = settings.SITE_URL.partition("://")
-_DOMAIN = _DOMAIN.rstrip("/")
+
+def _frontend_parts():
+    """(protocol, domain) of the SPA frontend origin, read at CALL time so a
+    misconfigured or test-overridden SITE_URL is always honored — matches
+    tasks.py's email deep-link convention (also a live settings.SITE_URL read)."""
+    protocol, _, domain = settings.SITE_URL.partition("://")
+    return (protocol or "https"), domain.rstrip("/")
 
 
 class _FrontendSitemap(Sitemap):
@@ -25,10 +30,10 @@ class _FrontendSitemap(Sitemap):
     backend host this sitemap is served from."""
 
     def get_protocol(self, protocol=None):
-        return _PROTOCOL or "https"
+        return _frontend_parts()[0]
 
     def get_domain(self, site=None):
-        return _DOMAIN
+        return _frontend_parts()[1]
 
 
 class ForumBoardSitemap(_FrontendSitemap):

--- a/backend/apps/forum_host/tests/test_seo.py
+++ b/backend/apps/forum_host/tests/test_seo.py
@@ -75,3 +75,58 @@ def test_rss_feed_lists_live_topic_with_frontend_link():
 
     assert "Fern care" in xml
     assert f"{_SITE}{topic.get_absolute_url()}" in xml
+
+
+@pytest.mark.django_db
+def test_rss_feed_excludes_draft_topic():
+    # The feed's own live=True guard needs coverage — the sitemap's is covered by
+    # test_sitemap_excludes_draft_topic, but the feed filters independently.
+    _index, board = _tree()
+    draft = Topic.objects.create(board=board, title="Draft", slug="draft", live=False)
+    xml = APIClient().get("/forum/rss/").content.decode()
+    assert draft.get_absolute_url() not in xml
+
+
+@pytest.mark.django_db
+def test_sitemap_and_feed_exclude_ancestor_restricted_topics():
+    # `.public()` excludes not just directly-restricted pages but descendants of
+    # a restricted ancestor. Restrict the ForumIndex and assert the board + its
+    # topic vanish from both surfaces — locks in the inheritance the code relies on.
+    index, board = _tree()
+    PageViewRestriction.objects.create(page=index, restriction_type="login")
+    topic = Topic.objects.create(board=board, title="Secret", slug="secret", live=True)
+
+    sitemap = APIClient().get("/forum/sitemap.xml").content.decode()
+    feed = APIClient().get("/forum/rss/").content.decode()
+
+    assert topic.get_absolute_url() not in sitemap
+    assert topic.get_absolute_url() not in feed
+    assert f"/forum/{board.id}-general</loc>" not in sitemap
+    assert "<loc>" + _SITE + "/forum</loc>" not in sitemap  # restricted index too
+
+
+@pytest.mark.django_db
+def test_sitemap_and_feed_query_counts_are_flat():
+    # Both endpoints gate visibility via .public() (a PageViewRestriction lookup),
+    # so pin the exact query count — a dropped select_related('board') or a
+    # per-topic query in location()/item_link() would regress it (docs/rules).
+    from django.db import connection
+    from django.test.utils import CaptureQueriesContext
+
+    _index, board = _tree()
+    for i in range(5):
+        Topic.objects.create(board=board, title=f"T{i}", slug=f"t{i}", live=True)
+
+    with CaptureQueriesContext(connection) as ctx:
+        assert APIClient().get("/forum/sitemap.xml").status_code == 200
+    sitemap_queries = len(ctx.captured_queries)
+
+    with CaptureQueriesContext(connection) as ctx:
+        assert APIClient().get("/forum/rss/").status_code == 200
+    rss_queries = len(ctx.captured_queries)
+
+    # Flat regardless of topic count (select_related('board') covers the only FK).
+    # sitemap = 8 (two sections, each with a .public() PageViewRestriction lookup);
+    # rss = 2 (topics query + one .public() lookup). Exact, not <= (docs/rules).
+    assert sitemap_queries == 8, sitemap_queries
+    assert rss_queries == 2, rss_queries

--- a/backend/apps/forum_host/tests/test_seo.py
+++ b/backend/apps/forum_host/tests/test_seo.py
@@ -1,0 +1,77 @@
+"""Forum SEO surface (todo 256 H9): sitemap.xml + RSS feed.
+
+The load-bearing test is visibility: a live topic on a hidden/view-restricted
+board must be ABSENT from both the sitemap and the feed — a public crawl surface
+must never leak restricted content.
+"""
+
+import pytest
+from django.conf import settings
+from rest_framework.test import APIClient
+from wagtail.models import Page, PageViewRestriction
+from wagtail_forum.models import ForumBoard, ForumIndex, Topic
+
+_SITE = settings.SITE_URL.rstrip("/")
+
+
+def _tree():
+    root = Page.objects.get(id=1)
+    index = root.add_child(instance=ForumIndex(title="Forum", slug="forum"))
+    board = index.add_child(instance=ForumBoard(title="General", slug="general"))
+    return index, board
+
+
+@pytest.mark.django_db
+def test_sitemap_lists_index_board_and_live_topic_at_frontend_urls():
+    _index, board = _tree()
+    topic = Topic.objects.create(
+        board=board, title="Monstera care", slug="monstera", live=True
+    )
+
+    resp = APIClient().get("/forum/sitemap.xml")
+    assert resp.status_code == 200
+    xml = resp.content.decode()
+
+    # Every <loc> is the SPA frontend URL (SITE_URL), not the backend host.
+    assert f"<loc>{_SITE}/forum</loc>" in xml  # index
+    assert f"<loc>{_SITE}/forum/{board.id}-general</loc>" in xml  # board
+    assert f"<loc>{_SITE}{topic.get_absolute_url()}</loc>" in xml  # topic
+
+
+@pytest.mark.django_db
+def test_sitemap_excludes_draft_topic():
+    _index, board = _tree()
+    draft = Topic.objects.create(board=board, title="Draft", slug="draft", live=False)
+    xml = APIClient().get("/forum/sitemap.xml").content.decode()
+    assert draft.get_absolute_url() not in xml
+
+
+@pytest.mark.django_db
+def test_sitemap_and_feed_exclude_restricted_board_topics():
+    # LOAD-BEARING: a view-restricted board is invisible to the whole API
+    # (_visible_boards uses .public()); its topics must not leak into the public
+    # crawl surface either.
+    _index, board = _tree()
+    PageViewRestriction.objects.create(page=board, restriction_type="login")
+    topic = Topic.objects.create(board=board, title="Secret", slug="secret", live=True)
+
+    sitemap = APIClient().get("/forum/sitemap.xml").content.decode()
+    feed = APIClient().get("/forum/rss/").content.decode()
+
+    assert topic.get_absolute_url() not in sitemap
+    assert topic.get_absolute_url() not in feed
+    # The restricted board page itself is absent from the sitemap.
+    assert f"/forum/{board.id}-general</loc>" not in sitemap
+
+
+@pytest.mark.django_db
+def test_rss_feed_lists_live_topic_with_frontend_link():
+    _index, board = _tree()
+    topic = Topic.objects.create(board=board, title="Fern care", slug="fern", live=True)
+
+    resp = APIClient().get("/forum/rss/")
+    assert resp.status_code == 200
+    xml = resp.content.decode()
+
+    assert "Fern care" in xml
+    assert f"{_SITE}{topic.get_absolute_url()}" in xml

--- a/backend/plant_community_backend/settings.py
+++ b/backend/plant_community_backend/settings.py
@@ -134,6 +134,7 @@ DJANGO_APPS = [
     "django.contrib.messages",
     "django.contrib.staticfiles",
     "django.contrib.sites",
+    "django.contrib.sitemaps",  # forum SEO sitemap (todo 256 H9)
     "django.contrib.postgres",
 ]
 

--- a/backend/plant_community_backend/urls.py
+++ b/backend/plant_community_backend/urls.py
@@ -17,6 +17,8 @@ from apps.blog.api.viewsets import (
 
 # Import core views
 from apps.core.views import ReactAppView, csp_report_view, csrf_token_view
+from apps.forum_host.feeds import ForumTopicsFeed
+from apps.forum_host.sitemaps import forum_sitemaps
 from apps.plant_identification.api.endpoints import (
     PlantCareGuideAPIViewSet,
     PlantCategoryAPIViewSet,
@@ -27,6 +29,7 @@ from apps.plant_identification.api.endpoints import (
 from django.conf import settings
 from django.conf.urls.static import static
 from django.contrib import admin
+from django.contrib.sitemaps.views import sitemap
 from django.urls import include, path, re_path
 from django.views.generic import RedirectView
 
@@ -162,6 +165,16 @@ urlpatterns = [
     path("app/identify/", ReactAppView.as_view(), name="react-app-identify"),
     path("app/login/", ReactAppView.as_view(), name="react-app-login"),
     path("app/register/", ReactAppView.as_view(), name="react-app-register"),
+    # Forum SEO — sitemap + RSS of live public topics/boards (todo 256 H9).
+    # Public crawler endpoints; placed before the Wagtail catch-all so they
+    # resolve. URLs point at the SPA frontend (settings.SITE_URL).
+    path(
+        "forum/sitemap.xml",
+        sitemap,
+        {"sitemaps": forum_sitemaps},
+        name="forum-sitemap",
+    ),
+    path("forum/rss/", ForumTopicsFeed(), name="forum-rss"),
     # Default redirect to Wagtail admin for development
     path("", RedirectView.as_view(url="/cms/", permanent=False)),
     # Wagtail Frontend URLs (should be last)

--- a/docs/audits/2026-07-11-forum-modernization.md
+++ b/docs/audits/2026-07-11-forum-modernization.md
@@ -295,8 +295,8 @@ Deferred findings converted to todos (Review Doc Tracking convention — the
 - [x] #H4 mentions → todo 253 (completed 2026-07-22)
 - [ ] #H6 solved-accepted-answer → todo 273 (re-pointed 2026-07-23; roadmap moved solved answers to Wave 2 / not 256)
 - [ ] #H7 public-user-identity → todo 257
-- [ ] #H8 search-discoverability-filters → todo 256
-- [ ] #H9 seo-surface → todo 256
+- [x] #H8 search-discoverability-filters → todo 256 (completed 2026-07-23)
+- [x] #H9 seo-surface → todo 256 (completed 2026-07-23)
 - [x] #H10 unread-indicators → todo 253 (completed 2026-07-22)
 - [ ] #H11 mobile-forum-client → todo 260
 - [x] #H12 entitlement-primitive → todo 255 (completed 2026-07-20, slice 1)

--- a/todos/256-in_progress-p1-forum-qa-discovery-seo.md
+++ b/todos/256-in_progress-p1-forum-qa-discovery-seo.md
@@ -74,8 +74,8 @@ _(H8 + H9 only — see the re-scope note at the top. H6 → todo 273; M1/M5/M11/
 - [x] **H8** Search reachable from forum navigation (Wave 1); changing sort/filters
       provably changes the outgoing request (unmocked service test) — done slice 1
 - [x] **H8** Search results paginated with an honest `has_more` (no silent 50-cap) — done slice 1
-- [ ] **H9** Every forum route sets a descriptive title + meta; sitemap lists live
-      topics/boards; RSS feed available; OG decision recorded
+- [x] **H9** Every forum route sets a descriptive title + meta; sitemap lists live
+      topics/boards; RSS feed available; OG decision recorded — done slice 2
 
 ## Work Log
 
@@ -141,6 +141,41 @@ _(H8 + H9 only — see the re-scope note at the top. H6 → todo 273; M1/M5/M11/
     tiebreak).
 - Re-verified: web **650 tests** pass + `tsc` clean; backend **225** forum-api
   tests pass; `spectacular` schema OK.
+
+### 2026-07-23 - Slice 2 (H9) implemented + verified
+
+- **Web** (per-route title/meta + OG): new `web/src/components/PageMeta.tsx`
+  renders `<title>`/`<meta>` inline (React 19 native hoisting — verified working
+  in jsdom). Wired into all 5 forum routes (CategoryList, ThreadList, ThreadDetail,
+  Search, NewThread) with data-derived titles; ThreadDetail also emits OG tags.
+- **Backend** (sitemap + RSS): `apps/forum_host/sitemaps.py` (`ForumBoardSitemap`
+  - `ForumTopicSitemap`) at `/forum/sitemap.xml`; `apps/forum_host/feeds.py`
+  (`ForumTopicsFeed`) at `/forum/rss/`. Both emit **SPA frontend canonical URLs**
+  (`settings.SITE_URL` + path) — byte-for-byte the same base the reply-notification
+  emails use (`tasks.py:337`). `django.contrib.sitemaps` added to INSTALLED_APPS;
+  routes mounted at the root before the Wagtail catch-all.
+- **Security (load-bearing)**: both surfaces filter through `_visible_boards()`
+  (`.live().public()`), so a topic on a hidden/view-restricted board never leaks
+  — proven by `test_seo.py::test_sitemap_and_feed_exclude_restricted_board_topics`.
+
+#### OG / crawler decision (recorded)
+
+Cheap, no-prerender path: forum pages render OG/meta via **React 19 native
+metadata**. This works for **JS-capable crawlers (Googlebot executes JS)** but
+**not** non-JS link unfurlers (Slack/Twitter/Facebook) — they won't show rich
+previews for topic detail. The sitemap + RSS give crawl discovery at the frontend
+canonical URLs. Rationale: the SPA is the real forum UI (audit H17 — backend board
+pages are only a minimal crawler fallback), so the frontend origin is canonical;
+a Cloudflare prerender was evaluated and **declined** (not worth the cost/complexity
+for the current stage). Ops note: the sitemap is served from the backend (Railway)
+while topic URLs live on the frontend (Cloudflare) — needs a Search-Console
+cross-submission or a frontend `robots.txt` pointer to be fully effective.
+
+- **Verification**: `tsc` clean; `npx vitest run` → `48 files / 655 tests` pass
+  (incl. PageMeta unit tests + a per-route title assertion on each of the 5 pages).
+  Backend `pytest test_seo.py test_ratelimits.py test_schema_429.py --create-db`
+  → `33 passed` (4 SEO incl. the restricted-board exclusion). `manage.py check`
+  clean; `spectacular` schema OK.
 
 ## Notes
 

--- a/todos/256-in_progress-p1-forum-qa-discovery-seo.md
+++ b/todos/256-in_progress-p1-forum-qa-discovery-seo.md
@@ -177,6 +177,34 @@ cross-submission or a frontend `robots.txt` pointer to be fully effective.
   → `33 passed` (4 SEO incl. the restricted-board exclusion). `manage.py check`
   clean; `spectacular` schema OK.
 
+### 2026-07-23 - Slice 2 (H9) code review + fixes
+
+- Reviewed by 4 domain reviewers (django-drf, wagtail, react-typescript,
+  cross-cutting) + advisor steer. **No correctness/security bugs** — cross-cutting
+  confirmed via mutation testing that the `.public()`/`live=True` guards ARE
+  load-bearing (dropping either fails the exclusion tests). All findings were
+  coverage/robustness. Fixes applied:
+  - **SITE_URL read at call-time** (django-drf) in `sitemaps.py` + `feeds.py`
+    (was module-frozen) — honors a test override / late config, matches the email
+    convention.
+  - **`MAX_ITEMS` → `FORUM_RSS_MAX_ITEMS`** constant (django-drf; app convention).
+  - **Canonical OG url** (react/cross-cutting): `origin + pathname` (drops
+    query/hash; removed the vestigial SSR guard).
+  - **Test coverage**: RSS draft-exclusion; **ancestor-restriction** exclusion
+    (restrict the ForumIndex — locks in `.public()` descendant inheritance,
+    wagtail med); exact **query-count pins** (sitemap 8, rss 2 — `.public()`
+    lookups, cross-cutting med); og:url + og:description assertions; SearchPage
+    `Search: {query}` title-branch assertion (cross-cutting meds).
+  - **Accepted low**: static-title pages (Category/NewThread) don't set the title
+    during the sub-second loading flash — the loaded state (crawler-visible)
+    has the correct title; a clean fix needs a structural refactor not warranted
+    for a LOW. Noted, not fixed.
+  - Info (no action): 50k-topic sitemap pagination (dormant); cross-origin sitemap
+    (recorded ops follow-up); `_visible_boards()` called twice per sitemap render
+    (harmless, flat 8 queries).
+- Re-verified: web **655 tests** + `tsc`; backend `forum_host` suite **157**
+  (test_seo **7**); `manage.py check` clean.
+
 ## Notes
 
 p1 by user triage decision. M11 was rated High by the react-typescript reviewer

--- a/todos/archive/256-completed-p1-forum-qa-discovery-seo.md
+++ b/todos/archive/256-completed-p1-forum-qa-discovery-seo.md
@@ -1,5 +1,5 @@
 ---
-status: in_progress
+status: completed
 priority: p1
 issue_id: "256"
 tags: [forum, seo, search, product-ux]
@@ -204,6 +204,19 @@ cross-submission or a frontend `robots.txt` pointer to be fully effective.
     (harmless, flat 8 queries).
 - Re-verified: web **655 tests** + `tsc`; backend `forum_host` suite **157**
   (test_seo **7**); `manage.py check` clean.
+
+### 2026-07-23 - Completed by completing-todos skill (run 2026-07-23-0217)
+
+- Both retained ACs met: **H8** (search end-to-end, PR #487 merged) and **H9**
+  (SEO surface, PR #488). Delivered as two per-slice PRs off fresh `main`.
+- Descoped up front (see the re-scope note): H6 → todo 273; M1/M5/M11/L8 → todo 276.
+- Verification: web 655 tests + `tsc`; backend forum_host 157 + wagtail_forum api
+  225 (H8) / test_seo 7 (H9); `manage.py check` + `spectacular` clean.
+- Review: H8 — 4 reviewers + advisor, all low/med fixed, security clean; H9 — 4
+  reviewers + advisor, no correctness/security bugs, coverage/robustness fixes applied.
+- Follow-up recorded (H9 ops): the backend-served sitemap lists frontend
+  (Cloudflare) URLs — needs a `robots.txt` Sitemap: pointer or Search-Console
+  cross-submission to be fully effective for discovery.
 
 ## Notes
 

--- a/web/src/components/PageMeta.test.tsx
+++ b/web/src/components/PageMeta.test.tsx
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+import PageMeta from './PageMeta';
+
+describe('PageMeta', () => {
+  it('sets document.title', async () => {
+    render(<PageMeta title="Test Title · PlantID" />);
+    await waitFor(() => expect(document.title).toBe('Test Title · PlantID'));
+  });
+
+  it('renders a meta description', async () => {
+    render(<PageMeta title="X" description="A helpful description" />);
+    await waitFor(() =>
+      expect(document.querySelector('meta[name="description"]')?.getAttribute('content')).toBe(
+        'A helpful description'
+      )
+    );
+  });
+
+  it('renders OG tags when og is provided', async () => {
+    render(<PageMeta title="X" og={{ title: 'OG Title', url: 'https://x/y', type: 'article' }} />);
+    await waitFor(() => {
+      expect(document.querySelector('meta[property="og:title"]')?.getAttribute('content')).toBe(
+        'OG Title'
+      );
+      expect(document.querySelector('meta[property="og:url"]')?.getAttribute('content')).toBe(
+        'https://x/y'
+      );
+      expect(document.querySelector('meta[property="og:type"]')?.getAttribute('content')).toBe(
+        'article'
+      );
+    });
+  });
+
+  it('omits OG tags when og is not provided', () => {
+    render(<PageMeta title="No OG · PlantID" />);
+    expect(document.querySelector('meta[property="og:title"]')).toBeNull();
+  });
+});

--- a/web/src/components/PageMeta.tsx
+++ b/web/src/components/PageMeta.tsx
@@ -1,0 +1,39 @@
+/**
+ * PageMeta — per-route document metadata (todo 256 H9).
+ *
+ * Renders `<title>` / `<meta>` inline; React 19 natively hoists these to
+ * `<head>`, so each route gets a descriptive title + description (in-app UX +
+ * JS-capable crawlers like Googlebot). OG tags are opt-in for shareable pages
+ * (e.g. topic detail). Note: non-JS unfurlers (Slack/Twitter/Facebook) do not
+ * execute the SPA, so they won't see these — an accepted tradeoff for the
+ * cheap, no-prerender path (see the sitemap/RSS for crawl discovery).
+ */
+interface OpenGraph {
+  title?: string;
+  description?: string;
+  url?: string;
+  type?: string;
+}
+
+interface PageMetaProps {
+  title: string;
+  description?: string;
+  og?: OpenGraph;
+}
+
+export default function PageMeta({ title, description, og }: PageMetaProps) {
+  return (
+    <>
+      <title>{title}</title>
+      {description && <meta name="description" content={description} />}
+      {og && (
+        <>
+          {og.title && <meta property="og:title" content={og.title} />}
+          {og.description && <meta property="og:description" content={og.description} />}
+          {og.url && <meta property="og:url" content={og.url} />}
+          <meta property="og:type" content={og.type || 'article'} />
+        </>
+      )}
+    </>
+  );
+}

--- a/web/src/pages/forum/CategoryListPage.test.tsx
+++ b/web/src/pages/forum/CategoryListPage.test.tsx
@@ -86,6 +86,8 @@ describe('CategoryListPage', () => {
     });
 
     expect(screen.getByText(/Connect with fellow plant enthusiasts/i)).toBeInTheDocument();
+    // H9: the route sets a descriptive document title (React 19 metadata).
+    expect(document.title).toContain('Community Forums');
   });
 
   it('displays error message when API call fails', async () => {

--- a/web/src/pages/forum/CategoryListPage.tsx
+++ b/web/src/pages/forum/CategoryListPage.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { fetchCategoryTree } from '../../services/forumService';
 import CategoryCard from '../../components/forum/CategoryCard';
 import LoadingSpinner from '../../components/ui/LoadingSpinner';
+import PageMeta from '../../components/PageMeta';
 import { logger } from '../../utils/logger';
 import type { Category } from '@/types';
 
@@ -58,6 +59,10 @@ export default function CategoryListPage() {
 
   return (
     <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      <PageMeta
+        title="Community Forums · PlantID"
+        description="Connect with fellow plant enthusiasts, share knowledge, and get help with your plants in the Plant Community forums."
+      />
       {/* Page Header */}
       <div className="mb-8">
         <h1 className="text-4xl font-bold text-ink mb-2">Community Forums</h1>

--- a/web/src/pages/forum/NewThreadPage.test.tsx
+++ b/web/src/pages/forum/NewThreadPage.test.tsx
@@ -50,6 +50,11 @@ describe('NewThreadPage', () => {
     });
   });
 
+  it('sets a descriptive document title (H9)', async () => {
+    renderPage();
+    await waitFor(() => expect(document.title).toContain('Start a New Thread'));
+  });
+
   it('published topic → navigates into the new thread', async () => {
     vi.spyOn(forumService, 'createThread').mockResolvedValue({
       id: '12',

--- a/web/src/pages/forum/NewThreadPage.tsx
+++ b/web/src/pages/forum/NewThreadPage.tsx
@@ -6,6 +6,7 @@ import { draftKey, loadDraft, saveDraft, clearDraft } from '../../utils/forumDra
 import TipTapEditor from '../../components/forum/TipTapEditor';
 import LoadingSpinner from '../../components/ui/LoadingSpinner';
 import Button from '../../components/ui/Button';
+import PageMeta from '../../components/PageMeta';
 import { logger } from '../../utils/logger';
 import type { Category } from '@/types';
 
@@ -131,6 +132,10 @@ export default function NewThreadPage() {
 
   return (
     <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      <PageMeta
+        title="Start a New Thread · PlantID"
+        description="Start a new discussion in the Plant Community forums."
+      />
       {/* Breadcrumb */}
       <nav className="mb-6 text-sm text-ink-2" aria-label="Breadcrumb">
         <ol className="flex items-center gap-2">

--- a/web/src/pages/forum/SearchPage.test.tsx
+++ b/web/src/pages/forum/SearchPage.test.tsx
@@ -59,6 +59,8 @@ describe('SearchPage', () => {
 
       expect(screen.getByRole('heading', { level: 1, name: 'Forum Search' })).toBeInTheDocument();
       expect(screen.getByText('Search across threads and posts')).toBeInTheDocument();
+      // H9: the route sets a descriptive document title (React 19 metadata).
+      expect(document.title).toContain('Forum Search');
     });
 
     it('shows search input with placeholder', () => {

--- a/web/src/pages/forum/SearchPage.test.tsx
+++ b/web/src/pages/forum/SearchPage.test.tsx
@@ -112,6 +112,8 @@ describe('SearchPage', () => {
           })
         );
       });
+      // H9: covers the query branch of the title ternary (`Search: ${query}`).
+      expect(document.title).toContain('Search: watering');
     });
 
     it('displays loading spinner while searching', async () => {

--- a/web/src/pages/forum/SearchPage.tsx
+++ b/web/src/pages/forum/SearchPage.tsx
@@ -7,6 +7,7 @@ import Button from '../../components/ui/Button';
 import { logger } from '../../utils/logger';
 import { sanitizeSearchQuery } from '../../utils/validation';
 import { threadPath } from '../../utils/forumUrls';
+import PageMeta from '../../components/PageMeta';
 import type { Category, SearchForumResponse } from '@/types';
 
 /** Strip HTML tags from a string, returning plain text. */
@@ -259,6 +260,10 @@ export default function SearchPage() {
 
   return (
     <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      <PageMeta
+        title={query ? `Search: ${query} · PlantID` : 'Forum Search · PlantID'}
+        description="Search across Plant Community forum threads and posts."
+      />
       {/* Header */}
       <div className="mb-8">
         <h1 className="text-3xl font-bold text-ink mb-2">Forum Search</h1>

--- a/web/src/pages/forum/ThreadDetailPage.test.tsx
+++ b/web/src/pages/forum/ThreadDetailPage.test.tsx
@@ -137,6 +137,11 @@ describe('ThreadDetailPage', () => {
 
     expect(screen.getByText(/Master Gardener/i)).toBeInTheDocument();
     expect(screen.getByText(/150 views/i)).toBeInTheDocument();
+    // H9: descriptive title + shareable OG tags (React 19 metadata).
+    expect(document.title).toContain('How to water succulents?');
+    expect(document.querySelector('meta[property="og:type"]')?.getAttribute('content')).toBe(
+      'article'
+    );
   });
 
   it('renders breadcrumb navigation', async () => {

--- a/web/src/pages/forum/ThreadDetailPage.test.tsx
+++ b/web/src/pages/forum/ThreadDetailPage.test.tsx
@@ -142,6 +142,12 @@ describe('ThreadDetailPage', () => {
     expect(document.querySelector('meta[property="og:type"]')?.getAttribute('content')).toBe(
       'article'
     );
+    expect(document.querySelector('meta[property="og:url"]')?.getAttribute('content')).toBe(
+      window.location.origin + window.location.pathname
+    );
+    expect(
+      document.querySelector('meta[property="og:description"]')?.getAttribute('content')
+    ).toContain('discussion');
   });
 
   it('renders breadcrumb navigation', async () => {

--- a/web/src/pages/forum/ThreadDetailPage.tsx
+++ b/web/src/pages/forum/ThreadDetailPage.tsx
@@ -20,6 +20,7 @@ import LoadingSpinner from '../../components/ui/LoadingSpinner';
 import Button from '../../components/ui/Button';
 import { useAuth } from '../../contexts/AuthContext';
 import { logger } from '../../utils/logger';
+import PageMeta from '../../components/PageMeta';
 import type { Thread, Post } from '@/types';
 import type { PaginatedResponse } from '@/types/forum';
 
@@ -400,6 +401,16 @@ export default function ThreadDetailPage() {
 
   return (
     <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      <PageMeta
+        title={`${thread.title} · PlantID`}
+        description={`${thread.title} — a discussion in ${thread.category.name} on the Plant Community forum.`}
+        og={{
+          title: thread.title,
+          description: `A discussion in ${thread.category.name} on Plant Community.`,
+          url: typeof window !== 'undefined' ? window.location.href : undefined,
+          type: 'article',
+        }}
+      />
       {/* Breadcrumb */}
       <nav className="mb-6 text-sm text-ink-2" aria-label="Breadcrumb">
         <ol className="flex items-center gap-2">

--- a/web/src/pages/forum/ThreadDetailPage.tsx
+++ b/web/src/pages/forum/ThreadDetailPage.tsx
@@ -407,7 +407,8 @@ export default function ThreadDetailPage() {
         og={{
           title: thread.title,
           description: `A discussion in ${thread.category.name} on Plant Community.`,
-          url: typeof window !== 'undefined' ? window.location.href : undefined,
+          // Canonical topic URL — drop any ?query/#hash; the SPA is client-only.
+          url: `${window.location.origin}${window.location.pathname}`,
           type: 'article',
         }}
       />

--- a/web/src/pages/forum/ThreadListPage.test.tsx
+++ b/web/src/pages/forum/ThreadListPage.test.tsx
@@ -101,6 +101,8 @@ describe('ThreadListPage', () => {
 
     expect(screen.getByText('Learn how to care for your plants')).toBeInTheDocument();
     expect(screen.getByText('🌱')).toBeInTheDocument();
+    // H9: the route sets a descriptive, category-derived document title.
+    expect(document.title).toContain('Plant Care Tips');
   });
 
   it('renders threads when API call succeeds', async () => {

--- a/web/src/pages/forum/ThreadListPage.tsx
+++ b/web/src/pages/forum/ThreadListPage.tsx
@@ -5,6 +5,7 @@ import { parseLeadingId } from '../../utils/forumUrls';
 import ThreadCard from '../../components/forum/ThreadCard';
 import LoadingSpinner from '../../components/ui/LoadingSpinner';
 import Button from '../../components/ui/Button';
+import PageMeta from '../../components/PageMeta';
 import { logger } from '../../utils/logger';
 import type { Thread, Category } from '@/types';
 
@@ -173,6 +174,12 @@ export default function ThreadListPage() {
 
   return (
     <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      <PageMeta
+        title={`${category?.name ?? 'Forum'} · PlantID`}
+        description={
+          category?.description || `Browse discussions in ${category?.name ?? 'the forum'}.`
+        }
+      />
       {/* Breadcrumb */}
       <nav className="mb-6 text-sm text-ink-2" aria-label="Breadcrumb">
         <ol className="flex items-center gap-2">


### PR DESCRIPTION
## What & why

Todo 256 slice 2 (of 2) — **H9: forum SEO surface**. The SPA had zero SEO surface
(static `<title>web</title>`, no per-route meta, no sitemap, no RSS). Completes the
re-scoped todo 256 (H8 landed in #487).

## Web — per-route metadata

- New `PageMeta` component renders `<title>` / `<meta>` inline, relying on **React
  19 native document-metadata hoisting** (verified working in jsdom — no
  react-helmet).
- Wired into all **5 forum routes** (CategoryList, ThreadList, ThreadDetail,
  Search, NewThread) with data-derived titles. **ThreadDetail** also emits
  OpenGraph tags for shareability.

## Backend — sitemap + RSS

- `apps/forum_host/sitemaps.py` → `/forum/sitemap.xml` (index + boards + live
  topics); `apps/forum_host/feeds.py` → `/forum/rss/` (latest live topics).
- Both emit the **SPA frontend canonical URLs** (`settings.SITE_URL` + path) —
  byte-for-byte the same base the reply-notification emails use.
- `django.contrib.sitemaps` added to INSTALLED_APPS; routes mounted at the root
  before the Wagtail catch-all.
- **Security (load-bearing):** both surfaces filter through `_visible_boards()`
  (`.live().public()`), so a hidden/view-restricted board's topics never leak —
  proven by `test_sitemap_and_feed_exclude_restricted_board_topics`.

## OG / crawler decision (recorded)

Cheap, no-prerender path: OG/meta render via React 19 metadata → works for
**JS-capable crawlers (Googlebot)**, not non-JS unfurlers (Slack/Twitter/FB). The
sitemap + RSS give crawl discovery at the frontend canonical URLs. The SPA is the
real forum UI (audit H17 — backend board pages are only a minimal crawler
fallback), so the frontend origin is canonical; a Cloudflare prerender was declined.
Ops note: sitemap is served from the backend while topic URLs live on the frontend
— needs a Search-Console cross-submission or frontend `robots.txt` pointer to be
fully effective.

## Verification

- `tsc` clean; `npx vitest run` → **48 files / 655 tests** pass (PageMeta unit
  tests + a per-route title assertion on each of the 5 pages).
- Backend `pytest test_seo.py test_ratelimits.py test_schema_429.py --create-db`
  → **33 pass** (4 SEO incl. the restricted-board exclusion).
- `manage.py check` clean; `spectacular` schema OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
