### PR TITLE
forum: reaction reacted-state + PostCard a11y (todo 257 slice C / M23 L14)

### DIFF
--- a/backend/docs/patterns/performance/query-optimization.md
+++ b/backend/docs/patterns/performance/query-optimization.md
@@ -1419,3 +1419,38 @@ Two things make it hold:
 - **Gate on the FK column (`profile.avatar_id`) before touching the related object (`profile.avatar`)** — `avatar_id` is already loaded on the joined row, so the common no-avatar case never issues the avatar SELECT.
 
 **Caveat**: a `refresh_from_db()` (e.g. `submit_edit_for_moderation` on a post edit) discards the `select_related`-joined instance, so a single-object serialize AFTER a refresh reloads the graph lazily — that path's pin reflects the lazy SELECTs, not the join. Document the count at the assertion site. See the forum unified author contract (`docs/patterns/domain/forum.md`); live in `wagtail_forum/api/{serializers,views,notifications}.py`.
+
+## Pattern 31: Per-request-user field on a `many=True` serializer → batch into context, and guard the read with `is not None`
+
+**Problem**: A list serializer needs a field whose value depends on the REQUESTING USER, not just the row — e.g. "which reaction types has *this user* reacted with on this post" (`PostSerializer.reacted`). It can't come from `select_related` (it's not a row attribute; it's a join keyed on the current user). The naive `SerializerMethodField` that queries per row is a per-user N+1 that only bites authenticated requests, so anonymous pin tests never catch it.
+
+**Fix**: build the whole page's per-user data in ONE query in the view's `list()` and inject it via serializer context — exactly like `build_forum_image_map`. The field method reads the map, never the DB (on the list path).
+
+```python
+# view.list(): one query for the whole page, AUTHED-ONLY so anon pins don't move
+reacted_map = None
+if request.user.is_authenticated:
+    reacted_map = {}
+    for post_id, rtype in Reaction.objects.filter(
+        post__in=objects, user=request.user            # `objects` = the materialized page
+    ).values_list("post_id", "reaction_type"):
+        reacted_map.setdefault(post_id, []).append(rtype)
+context = {..., "forum_reacted_map": reacted_map}
+
+# serializer field:
+def get_reacted(self, obj):
+    user = self._request_user()
+    if user is None or not user.is_authenticated:
+        return []                                       # anon: no query, no map read
+    reacted_map = self.context.get("forum_reacted_map")
+    if reacted_map is not None:                         # NOT `if reacted_map:`  ← the landmine
+        return reacted_map.get(obj.id, [])
+    return list(Reaction.objects.filter(post=obj, user=user)
+                .values_list("reaction_type", flat=True))  # single-object fallback (edit/reply)
+```
+
+Three load-bearing details:
+
+- **Guard the map read with `is not None`, NEVER truthiness.** An authenticated user with zero rows produces an empty dict `{}` — falsy but not `None`. `if reacted_map:` routes *every* row to the per-object fallback and silently reintroduces the N+1. Pin an authed test where the user has NO rows (empty map) and assert the count is the batched number, not `base + N` (in the forum this is the owner-affordance pin at 4, not 3+20).
+- **`post__in=objects` does not re-run the page query** as long as `objects` is the already-materialized page list (DRF `paginate_queryset` returns `list(qs[:page_size])`). Passing a *lazy* queryset there would make it a correlated subquery — use the paginated list.
+- **The single-object fallback is correct but load-bearing**: it keeps edit/reply-create responses (no batched map) accurate so a replace-the-post client update can't clobber the field. BUT any NEW `many=True` caller that forgets to seed the context map silently hits the per-row fallback — document the "seed the map" contract on the field (like this section). Authed list pins move (e.g. +1 for the batched query, +2 for `has_perm` cache-fill on non-author viewers); explain each shift in-comment. Lives in `wagtail_forum/api/{serializers,views}.py` (`forum_reacted_map`, todo 257 slice C / M23).

--- a/backend/packages/wagtail_forum/wagtail_forum/api/serializers.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/api/serializers.py
@@ -335,6 +335,7 @@ class PostSerializer(serializers.ModelSerializer):
     topic_id = serializers.IntegerField(read_only=True)
     edited_at = serializers.SerializerMethodField()
     status = serializers.SerializerMethodField()
+    reacted = serializers.SerializerMethodField()
     can_edit = serializers.SerializerMethodField()
     can_delete = serializers.SerializerMethodField()
     can_report = serializers.SerializerMethodField()
