### PR TITLE
forum: unify author contract + avatar (todo 257 slice A / H26 M41)

### DIFF
--- a/backend/docs/patterns/domain/forum.md
+++ b/backend/docs/patterns/domain/forum.md
@@ -109,6 +109,43 @@ moderator cannot smuggle in a *different*, unrelated member's image while
 editing someone else's post (pinned by
 `test_moderator_edit_cannot_smuggle_in_a_different_members_image`).
 
+## Unified author contract + settable avatar (todo 257 H26/M41)
+
+Every author a client sees — a topic's `author`, its `last_post_author`, a post's
+`author`, a notification's `actor` — serializes through the SINGLE helper
+`serialize_forum_author(user, request)` in `api/serializers.py`. It returns one
+object shape `{username, display_name, avatar, trust_level}`, and a deleted author
+(`user is None`) is the `[deleted]` sentinel OBJECT, never `null` and never a bare
+string. Before this, topics sent a username string (null when deleted) while posts
+sent a rich object with a partial `[deleted]` dict — two shapes for one concept.
+
+Three things make it correct and cheap:
+
+- **Pin-flatness by nested `select_related`.** The helper reads the profile via the
+  reverse OneToOne (`getattr(user, "wagtail_forum_profile", None)`) and the avatar
+  via the FK. The list/detail views join the whole chain —
+  `select_related("author__wagtail_forum_profile__avatar", ...)` — so those reads
+  are LEFT JOINs already materialized in the page query, NOT per-row SELECTs. The
+  query-count pins stay flat under N distinct authors (see query-optimization.md
+  Pattern 30). Gate on `profile.avatar_id` (the loaded FK column) before touching
+  `.avatar`, so the no-avatar case never issues a query.
+
+- **Avatar is the raw `.file.url` (absolute via `request.build_absolute_uri`), NOT a
+  rendition.** Inline body images use `serialize_image_for_api` renditions, but a
+  `get_rendition()` per author would add a SELECT and break the flat pin. Avatars
+  trade image-fidelity for pin-flatness — a conscious, documented tradeoff.
+
+- **Settable avatar is IDOR-scoped like inline images.** `MeProfileSerializer` takes
+  a write-only `avatar_id`; `validate_avatar_id` accepts it only if the image was
+  `uploaded_by_user=<caller>` AND lives in `get_forum_image_collection()` — the same
+  two-part membership check that gates inline images (the L21 pattern above). A bare
+  id is never trusted; `None` clears the avatar with no ownership check.
+
+`last_post_author` is the one field that returns `null` (not the sentinel) for a
+deleted last-poster: the denormalized Topic fields can't tell "no posts yet" from
+"last poster's account gone" without a live-post existence query that would break
+the pin. See `docs/LEARNINGS.md` 2026-07-24.
+
 ## LLM spam backend (optional, host-side — todo 255 slice 2 / H13)
 
 The package ships one spam check (`HeuristicSpamBackend`: banned words + link

--- a/backend/docs/patterns/performance/query-optimization.md
+++ b/backend/docs/patterns/performance/query-optimization.md
@@ -1397,3 +1397,25 @@ There is no `Q()` expression that replicates `.public()` without a subquery agai
 **Rule**: Never silently rely on `Count(filter=Q(live=True))` where `.live().public()` semantics are required. Choose option 1 or option 2 explicitly.
 
 **Accepted divergence — `BlogAuthorPageViewSet`**: `backend/apps/blog/api/viewsets.py` `BlogAuthorPageViewSet.get_queryset()` annotates `annotated_post_count` with `Count(filter=Q(live=True))`, while `BlogAuthorPageSerializer.get_post_count()` falls back to `.live().public()`. Option 2 (explicit divergence) is accepted here: the blog has no `PageViewRestriction` objects — author pages and blog posts are all public — so the annotation and the fallback return identical counts in practice. The correlated subquery in option 1 would add per-row cost for a gap that cannot occur given current content. If `PageViewRestriction` is ever introduced for blog content, switch that annotation to option 1.
+
+## Pattern 30: Nested `select_related` through reverse-OneToOne → FK keeps `SerializerMethodField` pins flat
+
+**Problem**: A serializer reads a related object graph off each row — e.g. a forum author's `ForumProfile` (reverse OneToOne) and that profile's `avatar` (FK). Done naively in a `SerializerMethodField`, each row triggers a profile SELECT and an avatar SELECT → a classic N+1 that a `<=` query ceiling hides but an exact pin catches.
+
+**Fix**: `select_related` the ENTIRE chain in the view's `get_queryset()`, including the deepest leaf. `select_related` adds JOINs, not queries — the whole graph materializes in the single page query, so the pin stays flat under N distinct authors.
+
+```python
+# The deepest path implies every shallower one, so this one string covers
+# author, author.wagtail_forum_profile, AND author.wagtail_forum_profile.avatar.
+qs = Topic.objects.filter(...).select_related(
+    "author__wagtail_forum_profile__avatar",
+    "last_post_author__wagtail_forum_profile__avatar",
+)
+```
+
+Two things make it hold:
+
+- **Read via `getattr(user, "wagtail_forum_profile", None)`** for the reverse OneToOne — a `RelatedObjectDoesNotExist` (subclass of `AttributeError`) yields `None` with no query when the join found no profile row, and the LEFT JOIN keeps authors-without-a-profile in the result set (an INNER JOIN would silently drop them — pin a `..._without_profile_still_renders` test).
+- **Gate on the FK column (`profile.avatar_id`) before touching the related object (`profile.avatar`)** — `avatar_id` is already loaded on the joined row, so the common no-avatar case never issues the avatar SELECT.
+
+**Caveat**: a `refresh_from_db()` (e.g. `submit_edit_for_moderation` on a post edit) discards the `select_related`-joined instance, so a single-object serialize AFTER a refresh reloads the graph lazily — that path's pin reflects the lazy SELECTs, not the join. Document the count at the assertion site. See the forum unified author contract (`docs/patterns/domain/forum.md`); live in `wagtail_forum/api/{serializers,views,notifications}.py`.

--- a/backend/packages/wagtail_forum/wagtail_forum/api/notifications.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/api/notifications.py
@@ -72,8 +72,12 @@ class NotificationListView(generics.ListAPIView):
     def get_queryset(self):
         if getattr(self, "swagger_fake_view", False):
             return Notification.objects.none()
+        # Join the actor down to ForumProfile.avatar so the unified author
+        # object (todo 257 H26) serializes with zero per-row queries — the
+        # deepest path implies actor + actor__wagtail_forum_profile, so the
+        # list pin stays flat (test_notifications_api).
         return _visible_notifications(self.request.user).select_related(
-            "actor", "actor__wagtail_forum_profile", "topic__board"
+            "actor__wagtail_forum_profile__avatar", "topic__board"
         )
 
 

--- a/backend/packages/wagtail_forum/wagtail_forum/api/serializers.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/api/serializers.py
@@ -3,6 +3,7 @@ from wagtail.blocks import RichTextBlock
 from wagtail.images import get_image_model
 from wagtail.rich_text import expand_db_html
 
+from ..collections import get_forum_image_collection
 from ..models import (
     ForumBoard,
     ForumProfile,
@@ -42,9 +43,58 @@ AUTHOR_SCHEMA = {
     "properties": {
         "username": {"type": "string"},
         "display_name": {"type": "string"},
+        "avatar": {"type": "string", "nullable": True},
         "trust_level": {"type": "integer", "nullable": True},
     },
 }
+
+
+def _deleted_author():
+    """The single deleted-author convention (H26/M41): one `[deleted]` sentinel
+    OBJECT everywhere — topics used to send `null`, posts a partial sentinel."""
+    return {
+        "username": "[deleted]",
+        "display_name": "[deleted]",
+        "avatar": None,
+        "trust_level": None,
+    }
+
+
+def serialize_forum_author(user, request=None):
+    """Unified author object for EVERY topic + post payload (H26): `author`,
+    `last_post_author`, and a post's author all share this shape.
+
+    Reads `ForumProfile` via the reverse OneToOne (`wagtail_forum_profile`);
+    `getattr(..., None)` yields None (no query) for an author with no profile
+    row AND issues no query when the view select_related-joined the profile.
+    Avatar is the raw image file URL (absolute) — deliberately NOT a rendition,
+    so a select_related-joined avatar costs zero per-row queries and the list
+    query-count pins stay flat (todo 257 slice A / H7).
+    """
+    if user is None:
+        return _deleted_author()
+    profile = getattr(user, "wagtail_forum_profile", None)
+    display_name = (
+        (profile.display_name if profile and profile.display_name else None)
+        or user.get_full_name()
+        or user.get_username()
+    )
+    avatar = None
+    # `avatar_id` (the FK column) is already loaded — gate on it so we never
+    # touch `.avatar` (a query if NOT select_related-joined) for the common
+    # no-avatar case.
+    if profile and profile.avatar_id and profile.avatar:
+        avatar = profile.avatar.file.url
+        if request is not None:
+            avatar = request.build_absolute_uri(avatar)
+    return {
+        "username": user.get_username(),
+        "display_name": display_name,
+        "avatar": avatar,
+        "trust_level": profile.trust_level if profile else None,
+    }
+
+
 BOARD_SCHEMA = {
     "type": "object",
     "properties": {
@@ -93,10 +143,8 @@ class BoardSerializer(serializers.ModelSerializer):
 
 
 class TopicListSerializer(serializers.ModelSerializer):
-    author = serializers.CharField(source="author.get_username", default=None)
-    last_post_author = serializers.CharField(
-        source="last_post_author.get_username", default=None
-    )
+    author = serializers.SerializerMethodField()
+    last_post_author = serializers.SerializerMethodField()
     # LockableMixin field, same as the detail serializer: the write guard is
     # `is_closed OR locked`, so list clients need both to render the lock badge
     # and predict write-eligibility (audit 2026-07-11 L3).
@@ -123,12 +171,23 @@ class TopicListSerializer(serializers.ModelSerializer):
             "is_unread",
         ]
 
+    @extend_schema_field(AUTHOR_SCHEMA)
+    def get_author(self, obj):
+        # Always an object; a deleted author (author_id None) → [deleted] sentinel.
+        return serialize_forum_author(obj.author, self.context.get("request"))
+
+    @extend_schema_field(AUTHOR_SCHEMA)
+    def get_last_post_author(self, obj):
+        # Secondary "last activity by" pointer: the object when a last poster is
+        # known, else null (no posts yet, or the last poster's account is gone).
+        if obj.last_post_author_id is None:
+            return None
+        return serialize_forum_author(obj.last_post_author, self.context.get("request"))
+
 
 class TopicDetailSerializer(serializers.ModelSerializer):
-    author = serializers.CharField(source="author.get_username", default=None)
-    last_post_author = serializers.CharField(
-        source="last_post_author.get_username", default=None
-    )
+    author = serializers.SerializerMethodField()
+    last_post_author = serializers.SerializerMethodField()
     board = serializers.SerializerMethodField()
     opening_post_id = serializers.SerializerMethodField()
     locked = serializers.BooleanField()
@@ -153,6 +212,16 @@ class TopicDetailSerializer(serializers.ModelSerializer):
             "opening_post_id",
             "is_subscribed",
         ]
+
+    @extend_schema_field(AUTHOR_SCHEMA)
+    def get_author(self, obj):
+        return serialize_forum_author(obj.author, self.context.get("request"))
+
+    @extend_schema_field(AUTHOR_SCHEMA)
+    def get_last_post_author(self, obj):
+        if obj.last_post_author_id is None:
+            return None
+        return serialize_forum_author(obj.last_post_author, self.context.get("request"))
 
     @extend_schema_field(BOARD_SCHEMA)
     def get_board(self, obj):
@@ -252,32 +321,6 @@ def serialize_forum_body(stream_value, image_map=None, request=None):
     return blocks
 
 
-class PostAuthorSerializer(serializers.Serializer):
-    username = serializers.CharField(source="get_username")
-    display_name = serializers.SerializerMethodField()
-    trust_level = serializers.SerializerMethodField()
-
-    @staticmethod
-    def _profile(obj):
-        # Reverse OneToOne accessor (ForumProfile.user, related_name
-        # "wagtail_forum_profile"). Its RelatedObjectDoesNotExist subclasses
-        # AttributeError, so getattr(..., None) yields None for an author with
-        # no ForumProfile row instead of raising — and issues no query when the
-        # caller select_related-joined the profile.
-        return getattr(obj, "wagtail_forum_profile", None)
-
-    def get_display_name(self, obj):
-        profile = self._profile(obj)
-        if profile and profile.display_name:
-            return profile.display_name
-        full = obj.get_full_name()
-        return full or obj.get_username()
-
-    def get_trust_level(self, obj):
-        profile = self._profile(obj)
-        return profile.trust_level if profile else None
-
-
 class PostSerializer(serializers.ModelSerializer):
     author = serializers.SerializerMethodField()
     body = serializers.SerializerMethodField()
@@ -308,13 +351,7 @@ class PostSerializer(serializers.ModelSerializer):
 
     @extend_schema_field(AUTHOR_SCHEMA)
     def get_author(self, obj):
-        if obj.author is None:
-            return {
-                "username": "[deleted]",
-                "display_name": "[deleted]",
-                "trust_level": None,
-            }
-        return PostAuthorSerializer(obj.author).data
+        return serialize_forum_author(obj.author, self.context.get("request"))
 
     @extend_schema_field(FORUM_BODY_SCHEMA)
     def get_body(self, obj):
@@ -381,16 +418,13 @@ class NotificationSerializer(serializers.ModelSerializer):
 
     @extend_schema_field(AUTHOR_SCHEMA)
     def get_actor(self, obj):
-        # Slice 1's only verb (reply) always sets an actor at creation; a null
-        # actor here means the acting user's account was deleted afterwards
-        # (SET_NULL) — same "[deleted]" placeholder as PostSerializer.get_author.
-        if obj.actor is None:
-            return {
-                "username": "[deleted]",
-                "display_name": "[deleted]",
-                "trust_level": None,
-            }
-        return PostAuthorSerializer(obj.actor).data
+        # Unified author object (todo 257 H26/M41): the actor shares the exact
+        # shape + `[deleted]` sentinel as every topic/post author. A null actor
+        # means the acting account was deleted after the notification was
+        # created (SET_NULL) → serialize_forum_author returns the sentinel.
+        # The queryset select_relates actor__wagtail_forum_profile__avatar so
+        # this stays flat (test_notifications_api pins 2 queries).
+        return serialize_forum_author(obj.actor, self.context.get("request"))
 
     @extend_schema_field(NOTIFICATION_TOPIC_SCHEMA)
     def get_topic(self, obj):
@@ -464,6 +498,15 @@ class MeProfileSerializer(serializers.ModelSerializer):
     fcm_token = serializers.CharField(
         max_length=255, required=False, allow_blank=True, write_only=True
     )
+    # Read side: the absolute avatar URL (or null). Write side: `avatar_id`,
+    # the id of an image the caller uploaded into the forum collection (todo
+    # 257 slice A). Split fields so the response carries a ready-to-render URL
+    # while the request takes a bare id — same author-object avatar contract
+    # rendered on every post.
+    avatar = serializers.SerializerMethodField()
+    avatar_id = serializers.IntegerField(
+        write_only=True, required=False, allow_null=True
+    )
 
     class Meta:
         model = ForumProfile
@@ -477,6 +520,8 @@ class MeProfileSerializer(serializers.ModelSerializer):
             "post_count",
             "capabilities",
             "fcm_token",
+            "avatar",
+            "avatar_id",
         ]
         read_only_fields = ["trust_level", "post_count"]
 
@@ -510,3 +555,36 @@ class MeProfileSerializer(serializers.ModelSerializer):
             "can_reply": True,
             "can_create_topic": True,
         }
