### PR TITLE
docs: codify todo 256 findings (forum discovery/SEO)

### DIFF
--- a/docs/LEARNINGS.md
+++ b/docs/LEARNINGS.md
@@ -1617,3 +1617,35 @@ Secondary tooling snag: the `detect-secrets` pre-commit hook flags any
 `OPENAI_API_KEY="..."` string literal (keyword detector, value-agnostic) — in a
 TEST, assign the fake key to a named constant with a `# pragma: allowlist secret`
 line and stage the updated `.secrets.baseline`.
+
+## 2026-07-23 — Forum discovery/SEO (todo 256, H8+H9)
+
+**DRF cursor pagination with a client-selectable sort.** To let a `?sort=` param
+reorder a `CursorPagination` list, override `get_ordering(request, queryset, view)`
+on the paginator and map a **whitelisted** value to an ordering tuple (keep a
+unique tiebreak like `-id` last so the cursor stays deterministic; fall back to the
+default on an unknown value — never 500). The chosen sort **survives in the
+`next`/`previous` links** because DRF bakes the full request URL (incl. `?sort=`)
+into `base_url`. Pin it with a test that follows every cursor page and asserts the
+whole traversal stays ordered with no dupes/omissions — a single-page test misses
+the cross-page reversion. (`wagtail_forum/api/pagination.py`.)
+
+**A backend-served sitemap/RSS for an SPA on a separate origin must emit the
+FRONTEND canonical URLs, not the backend host.** The React app is on Cloudflare;
+Django on Railway serves `/forum/sitemap.xml`. Subclass `django.contrib.sitemaps.Sitemap`
+and override `get_domain()`/`get_protocol()` to build `<loc>` against
+`settings.SITE_URL` (the SPA origin) — the same base the reply-notification emails
+use (`tasks.py`), so a topic's canonical URL is byte-for-byte identical in email,
+sitemap, and feed. Read `SITE_URL` at **call time**, not a module-level global, or
+a test `@override_settings`/late config is silently ignored. Ops caveat: a sitemap
+that lists a different origin than it's served from needs a frontend `robots.txt`
+`Sitemap:` pointer or Search-Console cross-submission to actually be honored.
+
+**Review agents can leave a mutation-test edit in the working tree.** A reviewer
+verifying a test is non-vacuous mutated `board__in=_visible_boards()` →
+`ForumBoard.objects.live()` (dropping `.public()`) in `sitemaps.py`/`feeds.py` and
+did not revert it — an **uncommitted working-tree security regression**. The
+committed code + PR were correct; the danger is only a later `git add -A` staging
+it. Before any archival/bookkeeping `git add -A`, diff the reviewed source files
+and restore (`git checkout HEAD -- <file>`) any mutation left behind, then re-run
+the load-bearing test. (Same pattern seen earlier the same session on a test file.)

--- a/docs/rules/forum.md
+++ b/docs/rules/forum.md
@@ -62,3 +62,13 @@ Compact checklist auto-injected before edits to the forum code. Long-form:
   visibility trigger did not cover `apps/forum_host/`; a broadened trigger now
   does. Filter the SOURCE too (e.g. a vector-index queryset), not just the
   response — never embed/cache restricted content.
+- **Public crawl surfaces enforce board visibility too.** The forum
+  `sitemap.xml` + RSS feed (`apps/forum_host/{sitemaps,feeds}.py`, todo 256 H9)
+  are the widest-blast-radius surface — anonymous, cacheable, search-indexed —
+  so both filter topics through `board__in=_visible_boards()` (`.live().public()`)
+  and list only `ForumIndex.objects.live().public()` boards. `.public()` excludes
+  a restricted board AND every descendant of a restricted ancestor, so a
+  restriction on the `ForumIndex` hides the whole tree; a coverage test must
+  exercise the ancestor case, not just a directly-restricted board. Draft
+  (`live=False`) topics need their own exclusion test per surface — the sitemap's
+  and the feed's `live=True` guards are independent.

--- a/web/docs/patterns/react-typescript.md
+++ b/web/docs/patterns/react-typescript.md
@@ -288,3 +288,37 @@ can't retry forever. And any request fired automatically from such an effect
 needs a **stale-thread guard** — capture the id before the `await` and skip the
 `setState` if `currentIdRef.current` moved on, or a late page for thread A
 appends to thread B (see `ThreadDetailPage.tsx`).
+
+## React 19 Native Document Metadata (per-route SEO)
+
+React 19 hoists `<title>`, `<meta>`, and `<link>` rendered **anywhere** in the
+tree to `<head>` automatically — no `react-helmet`. Use it for per-route
+title/description/OG on an SPA (todo 256 H9): a small `PageMeta` component
+(`web/src/components/PageMeta.tsx`) renders the tags inline; each page passes
+data-derived values.
+
+```tsx
+export default function PageMeta({ title, description, og }: PageMetaProps) {
+  return (
+    <>
+      <title>{title}</title>
+      {description && <meta name="description" content={description} />}
+      {og && <meta property="og:title" content={og.title} />}
+    </>
+  );
+}
+// In a page: <PageMeta title={`${thread.title} · PlantID`} og={{ ... }} />
+```
+
+- **Testable in jsdom/Vitest**: after render, assert `document.title` and
+  `document.querySelector('meta[property="og:type"]')` — the hoist runs on commit.
+- **Placement tradeoff**: rendering `PageMeta` in a page's main (post-load) return
+  means the title isn't set during the loading flash. Fine for data-derived titles
+  (a crawler waits for network idle); for a *static* title, render it before the
+  loading/error early returns if the flash matters.
+- **Crawler reach**: only JS-executing crawlers (Googlebot) see these — non-JS
+  link unfurlers (Slack/Twitter/FB) do not run the SPA. Pair with a
+  server-rendered sitemap/RSS for discovery; accept no rich unfurl without a
+  prerender.
+- **OG url**: build from `window.location.origin + window.location.pathname`
+  (drops query/hash) — the SPA is client-only, so no SSR guard is needed.


### PR DESCRIPTION
Codification from todo 256 (H8 search + H9 SEO), split from the feature PRs (#487, #488) which merged before the codify commit landed.

- **docs/rules/forum.md** — public crawl surfaces (sitemap.xml / RSS) enforce board visibility via `_visible_boards()`/`.public()`, incl. ancestor-restriction inheritance + per-surface draft-exclusion coverage.
- **web/docs/patterns/react-typescript.md** — React 19 native document metadata for per-route SPA SEO (PageMeta, no react-helmet).
- **docs/LEARNINGS.md** — DRF cursor pagination client-selectable sort via `get_ordering`; backend-served sitemap emits frontend canonical URLs (call-time SITE_URL); review-agent mutation-tests left in the working tree.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)