@@ -352,6 +353,7 @@ class PostSerializer(serializers.ModelSerializer):
             "is_opening_post",
             "status",
             "reaction_counts",
+            "reacted",
             "can_edit",
             "can_delete",
             "can_report",
@@ -376,6 +378,28 @@ class PostSerializer(serializers.ModelSerializer):
     @extend_schema_field(OpenApiTypes.STR)
     def get_status(self, obj):
         return "live" if obj.live else "pending"
+
+    @extend_schema_field({"type": "array", "items": {"type": "string"}})
+    def get_reacted(self, obj):
+        # Which reaction types the CURRENT user has active on this post (M23) —
+        # `[]` for anonymous. On the list endpoint this reads a per-page batched
+        # map from context (forum_reacted_map, built once in PostListView.list),
+        # so it costs zero per-post queries and the authed list pin stays flat
+        # under N posts. Single-post responses (edit/reply-create) carry no map
+        # and fall back to ONE O(1) query — deliberately, so the edit response's
+        # reacted state is correct and a replace-the-post client update
+        # (ThreadDetailPage.handleEditSubmit) can't clobber it.
+        user = self._request_user()
+        if user is None or not user.is_authenticated:
+            return []
+        reacted_map = self.context.get("forum_reacted_map")
+        if reacted_map is not None:
+            return reacted_map.get(obj.id, [])
+        return list(
+            Reaction.objects.filter(post=obj, user=user).values_list(
+                "reaction_type", flat=True
+            )
+        )
 
     def _request_user(self):
         request = self.context.get("request")

--- a/backend/packages/wagtail_forum/wagtail_forum/api/serializers.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/api/serializers.py
@@ -379,7 +379,15 @@ class PostSerializer(serializers.ModelSerializer):
     def get_status(self, obj):
         return "live" if obj.live else "pending"
 
-    @extend_schema_field({"type": "array", "items": {"type": "string"}})
+    @extend_schema_field(
+        {
+            "type": "array",
+            "items": {
+                "type": "string",
+                "enum": [choice[0] for choice in Reaction.REACTION_CHOICES],
+            },
+        }
+    )
     def get_reacted(self, obj):
         # Which reaction types the CURRENT user has active on this post (M23) —
         # `[]` for anonymous. On the list endpoint this reads a per-page batched
@@ -389,6 +397,10 @@ class PostSerializer(serializers.ModelSerializer):
         # and fall back to ONE O(1) query — deliberately, so the edit response's
         # reacted state is correct and a replace-the-post client update
         # (ThreadDetailPage.handleEditSubmit) can't clobber it.
+        # NB for future callers: any NEW many=True PostSerializer usage over an
+        # authed request MUST seed `forum_reacted_map` in context (like
+        # build_forum_image_map) — otherwise this fallback fires per row and
+        # reintroduces the N+1 the batched map exists to prevent.
         user = self._request_user()
         if user is None or not user.is_authenticated:
             return []

--- a/backend/packages/wagtail_forum/wagtail_forum/api/views.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/api/views.py
@@ -727,8 +727,10 @@ class ReactionToggleView(APIView):
         request=ReactionSerializer,
         responses={200: dict, 400: dict, 404: dict},
         description=(
-            "Toggle a reaction. The response includes `reacted` (the resulting "
-            "state for this user). With an Idempotency-Key header a retry "
+            "Toggle a reaction. The response's `reacted` is a BOOLEAN — the "
+            "resulting state of THIS reaction type for this user (distinct from "
+            "a post payload's `reacted`, which is the string[] of all the user's "
+            "active types on that post). With an Idempotency-Key header a retry "
             "replays the original result instead of toggling back."
         ),
     )

--- a/backend/packages/wagtail_forum/wagtail_forum/api/views.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/api/views.py
@@ -460,9 +460,21 @@ class PostListView(generics.ListAPIView):
         queryset = self.filter_queryset(self.get_queryset())
         page = self.paginate_queryset(queryset)
         objects = page if page is not None else queryset