+
+    @extend_schema_field({"type": "string", "nullable": True})
+    def get_avatar(self, obj):
+        if not (obj.avatar_id and obj.avatar):
+            return None
+        url = obj.avatar.file.url
+        request = self.context.get("request")
+        return request.build_absolute_uri(url) if request is not None else url
+
+    def validate_avatar_id(self, value):
+        # None is an explicit "clear my avatar" — allowed, no ownership check.
+        if value is None:
+            return value
+        request = self.context.get("request")
+        user = getattr(request, "user", None)
+        # IDOR-safe: an avatar must be an image THIS user uploaded into the
+        # forum image collection — the same membership check that gates inline
+        # post images (api/sanitize.py). Without it, a caller could point their
+        # avatar at any image id (a blog image, another member's upload).
+        owns_image = (
+            get_image_model()
+            .objects.filter(
+                id=value,
+                uploaded_by_user=user,
+                collection=get_forum_image_collection(),
+            )
+            .exists()
+        )
+        if not owns_image:
+            raise serializers.ValidationError(
+                "Avatar must be an image you uploaded to the forum."
+            )
+        return value

--- a/backend/packages/wagtail_forum/wagtail_forum/api/serializers.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/api/serializers.py
@@ -179,7 +179,13 @@ class TopicListSerializer(serializers.ModelSerializer):
     @extend_schema_field(AUTHOR_SCHEMA)
     def get_last_post_author(self, obj):
         # Secondary "last activity by" pointer: the object when a last poster is