+        # Per-page batched map of the CURRENT user's reactions (M23) so the
+        # serializer's `reacted` field costs zero per-post queries — one query
+        # for the whole page, like build_forum_image_map. Authed-only: an
+        # anonymous list issues no reaction query, so its pin stays 3.
+        reacted_map = None
+        if request.user.is_authenticated:
+            reacted_map = {}
+            for post_id, rtype in Reaction.objects.filter(
+                post__in=objects, user=request.user
+            ).values_list("post_id", "reaction_type"):
+                reacted_map.setdefault(post_id, []).append(rtype)
         context = {
             **self.get_serializer_context(),
             "forum_image_map": build_forum_image_map(objects),
+            "forum_reacted_map": reacted_map,
         }
         serializer = self.get_serializer(objects, many=True, context=context)
         if page is not None:

--- a/backend/packages/wagtail_forum/wagtail_forum/tests/api/test_post_edit_delete.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/tests/api/test_post_edit_delete.py
@@ -602,7 +602,9 @@ def test_edit_query_count_is_pinned():
     # 69 -> 70 (wave 2 slice 1): the edit response serializes the author via the
     # unified serialize_forum_author (todo 257 H26), which reads the author's
     # ForumProfile (real trust_level/display_name), adding ONE profile SELECT.
-    # Stays 70 under 257: submit_edit_for_moderation refresh_from_db()'s the post,
-    # discarding _get_visible_post's select_related join, so the profile reloads
-    # lazily here; the test author has no avatar, so no extra avatar SELECT.
-    assert len(ctx.captured_queries) == 70, len(ctx.captured_queries)
+    # 70 -> 71 (todo 257 slice C / M23): the single-post edit response has no
+    # batched forum_reacted_map (that's list-only), so PostSerializer.get_reacted
+    # falls back to ONE O(1) reacted lookup for this post — deliberate, so the
+    # response's `reacted` is correct and the replace-the-post client update
+    # (ThreadDetailPage.handleEditSubmit) can't clobber the user's reacted state.
+    assert len(ctx.captured_queries) == 71, len(ctx.captured_queries)

--- a/backend/packages/wagtail_forum/wagtail_forum/tests/api/test_post_list.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/tests/api/test_post_list.py
@@ -9,6 +9,7 @@ from wagtail_forum.models import (
     ForumIndex,
     ForumProfile,
     Post,
+    Reaction,
     Topic,
     TrustLevel,
 )
@@ -254,8 +255,10 @@ def test_post_list_affordances_add_no_per_post_queries():
     assert resp.status_code == 200
     assert len(resp.data["results"]) == 20
     # Q1 visibility prefetch, Q2 topic lookup, Q3 posts page (select_related
-    # author+topic). Same 3 as the anonymous pin — the predicate adds no query.
-    assert len(ctx.captured_queries) == 3
+    # author+topic — the affordance predicate adds no query), Q4 the batched M23
+    # reacted map (authed-only, one query for the page). 4, not the anonymous 3;
+    # still no has_perm here (the author owns every post → owner short-circuit).
+    assert len(ctx.captured_queries) == 4
 
 
 @pytest.mark.django_db
@@ -365,3 +368,74 @@ def test_post_list_author_without_profile_still_renders():
     assert results[0]["author"]["trust_level"] is None
     assert results[0]["author"]["display_name"] == "ghost"  # username fallback
     assert results[0]["author"]["avatar"] is None  # no profile → no avatar