-        # known, else null (no posts yet, or the last poster's account is gone).
+        # known, else null. Unlike `author` (the topic creator, which gets the
+        # [deleted] sentinel when SET_NULL'd — M41), a null here is deliberately
+        # NOT the sentinel: the denormalized fields can't tell "no live posts"
+        # (last_post_author_id None, last_post_at Coalesced to created_at) apart
+        # from "last poster's account gone" (also last_post_author_id None) —
+        # signals.py sets both the same way. Distinguishing them needs a live-post
+        # existence query, which would break the flat list pin (AC: pins unchanged).
         if obj.last_post_author_id is None:
             return None
         return serialize_forum_author(obj.last_post_author, self.context.get("request"))
@@ -219,6 +225,8 @@ class TopicDetailSerializer(serializers.ModelSerializer):
 
     @extend_schema_field(AUTHOR_SCHEMA)
     def get_last_post_author(self, obj):
+        # Null (not the [deleted] sentinel) when unknown — see the list
+        # serializer's get_last_post_author for the denorm/pin rationale.
         if obj.last_post_author_id is None:
             return None
         return serialize_forum_author(obj.last_post_author, self.context.get("request"))

--- a/backend/packages/wagtail_forum/wagtail_forum/api/user_search.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/api/user_search.py
@@ -54,8 +54,8 @@ class UserMentionSearchView(APIView):
         ).order_by("username")[:MAX_RESULTS]
         # get_full_name()/get_username() — not a `.display_name` property,
         # which is specific to THIS host's User model and breaks the
-        # package's host-agnostic contract (mirrors PostAuthorSerializer.
-        # get_display_name in serializers.py).
+        # package's host-agnostic contract (mirrors serialize_forum_author's
+        # display_name resolution in serializers.py).
         return Response(
             [
                 {

--- a/backend/packages/wagtail_forum/wagtail_forum/api/views.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/api/views.py
@@ -91,7 +91,7 @@ def _get_visible_post(post_id):
     return get_object_or_404(
         Post.objects.filter(
             live=True, topic__live=True, topic__board__in=_visible_boards()
-        ).select_related("topic", "author"),
+        ).select_related("topic", "author__wagtail_forum_profile__avatar"),
         id=post_id,
     )
 
@@ -241,8 +241,13 @@ class TopicListView(generics.ListAPIView):
         if getattr(self, "swagger_fake_view", False):
             return Topic.objects.none()
         board = _get_board(self.kwargs["slug"])
+        # Join author + last_post_author down to their ForumProfile.avatar so the
+        # unified author object (todo 257 H26) serializes with zero per-row
+        # queries — select_related adds JOINs, not queries, so the list pin stays
+        # flat (test_topics_list.py).
         qs = Topic.objects.filter(board=board, live=True).select_related(
-            "author", "last_post_author"
+            "author__wagtail_forum_profile__avatar",
+            "last_post_author__wagtail_forum_profile__avatar",
         )
         qs = _annotate_topic_unread(qs, self.request.user)
         # Kept in sync with TopicCursorPagination.ordering — the paginator
@@ -356,7 +361,11 @@ class TopicDetailView(generics.RetrieveAPIView):
             return Topic.objects.none()
         return Topic.objects.filter(
             live=True, board__in=_visible_boards()
-        ).select_related("board", "author", "last_post_author")
+        ).select_related(
+            "board",
+            "author__wagtail_forum_profile__avatar",
+            "last_post_author__wagtail_forum_profile__avatar",
+        )
 
     def retrieve(self, request, *args, **kwargs):
         response = super().retrieve(request, *args, **kwargs)
@@ -441,7 +450,7 @@ class PostListView(generics.ListAPIView):
         # (Post.edit_block reads obj.topic) adds no per-post query — flat, no N+1
         # for authenticated listers (todo 252).
         return topic.posts.filter(live=True).select_related(
-            "author", "author__wagtail_forum_profile", "topic"
+            "author__wagtail_forum_profile__avatar", "topic"
         )
 
     def list(self, request, *args, **kwargs):

--- a/backend/packages/wagtail_forum/wagtail_forum/tests/api/test_notifications_api.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/tests/api/test_notifications_api.py
@@ -357,10 +357,23 @@ def test_notification_actor_carries_trust_level_and_display_name():
     board = _board("gen-actor")
     topic, post = _topic_and_post(board, recipient, actor)
     _notify(recipient, actor, topic, post)
+    # The actor now carries the SAME unified author object as topic/post authors
+    # (todo 257 H26), including avatar — so give the actor one and assert it.
+    from wagtail.images import get_image_model
+    from wagtail.images.tests.utils import get_test_image_file
+    from wagtail_forum.collections import get_forum_image_collection
+
+    avatar = get_image_model().objects.create(
+        title="ann-avatar",
+        file=get_test_image_file(),
+        collection=get_forum_image_collection(),
+        uploaded_by_user=actor,
+    )
     profile = ForumProfile.for_user(actor)
     profile.trust_level = TrustLevel.LEADER  # 4
     profile.display_name = "Ann"
-    profile.save(update_fields=["trust_level", "display_name"])
+    profile.avatar = avatar
+    profile.save(update_fields=["trust_level", "display_name", "avatar"])
 
     client = APIClient()
     client.force_authenticate(recipient)
@@ -370,6 +383,7 @@ def test_notification_actor_carries_trust_level_and_display_name():
     assert got["username"] == "a"
     assert got["display_name"] == "Ann"
     assert got["trust_level"] == 4
+    assert got["avatar"] == f"http://testserver{avatar.file.url}"
 
 
 @pytest.mark.django_db

--- a/backend/packages/wagtail_forum/wagtail_forum/tests/api/test_post_edit_delete.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/tests/api/test_post_edit_delete.py
@@ -599,9 +599,10 @@ def test_edit_query_count_is_pinned():
     # revision save/publish + workflow finish + counter recount, unchanged by 255.
     # 68 -> 69 (audit 2026-07-11 M15): attributed publish (user=<editor>) adds
     # ONE `SELECT 1 FROM auth_user` existence check before the log-entry INSERT.
-    # 69 -> 70 (wave 2 slice 1): PostAuthorSerializer now reads author
-    # ForumProfile (real trust_level/display_name). The edit response
-    # serializes the author, adding ONE profile SELECT — `_get_visible_post`
-    # is a single-object fetch (O(1)), unlike the list views, which fold the
-    # profile into select_related to stay flat under N authors.
+    # 69 -> 70 (wave 2 slice 1): the edit response serializes the author via the
+    # unified serialize_forum_author (todo 257 H26), which reads the author's
+    # ForumProfile (real trust_level/display_name), adding ONE profile SELECT.
+    # Stays 70 under 257: submit_edit_for_moderation refresh_from_db()'s the post,
+    # discarding _get_visible_post's select_related join, so the profile reloads
+    # lazily here; the test author has no avatar, so no extra avatar SELECT.
     assert len(ctx.captured_queries) == 70, len(ctx.captured_queries)

--- a/backend/packages/wagtail_forum/wagtail_forum/tests/api/test_post_list.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/tests/api/test_post_list.py
@@ -278,10 +278,21 @@ def test_post_list_author_carries_trust_level_and_display_name():
     # (which recomputes trust_level from post_count) has already run and won't
     # clobber these values. REGULAR (3) is unreachable from 1 post, proving the
     # serializer reads the stored profile, not a recomputed level.
+    from wagtail.images import get_image_model
+    from wagtail.images.tests.utils import get_test_image_file
+    from wagtail_forum.collections import get_forum_image_collection
+
+    avatar = get_image_model().objects.create(
+        title="ada-avatar",
+        file=get_test_image_file(),
+        collection=get_forum_image_collection(),
+        uploaded_by_user=author,
+    )
     profile = ForumProfile.for_user(author)
     profile.trust_level = TrustLevel.REGULAR  # 3
     profile.display_name = "Ada L."
-    profile.save(update_fields=["trust_level", "display_name"])
+    profile.avatar = avatar
+    profile.save(update_fields=["trust_level", "display_name", "avatar"])
 
     resp = APIClient().get(f"/forum/topics/{topic.id}/posts/")
     assert resp.status_code == 200
@@ -289,6 +300,10 @@ def test_post_list_author_carries_trust_level_and_display_name():
     assert got["username"] == "ada"
     assert got["display_name"] == "Ada L."
     assert got["trust_level"] == 3
+    # The avatar serializes as the ABSOLUTE image file URL (todo 257 slice A) —
+    # not just non-null, so the feature deliverable "avatar rendered on posts"
+    # is actually proven, not merely query-pinned.
+    assert got["avatar"] == f"http://testserver{avatar.file.url}"
 
 
 @pytest.mark.django_db
@@ -349,3 +364,4 @@ def test_post_list_author_without_profile_still_renders():
     assert results[0]["author"]["username"] == "ghost"
     assert results[0]["author"]["trust_level"] is None
     assert results[0]["author"]["display_name"] == "ghost"  # username fallback
+    assert results[0]["author"]["avatar"] is None  # no profile → no avatar

--- a/backend/packages/wagtail_forum/wagtail_forum/tests/api/test_profiles.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/tests/api/test_profiles.py
@@ -102,6 +102,92 @@ def test_registering_a_token_releases_it_from_any_other_profile():
     assert prev_profile.fcm_token == "unrelated-token"
 
 
+def _forum_image(uploader, title="avatar"):
+    from wagtail.images import get_image_model
+    from wagtail.images.tests.utils import get_test_image_file
+    from wagtail_forum.collections import get_forum_image_collection
+
+    return get_image_model().objects.create(
+        title=title,
+        file=get_test_image_file(),
+        collection=get_forum_image_collection(),
+        uploaded_by_user=uploader,
+    )
+
+
+@pytest.mark.django_db
+def test_me_profile_avatar_set_and_read():
+    # todo 257 slice A (AC): avatar settable via /me/profile with a bare image
+    # id; response + GET echo the ABSOLUTE URL (same shape rendered on posts).
+    user = User.objects.create_user(username="ada")
+    ForumProfile.for_user(user)
+    image = _forum_image(user)
+    client = APIClient()
+    client.force_authenticate(user)
+
+    resp = client.patch("/forum/me/profile/", {"avatar_id": image.id}, format="json")
+    assert resp.status_code == 200
+    assert resp.data["avatar"] == f"http://testserver{image.file.url}"
+    assert "avatar_id" not in resp.data  # write-only, never echoed
+    assert ForumProfile.for_user(user).avatar_id == image.id
+
+    got = client.get("/forum/me/profile/")
+    assert got.data["avatar"] == f"http://testserver{image.file.url}"
+
+
+@pytest.mark.django_db
+def test_me_profile_avatar_rejects_foreign_image():
+    # IDOR: a caller must not set their avatar to an image ANOTHER user
+    # uploaded — mirrors the inline-image membership check (api/sanitize.py).
+    owner = User.objects.create_user(username="owner")
+    attacker = User.objects.create_user(username="attacker")
+    ForumProfile.for_user(attacker)
+    foreign = _forum_image(owner)
+    client = APIClient()
+    client.force_authenticate(attacker)
+
+    resp = client.patch("/forum/me/profile/", {"avatar_id": foreign.id}, format="json")
+    assert resp.status_code == 400
+    assert ForumProfile.for_user(attacker).avatar_id is None  # unchanged
+
+
+@pytest.mark.django_db
+def test_me_profile_avatar_rejects_image_outside_forum_collection():
+    # The other IDOR half: an image the caller DID upload but that lives outside
+    # the forum collection (e.g. a blog image) is not a valid avatar.
+    from wagtail.images import get_image_model
+    from wagtail.images.tests.utils import get_test_image_file
+
+    user = User.objects.create_user(username="ada")
+    ForumProfile.for_user(user)
+    outside = get_image_model().objects.create(
+        title="blog-hero", file=get_test_image_file(), uploaded_by_user=user
+    )
+    client = APIClient()
+    client.force_authenticate(user)
+
+    resp = client.patch("/forum/me/profile/", {"avatar_id": outside.id}, format="json")
+    assert resp.status_code == 400
+    assert ForumProfile.for_user(user).avatar_id is None
+
+
+@pytest.mark.django_db
+def test_me_profile_avatar_clear():
+    # An explicit null clears the avatar (no ownership check needed).
+    user = User.objects.create_user(username="ada")
+    image = _forum_image(user)
+    profile = ForumProfile.for_user(user)
+    profile.avatar = image
+    profile.save(update_fields=["avatar"])
+    client = APIClient()
+    client.force_authenticate(user)
+
+    resp = client.patch("/forum/me/profile/", {"avatar_id": None}, format="json")
+    assert resp.status_code == 200
+    assert resp.data["avatar"] is None
+    assert ForumProfile.for_user(user).avatar_id is None
+
+
 @pytest.mark.django_db
 def test_me_profile_requires_auth():
     resp = APIClient().get("/forum/me/profile/")

--- a/backend/packages/wagtail_forum/wagtail_forum/tests/api/test_topic_detail.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/tests/api/test_topic_detail.py
@@ -43,13 +43,22 @@ def test_topic_detail_returns_live_topic():
     assert resp.data["id"] == topic.id
     assert resp.data["title"] == "Hello"
     assert resp.data["board"]["slug"] == "general"
-    assert resp.data["author"] == "ada"
+    # Unified author object (todo 257 H26): every topic/post author is the same
+    # shape. `ada` has no ForumProfile row → display_name falls back to the
+    # username, avatar/trust_level are null.
+    assert resp.data["author"] == {
+        "username": "ada",
+        "display_name": "ada",
+        "avatar": None,
+        "trust_level": None,
+    }
     assert resp.data["opening_post_id"] == opening.id
     # Anonymous is_subscribed short-circuits with zero extra queries (todo
     # 253 slice 3) — the pin below stays 4, not 5, for this request.
     assert resp.data["is_subscribed"] is False
-    # Exactly 4: page-view-restriction check, topic fetch (select_related board/author),
-    # opening-post id lookup, post refetch by id.
+    # Exactly 4: page-view-restriction check, topic fetch (select_related board +
+    # author/last_post_author down to ForumProfile.avatar — LEFT JOINs, no extra
+    # queries), opening-post id lookup, post refetch by id.
     # Pinned EXACTLY (docs/rules/testing.md) — if this changes, explain the new count here.
     assert len(ctx.captured_queries) == 4
 

--- a/backend/packages/wagtail_forum/wagtail_forum/tests/api/test_topics_list.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/tests/api/test_topics_list.py
@@ -52,6 +52,58 @@ def test_topics_list_is_cursor_paginated_with_bounded_queries():
 
 
 @pytest.mark.django_db
+def test_topics_list_last_post_author_is_unified_object():
+    # H26: last_post_author used to be a bare username string; it now shares the
+    # unified author OBJECT (username, display_name, avatar, trust_level).
+    board = _board()
+    author = User.objects.create_user(username="starter")
+    last_poster = User.objects.create_user(username="replier")
+    profile = ForumProfile.for_user(last_poster)
+    profile.display_name = "Rep Lier"
+    profile.save(update_fields=["display_name"])
+    Topic.objects.create(
+        board=board,
+        title="T",
+        slug="t",
+        author=author,
+        live=True,
+        last_post_at=timezone.now(),
+        last_post_author=last_poster,
+    )
+
+    resp = APIClient().get(f"/forum/boards/{board.slug}/topics/")
+    assert resp.status_code == 200
+    assert resp.data["results"][0]["last_post_author"] == {
+        "username": "replier",
+        "display_name": "Rep Lier",
+        "avatar": None,
+        "trust_level": 0,
+    }
+
+
+@pytest.mark.django_db
+def test_topics_list_last_post_author_null_when_absent():
+    # No recorded last poster (last_post_author_id None) → null, deliberately NOT
+    # the [deleted] sentinel: the denorm can't tell "no posts" from "poster gone"
+    # without a pin-breaking query (see get_last_post_author's comment).
+    board = _board()
+    author = User.objects.create_user(username="starter")
+    Topic.objects.create(
+        board=board,
+        title="T",
+        slug="t",
+        author=author,
+        live=True,
+        last_post_at=timezone.now(),
+        last_post_author=None,
+    )
+
+    resp = APIClient().get(f"/forum/boards/{board.slug}/topics/")
+    assert resp.status_code == 200
+    assert resp.data["results"][0]["last_post_author"] is None
+
+
+@pytest.mark.django_db
 def test_pinned_topics_float_above_activity_ordering():
     # Audit 2026-07-11 H5: the cursor ordering ignored is_pinned, so a
     # moderator-pinned topic sank as normal activity accrued.

--- a/docs/LEARNINGS.md
+++ b/docs/LEARNINGS.md
@@ -1649,3 +1649,23 @@ committed code + PR were correct; the danger is only a later `git add -A` stagin
 it. Before any archival/bookkeeping `git add -A`, diff the reviewed source files
 and restore (`git checkout HEAD -- <file>`) any mutation left behind, then re-run
 the load-bearing test. (Same pattern seen earlier the same session on a test file.)
+
+## Forum author-contract unification (todo 257 slice A, 2026-07-24)
+
+**A denormalized `last_post_author` cannot distinguish "no posts yet" from "last
+poster's account deleted".** Unifying the forum author contract (H26/M41) meant
+one `[deleted]` sentinel object wherever an author can be null. It applies cleanly
+to a topic's `author` (the creator FK — SET_NULL → sentinel). It does NOT apply to
+`last_post_author`: `signals.py._refresh_topic_counters` sets
+`last_post_author_id=Subquery(latest_live_post.author_id)` and
+`last_post_at=Coalesce(latest_live_post.first_published_at, "created_at")`. So a
+topic with **no live posts** and a topic whose **last poster was deleted** BOTH end
+up with `last_post_author_id=None` and a **non-null** `last_post_at` (Coalesced to
+`created_at`) — the denorm fields carry no signal that separates them. Telling them
+apart needs a live-post existence query per row, which breaks the flat list pin
+(the AC explicitly required "query pins unchanged"). Resolution: `last_post_author`
+returns `null` for both, documented at `get_last_post_author`; the sentinel is
+reserved for the `author` field where the distinction is unambiguous. Lesson: a
+"consistent representation everywhere" AC can collide with a "pins unchanged" AC
+when a field is denormalized — pick the pin, and document the field that can't
+carry the finer distinction rather than adding a query to force it.

--- a/docs/rules/forum.md
+++ b/docs/rules/forum.md
@@ -72,3 +72,13 @@ Compact checklist auto-injected before edits to the forum code. Long-form:
   exercise the ancestor case, not just a directly-restricted board. Draft
   (`live=False`) topics need their own exclusion test per surface — the sitemap's
   and the feed's `live=True` guards are independent.
+- **A settable image/file reference on a user resource (e.g. profile `avatar_id`)
+  must be validated against the caller's OWN uploads within the allowed collection
+  before assignment** — `uploaded_by_user=<caller>` AND
+  `collection=get_forum_image_collection()`, the same two-part check that gates
+  inline images (audit L21). Never trust a bare image id; a `None` clear needs no
+  ownership check. See `docs/patterns/domain/forum.md` (unified author contract).
+- **Serialize every forum author through the single `serialize_forum_author` helper**
+  (topic `author`/`last_post_author`, post `author`, notification `actor`) so the
+  shape and the `[deleted]` sentinel OBJECT stay identical; `select_related` the
+  full `author__wagtail_forum_profile__avatar` chain to keep list pins flat.

--- a/todos/257-in_progress-p2-forum-identity-profiles.md
+++ b/todos/257-in_progress-p2-forum-identity-profiles.md
@@ -1,5 +1,5 @@
 ---
-status: pending
+status: in_progress
 priority: p2
 issue_id: "257"
 tags: [forum, profiles, product-ux, api]
@@ -90,6 +90,21 @@ Path shorthand: `W` = `backend/packages/wagtail_forum/wagtail_forum`, `web` = `w
 ### 2026-07-11 - Created from forum-modernization audit (Phase 4 deferral)
 
 - Epic groups 7 open findings per the manifest's Phase 4 grouping table.
+
+### 2026-07-24 - Started by completing-todos skill (run 2026-07-24-1314)
+
+- Reconciled vs current `main`: nothing re-homed (all 7 findings still point
+  here). Wave 2 slice 1 (#474) already gave `PostAuthorSerializer` real
+  `trust_level` + `display_name` (part of H7) and the web trust_level→label
+  render (part of L14). Residual: everything else — Topic authors are still bare
+  username strings (H26), no `avatar` in `MeProfileSerializer`/`PostAuthorSerializer`,
+  no public profile endpoint/page, reacted-state/anon-counts/badge/polish pending.
+- **258 overlap**: H26 unification collides with 258's M28 ("whichever lands
+  first"). 258 is pending/unstarted → **257 owns H26**; leave 258 a breadcrumb.
+- **User triage**: ALL slices, full treatment (review→fix→codify→merge per slice).
+  Order: **A** author-contract unification (H26+M41+avatar) → **C** PostCard UX
+  cluster (M23+L1+L5+L14) → **B** public profile endpoint + page (H7 remainder).
+- Slice A branch: `forum-257a-author-contract`.
 
 ## Notes
 

--- a/todos/257-in_progress-p2-forum-identity-profiles.md
+++ b/todos/257-in_progress-p2-forum-identity-profiles.md
@@ -75,15 +75,19 @@ Path shorthand: `W` = `backend/packages/wagtail_forum/wagtail_forum`, `web` = `w
 
 ## Acceptance Criteria
 
-- [ ] One author object shape across topic list/detail and post payloads; one
+- [x] One author object shape across topic list/detail and post payloads; one
       deleted-author convention; web mappers drop the `as unknown as ForumAuthor`
       casts for author identity (overlaps todo 258 M28 — whichever lands first)
-- [ ] Avatar settable via `/me/profile` and rendered on posts
+      (slice A, 2026-07-24: `serialize_forum_author` everywhere incl. notif actor;
+      `[deleted]` sentinel OBJECT; `mapAuthor` cast-free)
+- [x] Avatar settable via `/me/profile` and rendered on posts (slice A: IDOR-scoped
+      `avatar_id` write + absolute-URL read; `<img>` on PostCard)
 - [ ] Clicking an author opens a public profile page (profile + recent activity)
 - [ ] Reacted state visible with `aria-pressed`; reaction counts visible
       logged-out
 - [ ] Trust level renders as a styled badge
-- [ ] List query pins unchanged or new counts explained in-comment
+- [x] List query pins unchanged or new counts explained in-comment (slice A: pins
+      flat via select_related avatar JOINs; edit-delete 70 comment refreshed)
 
 ## Work Log
 
@@ -105,6 +109,32 @@ Path shorthand: `W` = `backend/packages/wagtail_forum/wagtail_forum`, `web` = `w
   Order: **A** author-contract unification (H26+M41+avatar) → **C** PostCard UX
   cluster (M23+L1+L5+L14) → **B** public profile endpoint + page (H7 remainder).
 - Slice A branch: `forum-257a-author-contract`.
+
+### 2026-07-24 - Slice A COMPLETE (author-contract unification, H26+M41+avatar)
+
+- Backend: one `serialize_forum_author(user, request)` helper backs every topic,
+  post, AND notification-actor payload → `{username, display_name, avatar, trust_level}`;
+  single `[deleted]` sentinel OBJECT (M41); `PostAuthorSerializer` deleted.
+- Avatar: read = absolute URL; write = `avatar_id` (write-only), IDOR-scoped to
+  caller-uploaded forum-collection images (mirrors `api/sanitize.py`); `<img>` on PostCard.
+- Web: new `ForumAuthor` type unifies `Thread.author`+`Post.author`; `mapAuthor` drops
+  the `as unknown as` casts; `NotificationActor` gains avatar.
+- **Decisions (advisor-vetted, review PASS 0 findings):**
+  1. Notification actor folded into the unified helper (its `@extend_schema_field`
+     already promised avatar) — full contract consistency.
+  2. Avatar = raw `.file.url` (full-size original), NOT a rendition — deliberate:
+     a `get_rendition` adds a per-author SELECT that breaks the flat list pin. Inline
+     body images still use renditions; avatars trade fidelity for pin-flatness.
+  3. `last_post_author` → `null` (not the sentinel) for a deleted last-poster: the
+     denorm can't tell "no posts" from "poster gone" without a pin-breaking query
+     (AC: pins unchanged). Primary M41 target (`author`) uses the sentinel. Documented
+     in `get_last_post_author`.
+  4. Mobile-safe: `plant_community_mobile` forum screen uses hardcoded mock strings,
+     not API author parsing (Wave 3 unstarted) — the string→object change breaks nothing.
+- Verify: backend 324+2 pass (`--create-db`), `spectacular` exit 0; web `type-check`
+  clean, `vitest run` 656 pass. code-review-orchestrator: PASS, 0 findings.
+- Commits on branch: `2ed4b28` (impl) + review-response (last_post_author docs+tests).
+- NEXT: codify → PR → merge slice A; then slice C off fresh main, then slice B.
 
 ## Notes
 

--- a/web/src/components/forum/PostCard.test.tsx
+++ b/web/src/components/forum/PostCard.test.tsx
@@ -22,10 +22,9 @@ describe('PostCard', () => {
   it('renders post author information', () => {
     const post = createMockPost({
       author: {
-        id: 1,
-        email: 'plantlover@example.com',
         username: 'plantlover',
         display_name: 'Green Thumb',
+        avatar: null,
         trust_level: 2,
       },
     });
@@ -39,10 +38,9 @@ describe('PostCard', () => {
   it('hides the trust badge for a NEW (level 0) author', () => {
     const post = createMockPost({
       author: {
-        id: 1,
-        email: 'newbie@example.com',
         username: 'newbie',
         display_name: 'New Person',
+        avatar: null,
         trust_level: 0,
       },
     });
@@ -58,10 +56,9 @@ describe('PostCard', () => {
   it('falls back to username when display_name is missing', () => {
     const post = createMockPost({
       author: {
-        id: 1,
-        email: 'plantlover@example.com',
         username: 'plantlover',
         display_name: undefined,
+        avatar: null,
         trust_level: 1,
       },
     });
@@ -260,10 +257,9 @@ describe('PostCard', () => {
   it('renders author avatar with first letter', () => {
     const post = createMockPost({
       author: {
-        id: 1,
-        email: 'gardener@example.com',
         username: 'gardener',
         display_name: 'Garden Expert',
+        avatar: null,
         trust_level: 3,
       },
     });
@@ -274,13 +270,30 @@ describe('PostCard', () => {
     expect(screen.getByText('G')).toBeInTheDocument();
   });
 
+  it('renders the avatar image when the author has an avatar (todo 257)', () => {
+    const post = createMockPost({
+      author: {
+        username: 'gardener',
+        display_name: 'Garden Expert',
+        avatar: 'http://x/media/avatar.jpg',
+        trust_level: 3,
+      },
+    });
+
+    renderPostCard(post);
+
+    const img = screen.getByAltText('Garden Expert avatar');
+    expect(img).toHaveAttribute('src', 'http://x/media/avatar.jpg');
+    // The initial-letter fallback is replaced by the image.
+    expect(screen.queryByText('G')).not.toBeInTheDocument();
+  });
+
   it('uses username first letter when display_name is missing', () => {
     const post = createMockPost({
       author: {
-        id: 1,
-        email: 'plantlover@example.com',
         username: 'plantlover',
         display_name: undefined,
+        avatar: null,
         trust_level: 1,
       },
     });

--- a/web/src/components/forum/PostCard.tsx
+++ b/web/src/components/forum/PostCard.tsx
@@ -112,10 +112,18 @@ function PostCard({ post, onEdit, onDelete, onReact, onReport }: PostCardProps) 
       <div className="flex items-start justify-between flex-wrap gap-2 mb-4">
         {/* Author Info */}
         <div className="flex items-center gap-3">
-          <div className="w-12 h-12 bg-primary/10 rounded-full flex items-center justify-center">
-            <span className="text-xl font-bold text-leaf">
-              {post.author.display_name?.[0] || post.author.username[0]}
-            </span>
+          <div className="w-12 h-12 bg-primary/10 rounded-full flex items-center justify-center overflow-hidden">
+            {post.author.avatar ? (
+              <img
+                src={post.author.avatar}
+                alt={`${post.author.display_name || post.author.username} avatar`}
+                className="w-full h-full object-cover"
+              />
+            ) : (
+              <span className="text-xl font-bold text-leaf">
+                {post.author.display_name?.[0] || post.author.username[0]}
+              </span>
+            )}
           </div>
 
           <div>

--- a/web/src/components/forum/ThreadCard.test.tsx
+++ b/web/src/components/forum/ThreadCard.test.tsx
@@ -31,10 +31,10 @@ describe('ThreadCard', () => {
   it('renders author display name', () => {
     const thread = createMockThread({
       author: {
-        id: 1,
-        email: 'plantlover@example.com',
         username: 'plantlover',
         display_name: 'Plant Enthusiast',
+        avatar: null,
+        trust_level: null,
       },
     });
 
@@ -46,10 +46,10 @@ describe('ThreadCard', () => {
   it('falls back to username when display_name is missing', () => {
     const thread = createMockThread({
       author: {
-        id: 1,
-        email: 'plantlover@example.com',
         username: 'plantlover',
         display_name: undefined,
+        avatar: null,
+        trust_level: null,
       },
     });
 

--- a/web/src/components/layout/NotificationBell.test.tsx
+++ b/web/src/components/layout/NotificationBell.test.tsx
@@ -26,7 +26,7 @@ function makeNotification(overrides: Partial<ForumNotification> = {}): ForumNoti
   return {
     id: 1,
     verb: 'reply',
-    actor: { username: 'ada', display_name: 'Ada', trust_level: 0 },
+    actor: { username: 'ada', display_name: 'Ada', avatar: null, trust_level: 0 },
     topic: {
       id: 10,
       slug: 'watering-tips',

--- a/web/src/pages/forum/SearchPage.test.tsx
+++ b/web/src/pages/forum/SearchPage.test.tsx
@@ -183,7 +183,12 @@ describe('SearchPage', () => {
       const deletedThread = createMockThread({
         id: '1',
         title: 'Watering Guide',
-        author: { id: 0, email: '', username: '[deleted]', display_name: '[deleted]' },
+        author: {
+          username: '[deleted]',
+          display_name: '[deleted]',
+          avatar: null,
+          trust_level: null,
+        },
       });
       const mockResults = createMockSearchResults({
         query: 'watering',

--- a/web/src/pages/forum/ThreadDetailPage.test.tsx
+++ b/web/src/pages/forum/ThreadDetailPage.test.tsx
@@ -113,10 +113,10 @@ describe('ThreadDetailPage', () => {
       slug: 'watering-tips',
       title: 'How to water succulents?',
       author: {
-        id: 1,
-        email: 'gardener@example.com',
         username: 'gardener',
         display_name: 'Master Gardener',
+        avatar: null,
+        trust_level: null,
       },
       view_count: 150,
     });

--- a/web/src/services/forumMappers.test.ts
+++ b/web/src/services/forumMappers.test.ts
@@ -47,14 +47,19 @@ describe('forumMappers (wagtail_forum contract)', () => {
       id: 12,
       title: 'Succulent help',
       slug: 'succulent-help',
-      author: 'jdoe',
+      author: {
+        username: 'jdoe',
+        display_name: 'Jane Doe',
+        avatar: 'http://x/media/a.jpg',
+        trust_level: 2,
+      },
       is_pinned: false,
       is_closed: false,
       locked: false,
       reply_count: 4,
       view_count: 99,
       last_post_at: '2026-01-02T00:00:00Z',
-      last_post_author: 'jdoe',
+      last_post_author: null,
       is_unread: false,
     });
     expect(t).toMatchObject({
@@ -67,15 +72,20 @@ describe('forumMappers (wagtail_forum contract)', () => {
       is_pinned: false,
       is_locked: false,
     });
-    expect(t.author?.username).toBe('jdoe');
+    // Unified author object (todo 257 H26): username, display_name, avatar.
+    expect(t.author.username).toBe('jdoe');
+    expect(t.author.display_name).toBe('Jane Doe');
+    expect(t.author.avatar).toBe('http://x/media/a.jpg');
+    expect(t.author.trust_level).toBe(2);
   });
 
-  it('mapTopicListItemToThread handles null author ([deleted])', () => {
+  it('mapTopicListItemToThread maps the [deleted] sentinel author', () => {
     const t = mapTopicListItemToThread({
       id: 1,
       title: 'T',
       slug: 't',
-      author: null,
+      // Backend sends the [deleted] sentinel OBJECT for a deleted author (M41).
+      author: { username: '[deleted]', display_name: '[deleted]', avatar: null, trust_level: null },
       is_pinned: false,
       is_closed: false,
       locked: false,
@@ -85,7 +95,8 @@ describe('forumMappers (wagtail_forum contract)', () => {
       last_post_author: null,
       is_unread: false,
     });
-    expect(t.author?.username).toBe('[deleted]');
+    expect(t.author.username).toBe('[deleted]');
+    expect(t.author.avatar).toBeNull();
   });
 
   it('mapTopicListItemToThread passes through is_unread', () => {
@@ -93,7 +104,7 @@ describe('forumMappers (wagtail_forum contract)', () => {
       id: 1,
       title: 'T',
       slug: 't',
-      author: 'u',
+      author: { username: 'u', display_name: 'U', avatar: null, trust_level: null },
       is_pinned: false,
       is_closed: false,
       locked: false,
@@ -111,7 +122,7 @@ describe('forumMappers (wagtail_forum contract)', () => {
       id: 1,
       title: 'T',
       slug: 't',
-      author: 'u',
+      author: { username: 'u', display_name: 'U', avatar: null, trust_level: null },
       is_pinned: false,
       is_closed: true,
       locked: false,
@@ -142,7 +153,7 @@ describe('forumMappers (wagtail_forum contract)', () => {
       title: 'Succulent help',
       slug: 'succulent-help',
       board: { id: 3, slug: 'plant-care', title: 'Plant Care' },
-      author: 'jdoe',
+      author: { username: 'jdoe', display_name: 'Jane Doe', avatar: null, trust_level: 2 },
       is_pinned: true,
       is_closed: false,
       locked: false,
@@ -150,7 +161,7 @@ describe('forumMappers (wagtail_forum contract)', () => {
       view_count: 99,
       created_at: '2026-01-01T00:00:00Z',
       last_post_at: '2026-01-02T00:00:00Z',
-      last_post_author: 'jdoe',
+      last_post_author: null,
       opening_post_id: 50,
       is_subscribed: true,
     });
@@ -175,7 +186,7 @@ describe('forumMappers (wagtail_forum contract)', () => {
       title: 'T',
       slug: 't',
       board: { id: 1, slug: 'b', title: 'B' },
-      author: null,
+      author: { username: '[deleted]', display_name: '[deleted]', avatar: null, trust_level: null },
       is_pinned: false,
       is_closed: false,
       locked: true,
@@ -199,7 +210,12 @@ describe('forumMappers (wagtail_forum contract)', () => {
       {
         id: 50,
         topic_id: 12,
-        author: { username: 'jdoe', display_name: 'Jane Doe', trust_level: 2 },
+        author: {
+          username: 'jdoe',
+          display_name: 'Jane Doe',
+          avatar: 'http://x/media/jane.jpg',
+          trust_level: 2,
+        },
         body: [{ type: 'paragraph', value: 'hello', id: 'blk-1' }],
         created_at: '2026-01-01T00:00:00Z',
         updated_at: '2026-01-01T00:00:00Z',
@@ -223,9 +239,10 @@ describe('forumMappers (wagtail_forum contract)', () => {
       can_delete: false,
       can_report: true,
     });
-    expect(p.author?.username).toBe('jdoe');
-    expect(p.author?.display_name).toBe('Jane Doe');
-    expect(p.author?.trust_level).toBe(2);
+    expect(p.author.username).toBe('jdoe');
+    expect(p.author.display_name).toBe('Jane Doe');
+    expect(p.author.trust_level).toBe(2);
+    expect(p.author.avatar).toBe('http://x/media/jane.jpg');
     expect(p.body).toHaveLength(1);
     expect(p.body?.[0].type).toBe('paragraph');
   });
@@ -235,7 +252,12 @@ describe('forumMappers (wagtail_forum contract)', () => {
       {
         id: 51,
         topic_id: 12,
-        author: { username: '[deleted]', display_name: '[deleted]', trust_level: null },
+        author: {
+          username: '[deleted]',
+          display_name: '[deleted]',
+          avatar: null,
+          trust_level: null,
+        },
         body: [],
         created_at: '2026-01-01T00:00:00Z',
         is_opening_post: false,
@@ -256,7 +278,7 @@ describe('forumMappers (wagtail_forum contract)', () => {
       {
         id: 52,
         topic_id: 12,
-        author: { username: 'u', display_name: 'U', trust_level: null },
+        author: { username: 'u', display_name: 'U', avatar: null, trust_level: null },
         body: [],
         created_at: '2026-01-01T00:00:00Z',
         is_opening_post: false,

--- a/web/src/services/forumMappers.ts
+++ b/web/src/services/forumMappers.ts
@@ -1,5 +1,5 @@
 import type { StreamFieldBlock } from '../types/blog';
-import type { Category, Thread, Post } from '../types/forum';
+import type { Category, Thread, Post, ForumAuthor } from '../types/forum';
 
 // ---------------------------------------------------------------------------
 // Backend shapes — wagtail_forum API contract
@@ -18,14 +18,16 @@ export interface BackendTopicListItem {
   id: number;
   title: string;
   slug: string;
-  author: string | null;
+  // Unified author object (todo 257 H26) — a deleted author is the `[deleted]`
+  // sentinel object, never null. last_post_author is object-or-null.
+  author: BackendAuthor;
   is_pinned: boolean;
   is_closed: boolean;
   locked: boolean;
   reply_count: number;
   view_count: number;
   last_post_at: string | null;
-  last_post_author: string | null;
+  last_post_author: BackendAuthor | null;
   is_unread: boolean;
 }
 
@@ -34,7 +36,7 @@ export interface BackendTopicDetail {
   title: string;
   slug: string;
   board: { id: number; slug: string; title: string };
-  author: string | null;
+  author: BackendAuthor;
   is_pinned: boolean;
   is_closed: boolean;
   locked: boolean;
@@ -42,7 +44,7 @@ export interface BackendTopicDetail {
   view_count: number;
   created_at: string;
   last_post_at: string | null;
-  last_post_author: string | null;
+  last_post_author: BackendAuthor | null;
   opening_post_id: number | null;
   is_subscribed: boolean;
 }
@@ -50,16 +52,20 @@ export interface BackendTopicDetail {
 // StreamFieldBlock re-exported for consumers that import backend shapes from this module.
 export type { StreamFieldBlock } from '../types/blog';
 
-export interface BackendPostAuthor {
+// The unified author object every topic/post payload carries (backend
+// serialize_forum_author, todo 257 H26/M41). A deleted author is the
+// `[deleted]` sentinel object, never null.
+export interface BackendAuthor {
   username: string;
   display_name: string;
+  avatar: string | null;
   trust_level: number | null;
 }
 
 export interface BackendPost {
   id: number;
   topic_id: number;
-  author: BackendPostAuthor;
+  author: BackendAuthor;
   body: StreamFieldBlock[];
   created_at: string;
   updated_at?: string;
@@ -97,31 +103,23 @@ export interface BackendSearchPost {
 // Helpers
 // ---------------------------------------------------------------------------
 
-type ForumAuthor = Thread['author'];
-
-/** Build a forum author from a plain string username (topic list/detail). */
-function authorFromString(username: string | null): ForumAuthor {
-  if (!username) {
-    return { id: '', username: '[deleted]', display_name: '[deleted]' } as unknown as ForumAuthor;
-  }
-  return { id: '', username, display_name: username } as unknown as ForumAuthor;
-}
-
-/** Build a forum author from the post author object. */
-function authorFromObject(a: BackendPostAuthor): Post['author'] {
-  if (a.username === '[deleted]') {
-    return {
-      id: '',
-      username: '[deleted]',
-      display_name: '[deleted]',
-    } as unknown as Post['author'];
+/**
+ * Map the backend author object to the unified ForumAuthor used by both
+ * Thread.author and Post.author (todo 257 H26). The backend already sends the
+ * `[deleted]` sentinel object for a deleted author, so this mostly passes
+ * through; the null branch covers `last_post_author` and the search payloads,
+ * which carry no author. No casts — the shapes line up exactly.
+ */
+function mapAuthor(a: BackendAuthor | null): ForumAuthor {
+  if (!a) {
+    return { username: '[deleted]', display_name: '[deleted]', avatar: null, trust_level: null };
   }
   return {
-    id: '',
     username: a.username,
     display_name: a.display_name || a.username,
-    trust_level: a.trust_level ?? undefined,
-  } as unknown as Post['author'];
+    avatar: a.avatar,
+    trust_level: a.trust_level,
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -147,7 +145,7 @@ export function mapTopicListItemToThread(t: BackendTopicListItem): Thread {
     slug: t.slug,
     // No category info on the list item — caller must supply or leave empty
     category: { id: '', name: '', slug: '', created_at: '' },
-    author: authorFromString(t.author),
+    author: mapAuthor(t.author),
     // list item has no created_at; use last_post_at as best proxy
     created_at: t.last_post_at || '',
     last_activity_at: t.last_post_at || '',
@@ -173,7 +171,7 @@ export function mapTopicDetailToThread(t: BackendTopicDetail): Thread {
     title: t.title,
     slug: t.slug,
     category,
-    author: authorFromString(t.author),
+    author: mapAuthor(t.author),
     created_at: t.created_at,
     last_activity_at: t.last_post_at || t.created_at,
     post_count: t.reply_count,
@@ -189,7 +187,7 @@ export function mapPostToPost(p: BackendPost, threadId: string): Post {
   return {
     id: String(p.id),
     thread: threadId,
-    author: authorFromObject(p.author),
+    author: mapAuthor(p.author),
     content_raw: '', // StreamField body — no plain-text equivalent; Task 6 renders body blocks
     content_html: undefined,
     content_format: 'draftail',
@@ -212,7 +210,8 @@ export function mapSearchTopicToThread(t: BackendSearchTopic): Thread {
     title: t.title,
     slug: t.slug,
     category: { id: String(t.board_id), name: '', slug: t.board_slug, created_at: '' },
-    author: authorFromString(null),
+    // Search payload carries no author (BackendSearchTopic) → sentinel author.
+    author: mapAuthor(null),
     // Search payload carries no creation time; only last activity. Don't alias
     // last_post_at as created_at (that misrepresents it downstream).
     created_at: '',
@@ -227,9 +226,8 @@ export function mapSearchPostToPost(p: BackendSearchPost): Post {
   return {
     id: String(p.id),
     thread: String(p.topic_id),
-    // Same cast as mapPostToPost — authorFromString returns ForumAuthor
-    // (Thread's User shape) but this feeds Post.author (numeric trust_level).
-    author: authorFromString(null) as unknown as Post['author'],
+    // Search payload carries no author (BackendSearchPost) → sentinel author.
+    author: mapAuthor(null),
     content_raw: p.excerpt,
     content_format: 'plain',
     body: [],

--- a/web/src/tests/forumUtils.ts
+++ b/web/src/tests/forumUtils.ts
@@ -7,8 +7,7 @@
  * Previous version was deleted but not converted, causing test failures.
  */
 
-import type { Category, Thread, Post } from '../types/forum';
-import type { User } from '../types/auth';
+import type { Category, Thread, Post, ForumAuthor } from '../types/forum';
 
 /**
  * Create a mock Category for testing
@@ -33,24 +32,18 @@ export function createMockCategory(overrides: Partial<Category> = {}): Category 
 }
 
 /**
- * Create a mock User for testing
+ * Create a mock ForumAuthor for testing — the unified author object every
+ * topic/post payload carries (todo 257 H26).
  *
- * @param overrides - Partial user data to override defaults
- * @returns Complete User object with defaults
+ * @param overrides - Partial author data to override defaults
+ * @returns Complete ForumAuthor object with defaults
  */
-function createMockUser(overrides: Partial<User> = {}): User {
-  const defaults: User = {
-    id: 1,
-    email: 'testuser@example.com',
+export function createMockForumAuthor(overrides: Partial<ForumAuthor> = {}): ForumAuthor {
+  const defaults: ForumAuthor = {
     username: 'testuser',
     display_name: 'Test User',
-    first_name: 'Test',
-    last_name: 'User',
-    trust_level: 'basic',
-    date_joined: new Date(Date.now() - 1000 * 60 * 60 * 24 * 30).toISOString(), // 30 days ago
-    is_active: true,
-    is_staff: false,
-    is_moderator: false,
+    avatar: null,
+    trust_level: 1,
   };
 
   return { ...defaults, ...overrides };
@@ -69,7 +62,7 @@ export function createMockThread(overrides: Partial<Thread> = {}): Thread {
     slug: 'how-to-water-succulents',
     excerpt: 'Looking for advice on watering frequency',
     category: createMockCategory(),
-    author: createMockUser(),
+    author: createMockForumAuthor(),
     created_at: new Date(Date.now() - 1000 * 60 * 60 * 24 * 3).toISOString(), // 3 days ago
     updated_at: new Date(Date.now() - 1000 * 60 * 60 * 2).toISOString(), // 2 hours ago
     last_activity_at: new Date(Date.now() - 1000 * 60 * 60 * 2).toISOString(), // 2 hours ago
@@ -93,10 +86,7 @@ export function createMockPost(overrides: Partial<Post> = {}): Post {
   const defaults: Post = {
     id: 'post-1',
     thread: 'thread-1',
-    author: {
-      ...createMockUser(),
-      trust_level: 1,
-    },
+    author: createMockForumAuthor({ trust_level: 1 }),
     content_raw: '<p>This is a test post content</p>',
     content_html: '<p>This is a test post content</p>',
     content_format: 'rich',

--- a/web/src/types/forum.ts
+++ b/web/src/types/forum.ts
@@ -21,6 +21,20 @@ export interface Category {
 }
 
 /**
+ * Forum author — the unified object every topic/post/notification-actor payload
+ * shares (backend serialize_forum_author, todo 257 H26/M41). A deleted author is
+ * the `[deleted]` sentinel object, never null. `trust_level` is the backend
+ * ForumProfile integer enum (0=New … 4=Leader) or null when the author has no
+ * profile; `avatar` is an absolute image URL or null.
+ */
+export interface ForumAuthor {
+  username: string;
+  display_name: string;
+  avatar: string | null;
+  trust_level: number | null;
+}
+
+/**
  * Forum thread
  */
 export interface Thread {
@@ -29,7 +43,7 @@ export interface Thread {
   slug: string;
   excerpt?: string;
   category: Category;
-  author: User;
+  author: ForumAuthor;
   created_at: string;
   updated_at?: string;
   last_activity_at: string;
@@ -48,12 +62,9 @@ export interface Thread {
 export interface Post {
   id: string;
   thread: string;
-  // Forum posts carry the backend ForumProfile trust level as an integer enum
-  // (0=New … 4=Leader), distinct from the auth User's string trust_level enum,
-  // so override (not intersect) trust_level to a number.
-  author: Omit<User, 'trust_level'> & {
-    trust_level?: number;
-  };
+  // Same unified ForumAuthor object as Thread.author (todo 257 H26): username,
+  // display_name, avatar, and the ForumProfile integer trust_level.
+  author: ForumAuthor;
   content_raw: string;
   content_html?: string;
   content_format?: string;

--- a/web/src/types/notifications.ts
+++ b/web/src/types/notifications.ts
@@ -6,6 +6,9 @@
 export interface NotificationActor {
   username: string;
   display_name: string;
+  // Unified author object (todo 257 H26): the actor now carries an avatar
+  // (absolute URL or null), same shape as every topic/post author.
+  avatar: string | null;
   trust_level: number | null;
 }
 


### PR DESCRIPTION
## Summary

Slice A of todo 257 (forum identity & profiles): **unify the author contract and add avatars** — audit findings **H26** (topic author = string vs post author = object) and **M41** (deleted-author `null` on topics vs `[deleted]` sentinel on posts), plus the avatar half of **H7**.

One helper — `serialize_forum_author(user, request)` — now backs **every** author a client sees: a topic's `author` and `last_post_author`, a post's `author`, and a notification's `actor`. All return one shape `{username, display_name, avatar, trust_level}`, and a deleted author is a single `[deleted]` sentinel **object** everywhere. `PostAuthorSerializer` is deleted.

## What changed

**Backend**
- `serialize_forum_author` + `_deleted_author` helpers; topic/post/notification authors routed through them.
- Avatar: read = absolute URL; write = a **write-only `avatar_id`** on `/me/profile`, IDOR-scoped to images the caller uploaded into the forum collection (mirrors `api/sanitize.py`'s L21 check). `None` clears it.
- List query pins stay **flat** — `select_related` joins `author__wagtail_forum_profile__avatar` (JOINs, not queries). Notification list pin held at 2, post list at 3, topic list at 3, topic detail at 4.

**Web**
- New `ForumAuthor` type unifies `Thread.author` + `Post.author`; cast-free `mapAuthor` drops the `as unknown as ForumAuthor` double-casts.
- Avatar `<img>` rendered on `PostCard` (initial-letter fallback kept); `NotificationActor` gains `avatar`.

## Deliberate decisions (advisor-vetted)
- **Avatar = raw `.file.url`, not a rendition** — a `get_rendition()` per author would add a SELECT and break the flat pin.
- **`last_post_author` → `null` (not the sentinel) for a deleted last-poster** — the denorm can't distinguish "no posts" from "poster gone" without a pin-breaking query (`docs/LEARNINGS.md` 2026-07-24).
- **Mobile-safe** — `plant_community_mobile` forum screen uses hardcoded mock strings, not API author parsing (Wave 3 unstarted).

## Verification
- Backend: **326 forum tests pass** (`--create-db`); `manage.py spectacular` exit 0 (no new schema errors).
- Web: `npm run type-check` clean; `vitest run` **656 pass**.
- `code-review-orchestrator`: **PASS, 0 findings**. `kimi-review` branch diff: clean.

New tests: avatar serialization (post/notification/me-profile → absolute URL), me-profile avatar write set/read + both IDOR halves + clear, PostCard avatar img, `last_post_author` object-shape + null cases.

Codified in `docs/patterns/domain/forum.md`, `query-optimization.md` Pattern 30, `docs/LEARNINGS.md`, `docs/rules/forum.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)