+
+
+@pytest.mark.django_db
+def test_post_list_reacted_reflects_current_user():
+    # M23: `reacted` lists the reaction types the CURRENT user has active on each
+    # post — `[]` for anonymous, and it never leaks another user's reactions.
+    topic = _topic_with_posts(2)
+    posts = list(topic.posts.filter(live=True).order_by("id"))
+    me = User.objects.create_user(username="me")
+    other = User.objects.create_user(username="other")
+    Reaction.objects.create(post=posts[0], user=me, reaction_type="like")
+    Reaction.objects.create(post=posts[0], user=me, reaction_type="helpful")
+    Reaction.objects.create(post=posts[0], user=other, reaction_type="love")  # not mine
+    Reaction.objects.create(post=posts[1], user=other, reaction_type="like")  # not mine
+
+    client = APIClient()
+    client.force_authenticate(me)
+    resp = client.get(f"/forum/topics/{topic.id}/posts/")
+    assert resp.status_code == 200
+    rows = {r["id"]: r for r in resp.data["results"]}
+    assert sorted(rows[posts[0].id]["reacted"]) == ["helpful", "like"]  # mine only
+    assert rows[posts[1].id]["reacted"] == []  # only `other` reacted here
+
+    # Anonymous carries no personal reacted state.
+    anon = APIClient().get(f"/forum/topics/{topic.id}/posts/")
+    assert all(r["reacted"] == [] for r in anon.data["results"])
+
+
+@pytest.mark.django_db
+def test_post_list_reacted_is_batched_no_per_post_queries():
+    # M23 pin (the landmine): an authed user with reactions across MANY posts —
+    # the reacted map is ONE batched query, so the authed list pin stays flat
+    # under N. 20 posts proving a fixed count is the proof there is no per-post
+    # N+1 (a per-post reacted query would be 20+; a per-post has_perm would be 40+).
+    topic = _topic_with_posts(20)
+    me = User.objects.create_user(username="me")
+    for p in topic.posts.filter(live=True):
+        Reaction.objects.create(post=p, user=me, reaction_type="like")
+
+    client = APIClient()
+    client.force_authenticate(me)
+    with CaptureQueriesContext(connection) as ctx:
+        resp = client.get(f"/forum/topics/{topic.id}/posts/")
+    assert resp.status_code == 200
+    assert len(resp.data["results"]) == 20
+    # Pinned EXACTLY (docs/rules/testing.md): 3 base (visibility, topic, posts
+    # page) + 2 authed permission-cache queries (the first post's can_edit/delete
+    # has_perm populates the user perm-cache; the other 19 hit it) + 1 batched
+    # reacted map = 6. Anonymous never runs the last three (pins 3). FLAT under N;
+    # if this changes, explain the new count here.
+    assert len(ctx.captured_queries) == 6
+
+
+@pytest.mark.django_db
+def test_reacted_single_object_fallback_is_correct():
+    # A single-post response (edit/reply) carries NO batched forum_reacted_map, so
+    # get_reacted falls back to a per-object query. Prove the fallback returns the
+    # real reacted state (not []), so the replace-the-post client update
+    # (ThreadDetailPage.handleEditSubmit) can't clobber it (M23).
+    from rest_framework.test import APIRequestFactory
+    from wagtail_forum.api.serializers import PostSerializer
+
+    topic = _topic_with_posts(1)
+    post = topic.posts.filter(live=True).first()
+    me = User.objects.create_user(username="me")
+    Reaction.objects.create(post=post, user=me, reaction_type="love")
+
+    request = APIRequestFactory().get("/")
+    request.user = me
+    data = PostSerializer(post, context={"request": request}).data  # no reacted map
+    assert data["reacted"] == ["love"]

--- a/docs/rules/database.md
+++ b/docs/rules/database.md
@@ -75,3 +75,10 @@ Compact checklist auto-injected before edits. Long-form:
   `except Exception` swallow it into a fake success and then re-raise on the next
   ORM call (`refresh_from_db`). Keep the service layer framework-free: let the
   model's `DoesNotExist` propagate and translate it to `NotFound` at the view.
+- **A per-request-user field on a `many=True` serializer must batch its data into
+  serializer context in ONE query (like `build_forum_image_map`), and the field
+  method must guard the map read with `if map is not None:` — NEVER truthiness.**
+  An authed user with zero rows yields an empty `{}` (falsy but not `None`); a
+  truthiness check silently routes every row to the per-object fallback and
+  reintroduces the N+1. Pin an authed test where the user has NO rows. See
+  `docs/patterns/performance/query-optimization.md` Pattern 31.

--- a/todos/257-in_progress-p2-forum-identity-profiles.md
+++ b/todos/257-in_progress-p2-forum-identity-profiles.md
@@ -83,11 +83,15 @@ Path shorthand: `W` = `backend/packages/wagtail_forum/wagtail_forum`, `web` = `w
 - [x] Avatar settable via `/me/profile` and rendered on posts (slice A: IDOR-scoped
       `avatar_id` write + absolute-URL read; `<img>` on PostCard)
 - [ ] Clicking an author opens a public profile page (profile + recent activity)
-- [ ] Reacted state visible with `aria-pressed`; reaction counts visible
-      logged-out
-- [ ] Trust level renders as a styled badge
+- [x] Reacted state visible with `aria-pressed`; reaction counts visible
+      logged-out (slice C: M23 per-type `reacted` map on the post payload +
+      `aria-pressed`; L1 anon counts already shipped in Wave 1 #473, test-proven)
+- [x] Trust level renders as a styled badge (slice C: the styled trust pill from
+      wave 2 #474 satisfies the badge AC; L5's fuller gamification machinery is
+      explicitly DEFERRED per the finding's own "defer unless cheap" guidance)
 - [x] List query pins unchanged or new counts explained in-comment (slice A: pins
-      flat via select_related avatar JOINs; edit-delete 70 comment refreshed)
+      flat via select_related avatar JOINs; slice C: authed post-list 3→4/6 and
+      edit-delete 70→71 all explained in-comment with the batched-map rationale)
 
 ## Work Log
 
@@ -133,8 +137,37 @@ Path shorthand: `W` = `backend/packages/wagtail_forum/wagtail_forum`, `web` = `w
      not API author parsing (Wave 3 unstarted) — the string→object change breaks nothing.
 - Verify: backend 324+2 pass (`--create-db`), `spectacular` exit 0; web `type-check`
   clean, `vitest run` 656 pass. code-review-orchestrator: PASS, 0 findings.
-- Commits on branch: `2ed4b28` (impl) + review-response (last_post_author docs+tests).
-- NEXT: codify → PR → merge slice A; then slice C off fresh main, then slice B.
+- Commits on branch: `2ed4b28` (impl) + `f29076f` (review-response) + `9acc12e` (codify).
+- **MERGED**: PR #490 squashed to main as `e8d461d` (2026-07-24). Slice A ACs checked above.
+- NEXT: slice C (PostCard UX: M23/L1/L5/L14) off fresh main → then slice B (H7 profile
+  endpoint+page) → then archive todo 257. Slice C/B execution plan in scratchpad RESUME-257.md.
+
+### 2026-07-24 - Slice C COMPLETE (PostCard UX cluster: M23/L1/L5/L14)
+
+- Branch `forum-257c-postcard-ux` off fresh main (e8d461d).
+- **Reconciliation narrowed the scope**: L1 (anon reaction counts) + L14 reactions
+  `flex-wrap` shipped in Wave 1 #473 already (PostCard renders the row for anon when
+  `nonZeroReactions>0`; row has `flex-wrap`); the L5 trust-badge pill shipped in wave 2
+  #474. So net-new = **M23** + **L14 emoji `aria-hidden`**.
+- **M23 (reacted state)**: `PostSerializer.reacted` (list of the current user's active
+  reaction types, `[]` anon). Pin-safe: `PostListView.list()` builds a per-page batched
+  `forum_reacted_map` in ONE query (authed-only, like `build_forum_image_map`); the
+  serializer reads it → zero per-post queries. Single-post responses (edit/reply) have no
+  map → ONE O(1) fallback query, deliberately (keeps the edit response's `reacted` correct
+  so `handleEditSubmit`'s replace-the-post update can't clobber it — advisor-flagged).
+  Web: `Post.reacted`/`BackendPost.reacted`, `mapPostToPost` maps it, `handleReact` carries
+  the toggle's `reacted` (was dropped), PostCard buttons get `aria-pressed` + pressed styling.
+- **L14 emoji `aria-hidden`**: reaction emoji spans marked `aria-hidden` (the aria-label/count
+  conveys meaning).
+- **Query pins (the M23 landmine)**: authed post-list is FLAT under N — pinned at 4 (author
+  viewing own posts: 3 base + 1 batched reacted map; owner short-circuits has_perm) and 6
+  (non-author: +2 has_perm cache-fill, once); edit-delete 70→71 (single-post fallback). All
+  explained in-comment. Anonymous pins unchanged (reacted query is authed-only).
+- Verify: backend 329 forum tests pass (`--create-db`) + `spectacular` exit 0; web
+  `type-check` clean + `vitest run` 658 pass. New tests: reacted serialization (authed/anon/
+  no-leak), authed multi-post batched pin, single-object fallback value, PostCard aria-pressed
+  - emoji aria-hidden, ThreadDetailPage toggle flips pressed state, mapper reacted default.
+- NEXT: review (orchestrator + advisor) → fix → codify → PR → merge; then slice B (H7).
 
 ## Notes
 

--- a/web/src/components/forum/PostCard.test.tsx
+++ b/web/src/components/forum/PostCard.test.tsx
@@ -508,6 +508,9 @@ describe('PostCard', () => {
     expect(screen.getByText('2')).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /add reaction/i })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /react love/i })).not.toBeInTheDocument();
+    // The read-only count button is not a toggle → aria-pressed is omitted
+    // entirely (not "false"), so a screen reader doesn't announce it as pressable.
+    expect(screen.getByRole('button', { name: '2 like' })).not.toHaveAttribute('aria-pressed');
   });
 
   it('hides zero counts at rest and expands the picker on demand', () => {

--- a/web/src/components/forum/PostCard.test.tsx
+++ b/web/src/components/forum/PostCard.test.tsx
@@ -177,6 +177,32 @@ describe('PostCard', () => {
     expect(screen.getByText('1')).toBeInTheDocument();
   });
 
+  it('sets aria-pressed on reaction buttons the current user has reacted to (M23)', () => {
+    const post = createMockPost({
+      reaction_counts: { like: 3, love: 1 },
+      reacted: ['like'],
+    });
+
+    renderPostCard(post); // renderPostCard passes onReact (interactive buttons)
+
+    expect(screen.getByRole('button', { name: 'React like' })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    );
+    expect(screen.getByRole('button', { name: 'React love' })).toHaveAttribute(
+      'aria-pressed',
+      'false'
+    );
+  });
+
+  it('marks decorative reaction emoji as aria-hidden (L14)', () => {
+    const post = createMockPost({ reaction_counts: { like: 5 } });
+
+    renderPostCard(post);
+
+    expect(screen.getByText('👍')).toHaveAttribute('aria-hidden', 'true');
+  });
+
   it('shows all four reaction options in the picker when no reactions exist yet and onReact is provided', () => {
     const post = createMockPost({
       reaction_counts: {},

--- a/web/src/components/forum/PostCard.tsx
+++ b/web/src/components/forum/PostCard.tsx
@@ -205,20 +205,31 @@ function PostCard({ post, onEdit, onDelete, onReact, onReport }: PostCardProps) 
 
       {(onReact || nonZeroReactions.length > 0) && (
         <div className="flex flex-wrap items-center gap-2 pt-4 border-t border-line">
-          {nonZeroReactions.map((type) => (
-            <button
-              key={type}
-              type="button"
-              onClick={onReact ? () => onReact(post.id, type) : undefined}
-              disabled={!onReact}
-              className="inline-flex items-center gap-1 min-h-11 px-3 py-1 bg-surface-2 hover:bg-surface-3 rounded-full text-sm transition-colors disabled:cursor-default disabled:hover:bg-surface-2"
-              aria-label={onReact ? `React ${type}` : `${post.reaction_counts?.[type]} ${type}`}
-              title={onReact ? `React ${type}` : type}
-            >
-              <span>{getReactionEmoji(type)}</span>
-              <span className="font-medium">{post.reaction_counts?.[type]}</span>
-            </button>
-          ))}
+          {nonZeroReactions.map((type) => {
+            // Whether the CURRENT user has this reaction active (M23). Only
+            // meaningful on the interactive (authed) buttons; the anon display
+            // buttons omit aria-pressed (they aren't toggles).
+            const isReacted = !!post.reacted?.includes(type);
+            return (
+              <button
+                key={type}
+                type="button"
+                onClick={onReact ? () => onReact(post.id, type) : undefined}
+                disabled={!onReact}
+                aria-pressed={onReact ? isReacted : undefined}
+                className={`inline-flex items-center gap-1 min-h-11 px-3 py-1 rounded-full text-sm transition-colors disabled:cursor-default ${
+                  isReacted
+                    ? 'bg-primary/10 text-primary ring-1 ring-primary/40'
+                    : 'bg-surface-2 hover:bg-surface-3 disabled:hover:bg-surface-2'
+                }`}
+                aria-label={onReact ? `React ${type}` : `${post.reaction_counts?.[type]} ${type}`}
+                title={onReact ? `React ${type}` : type}
+              >
+                <span aria-hidden="true">{getReactionEmoji(type)}</span>
+                <span className="font-medium">{post.reaction_counts?.[type]}</span>
+              </button>
+            );
+          })}
           {onReact && !showReactionPicker && (
             <button
               type="button"
@@ -227,7 +238,7 @@ function PostCard({ post, onEdit, onDelete, onReact, onReport }: PostCardProps) 
               aria-label="Add reaction"
               title="Add reaction"
             >
-              +🙂
+              <span aria-hidden="true">+🙂</span>
             </button>
           )}
           {onReact &&
@@ -240,11 +251,12 @@ function PostCard({ post, onEdit, onDelete, onReact, onReport }: PostCardProps) 
                   onReact(post.id, type);
                   setShowReactionPicker(false);
                 }}
+                aria-pressed={false}
                 className="inline-flex items-center min-h-11 px-3 py-1 bg-surface-2 hover:bg-surface-3 rounded-full text-sm transition-colors"
                 aria-label={`React ${type}`}
                 title={`React ${type}`}
               >
-                {getReactionEmoji(type)}
+                <span aria-hidden="true">{getReactionEmoji(type)}</span>
               </button>
             ))}
         </div>

--- a/web/src/pages/forum/ThreadDetailPage.test.tsx
+++ b/web/src/pages/forum/ThreadDetailPage.test.tsx
@@ -585,6 +585,9 @@ describe('ThreadDetailPage', () => {
 
     await waitFor(() => expect(screen.getByLabelText('React like')).toHaveTextContent('1'));
     expect(forumService.toggleReaction).toHaveBeenCalledWith('5', 'like');
+    // M23: the toggle's `reacted: true` flips the button's pressed state (was
+    // previously dropped, so the button never showed as reacted).
+    expect(screen.getByLabelText('React like')).toHaveAttribute('aria-pressed', 'true');
   });
 
   it('reports a post and shows a confirmation', async () => {

--- a/web/src/pages/forum/ThreadDetailPage.test.tsx
+++ b/web/src/pages/forum/ThreadDetailPage.test.tsx
@@ -590,6 +590,30 @@ describe('ThreadDetailPage', () => {
     expect(screen.getByLabelText('React like')).toHaveAttribute('aria-pressed', 'true');
   });
 
+  it('un-reacting removes the type and flips aria-pressed back to false (M23)', async () => {
+    vi.spyOn(forumService, 'fetchThread').mockResolvedValue(createMockThread());
+    vi.spyOn(forumService, 'fetchPosts').mockResolvedValue({
+      // Starts reacted (pressed), count 2 (others reacted too).
+      items: [createMockPost({ id: '5', reaction_counts: { like: 2 }, reacted: ['like'] })],
+      meta: { count: 0, next: null, previous: null },
+    });
+    vi.spyOn(forumService, 'toggleReaction').mockResolvedValue({
+      reaction_counts: { like: 1 },
+      reacted: false, // the un-react branch of handleReact's ternary
+    });
+
+    renderThreadDetailPage();
+
+    const likeBtn = await screen.findByRole('button', { name: 'React like' });
+    expect(likeBtn).toHaveAttribute('aria-pressed', 'true');
+
+    await userEvent.click(likeBtn);
+
+    // Count drops to 1 (others still reacted) and the user's pressed state clears.
+    await waitFor(() => expect(screen.getByLabelText('React like')).toHaveTextContent('1'));
+    expect(screen.getByLabelText('React like')).toHaveAttribute('aria-pressed', 'false');
+  });
+
   it('reports a post and shows a confirmation', async () => {
     vi.spyOn(forumService, 'fetchThread').mockResolvedValue(createMockThread());
     vi.spyOn(forumService, 'fetchPosts').mockResolvedValue({

--- a/web/src/pages/forum/ThreadDetailPage.tsx
+++ b/web/src/pages/forum/ThreadDetailPage.tsx
@@ -263,8 +263,17 @@ export default function ThreadDetailPage() {
   const handleReact = useCallback(async (postId: string, reactionType: string) => {
     try {
       const result = await toggleReaction(postId, reactionType);
+      // Carry the toggle's `reacted` into the post's reacted set (M23) so the
+      // button's pressed state flips immediately — previously dropped.
       setPosts((prev) =>
-        prev.map((p) => (p.id === postId ? { ...p, reaction_counts: result.reaction_counts } : p))
+        prev.map((p) => {
+          if (p.id !== postId) return p;
+          const prevReacted = p.reacted ?? [];
+          const reacted = result.reacted
+            ? [...new Set([...prevReacted, reactionType])]
+            : prevReacted.filter((t) => t !== reactionType);
+          return { ...p, reaction_counts: result.reaction_counts, reacted };
+        })
       );
     } catch (err) {
       logger.error('Error toggling reaction', {

--- a/web/src/services/forumMappers.test.ts
+++ b/web/src/services/forumMappers.test.ts
@@ -223,6 +223,7 @@ describe('forumMappers (wagtail_forum contract)', () => {
         is_opening_post: true,
         status: 'live',
         reaction_counts: { like: 3 },
+        reacted: ['like'],
         can_edit: true,
         can_delete: false,
         can_report: true,
@@ -235,6 +236,7 @@ describe('forumMappers (wagtail_forum contract)', () => {
       is_first_post: true,
       is_active: true,
       reaction_counts: { like: 3 },
+      reacted: ['like'],
       can_edit: true,
       can_delete: false,
       can_report: true,
@@ -291,6 +293,7 @@ describe('forumMappers (wagtail_forum contract)', () => {
       '12'
     );
     expect(p.is_active).toBe(false);
+    expect(p.reacted).toEqual([]); // absent in payload → defaults to []
   });
 
   // -------------------------------------------------------------------------

--- a/web/src/services/forumMappers.ts
+++ b/web/src/services/forumMappers.ts
@@ -73,6 +73,7 @@ export interface BackendPost {
   is_opening_post: boolean;
   status: 'live' | 'pending';
   reaction_counts: Record<string, number>;
+  reacted?: string[];
   can_edit: boolean;
   can_delete: boolean;
   can_report: boolean;
@@ -198,6 +199,7 @@ export function mapPostToPost(p: BackendPost, threadId: string): Post {
     is_first_post: p.is_opening_post,
     is_active: p.status === 'live',
     reaction_counts: p.reaction_counts ?? {},
+    reacted: p.reacted ?? [],
     can_edit: p.can_edit,
     can_delete: p.can_delete,
     can_report: p.can_report,

--- a/web/src/types/forum.ts
+++ b/web/src/types/forum.ts
@@ -90,6 +90,9 @@ export interface Post {
   is_first_post?: boolean;
   is_active?: boolean;
   reaction_counts?: Record<string, number>;
+  /** Reaction types the current user has active on this post (M23); [] when
+   * logged out. Drives the reaction buttons' aria-pressed / pressed styling. */
+  reacted?: string[];
   /** Permission flags from the backend (wagtail_forum PostSerializer). */
   can_edit?: boolean;
   can_delete?: boolean;


### PR DESCRIPTION
## Summary

Slice C of todo 257 — the **PostCard UX cluster**. Net-new: **M23** (reaction "reacted" state was discarded end-to-end) and **L14** emoji `aria-hidden`.

The API returned `ReactionToggleResult.reacted` but the web dropped it, the `Post` type couldn't hold it, and reaction buttons had no pressed state. Now the current user's active reactions flow all the way to `aria-pressed` + pressed styling.

## What changed

**Backend**
- `PostSerializer.reacted` — the list of reaction types the current user has active on a post (`[]` anon).
- **Pin-safe**: `PostListView.list()` batches the whole page's reactions into one `forum_reacted_map` (authed-only, mirrors `build_forum_image_map`), so the serializer costs zero per-post queries. Single-post responses (edit/reply) fall back to one O(1) query — deliberately, so the edit response's `reacted` is correct and `handleEditSubmit`'s replace-the-post update can't clobber it.

**Web**
- `Post.reacted` + mapper; `handleReact` now carries the toggle's `reacted` (was dropped); `PostCard` buttons render `aria-pressed` (interactive only) + pressed styling; decorative reaction emoji `aria-hidden`.

## Scope reconciliation (verified against `main`, not re-implemented)
- **L1** (anon reaction counts) and **L14 flex-wrap** already shipped in Wave 1 (#473); the **L5** trust-badge pill in #474. This slice adds tests proving them and **defers L5's fuller gamification machinery** per the finding's own "defer unless cheap" guidance.

## Query pins (the M23 landmine)
Authed post-list is **flat under N** — pinned exactly at **4** (author viewing own posts: 3 base + 1 batched map; owner short-circuits `has_perm`) and **6** (non-author: +2 `has_perm` cache-fill, once); edit-delete **70→71** (single-post fallback). Anonymous unchanged (reacted query is authed-only). The `if map is not None` guard (not truthiness) is what keeps a zero-reaction authed user from silently falling back to N+1 — pinned by the affordance test.

## Review
`code-review-orchestrator` → 3 domain reviewers (django-drf, react-ts, cross-cutting). **No blockers**; all findings LOW/INFO and addressed: schema `items` enum, toggle-vs-post `reacted` shape disambiguation, un-react branch test (was mutation-uncovered), anon `aria-pressed`-omitted assertion, future-bulk-caller N+1 warning. Cross-cutting mutation-tested the batching (kills to 26 queries if broken) and the no-cross-user-leak test.

## Verification
- Backend: **329 forum tests pass** (`--create-db`); `spectacular` exit 0.
- Web: `type-check` clean; `vitest run` **659 pass**.

Codified: `query-optimization.md` Pattern 31 (per-user batched context-map N+1 landmine) + `rules/database.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)