### PR TITLE
chore: archive todo 257 (forum identity & profiles epic)

### DIFF
--- a/docs/audits/2026-07-11-forum-modernization.md
+++ b/docs/audits/2026-07-11-forum-modernization.md
@@ -294,7 +294,7 @@ Deferred findings converted to todos (Review Doc Tracking convention — the
 - [x] #H3 subscriptions-watching → todo 253 (completed 2026-07-22)
 - [x] #H4 mentions → todo 253 (completed 2026-07-22)
 - [ ] #H6 solved-accepted-answer → todo 273 (re-pointed 2026-07-23; roadmap moved solved answers to Wave 2 / not 256)
-- [ ] #H7 public-user-identity → todo 257
+- [x] #H7 public-user-identity → todo 257 (completed 2026-07-24, PR #492)
 - [x] #H8 search-discoverability-filters → todo 256 (completed 2026-07-23)
 - [x] #H9 seo-surface → todo 256 (completed 2026-07-23)
 - [x] #H10 unread-indicators → todo 253 (completed 2026-07-22)
@@ -306,7 +306,7 @@ Deferred findings converted to todos (Review Doc Tracking convention — the
 - [x] #H16 admin-moderation-queue → todo 254 (completed 2026-07-13)
 - [ ] #H18 error-retry-affordance → todo 259
 - [ ] #H21 tombstone-prune-scheduling → todo 261
-- [ ] #H26 author-shape-inconsistency → todo 257
+- [x] #H26 author-shape-inconsistency → todo 257 (completed 2026-07-24, PR #490)
 - [ ] #M1 quote-reply → todo 276 (re-pointed 2026-07-23; split out of 256)
 - [ ] #M2 bookmarks → todo 263
 - [ ] #M3 drafts-autosave → todo 263
@@ -327,7 +327,7 @@ Deferred findings converted to todos (Review Doc Tracking convention — the
 - [x] #M19 per-board-moderation → todo 254 (completed 2026-07-13)
 - [x] #M20 admin-polish-cluster → todo 254 (completed 2026-07-13)
 - [ ] #M22 fetch-race-guards → todo 259
-- [ ] #M23 reacted-state → todo 257
+- [x] #M23 reacted-state → todo 257 (completed 2026-07-24, PR #491)
 - [ ] #M24 native-dialogs → todo 259
 - [ ] #M25 reply-focus-drop → todo 259
 - [ ] #M26 live-region-announcements → todo 259
@@ -343,12 +343,12 @@ Deferred findings converted to todos (Review Doc Tracking convention — the
 - [ ] #M38 meprofile-schema → todo 258
 - [ ] #M39 error-envelope-ownership → todo 258
 - [ ] #M40 envelope-shapes → todo 258
-- [ ] #M41 deleted-author-convention → todo 257
+- [x] #M41 deleted-author-convention → todo 257 (completed 2026-07-24, PR #490)
 - [ ] #M42 http-caching → todo 261
-- [ ] #L1 anon-reaction-counts → todo 257
+- [x] #L1 anon-reaction-counts → todo 257 (completed 2026-07-24, PR #491; shipped Wave 1 #473, test-proven)
 - [ ] #L2 onboarding-empty-states → todo 259
 - [ ] #L4 markdown-board-picker → todo 259
-- [ ] #L5 badges-gamification → todo 257
+- [x] #L5 badges-gamification → todo 257 (completed 2026-07-24, PR #491; styled trust badge satisfies; fuller gamification deferred per the finding's own guidance)
 - [x] #L6 blog-md-doc-drift → todo 255 (completed 2026-07-20, slice 1)
 - [x] #L7 openai-key-ops-check → todo 255 (completed 2026-07-20, slice 1)
 - [ ] #L8 autocomplete-typeahead → todo 276 (re-pointed 2026-07-23; split out of 256)
@@ -356,7 +356,7 @@ Deferred findings converted to todos (Review Doc Tracking convention — the
 - [ ] #L11 button-busy-state → todo 259
 - [ ] #L12 timestamp-accessibility → todo 259
 - [ ] #L13 tautological-composer-tests → todo 259
-- [ ] #L14 identity-polish → todo 257 (trust_level render done in todo 273 / wave 2 slice 1; emoji aria-hidden + reactions flex-wrap remain)
+- [x] #L14 identity-polish → todo 257 (completed 2026-07-24, PR #491; trust_level render #474, emoji aria-hidden #491, reactions flex-wrap shipped Wave 1 #473)
 - [ ] #L16 reaction-types-duplication → todo 258
 - [ ] #L17 migrations-check-ci → todo 261
 - [ ] #L18 write-path-query-profiling → todo 258

--- a/todos/archive/257-completed-p2-forum-identity-profiles.md
+++ b/todos/archive/257-completed-p2-forum-identity-profiles.md
@@ -1,5 +1,5 @@
 ---
-status: in_progress
+status: completed
 priority: p2
 issue_id: "257"
 tags: [forum, profiles, product-ux, api]
@@ -82,7 +82,9 @@ Path shorthand: `W` = `backend/packages/wagtail_forum/wagtail_forum`, `web` = `w
       `[deleted]` sentinel OBJECT; `mapAuthor` cast-free)
 - [x] Avatar settable via `/me/profile` and rendered on posts (slice A: IDOR-scoped
       `avatar_id` write + absolute-URL read; `<img>` on PostCard)
-- [ ] Clicking an author opens a public profile page (profile + recent activity)
+- [x] Clicking an author opens a public profile page (profile + recent activity)
+      (slice B: `GET /forum/users/{username}/` read-only endpoint + `UserProfilePage`;
+      author name links on PostCard + thread header)
 - [x] Reacted state visible with `aria-pressed`; reaction counts visible
       logged-out (slice C: M23 per-type `reacted` map on the post payload +
       `aria-pressed`; L1 anon counts already shipped in Wave 1 #473, test-proven)
@@ -168,6 +170,28 @@ Path shorthand: `W` = `backend/packages/wagtail_forum/wagtail_forum`, `web` = `w
   no-leak), authed multi-post batched pin, single-object fallback value, PostCard aria-pressed
   - emoji aria-hidden, ThreadDetailPage toggle flips pressed state, mapper reacted default.
 - NEXT: review (orchestrator + advisor) → fix → codify → PR → merge; then slice B (H7).
+
+### 2026-07-24 - Slice B COMPLETE + EPIC CLOSED (H7 public profiles) — PR #492 (64d7d30)
+
+- Backend: `GET /forum/users/<username>/` (`PublicProfileView`, AllowAny, read-only) —
+  identity via `serialize_forum_author` + bio/signature/post_count/joined_at + 10 most
+  recent live topics/replies as lightweight dicts (NOT the heavy serializers). Never
+  leaks fcm_token/flags_received; getattr-not-`for_user()`; 404 missing/inactive vs
+  defaults for profileless; visibility-filtered; query pin=4 flat. Route mounted in BOTH
+  the package urls AND `apps/forum_host/api_urls.py` (route-parity CI catch — the host
+  mount was missed first pass; fixed + codified).
+- Web: `UserProfilePage` (`/forum/users/:username`); author name links on PostCard +
+  thread header (ThreadCard left plain — the whole card is already a `<Link>`, nested
+  `<a>` is invalid); shared `utils/forumAuthor` constants; stale-flash fix.
+- Review: 3 reviewers + advisor, all findings folded (route-collision was a false
+  positive — board URLs are ID-prefixed; restricted-board test added). Verified: backend
+  full forum suite (incl. apps/forum_host) + spectacular exit 0; web tsc + vitest green.
+- Codified: `react-typescript.md` (nested-anchor + RR score-based matching), `rules/react.md`,
+  `rules/forum.md` (host-route parity), `forum.md` (public read-only profile pattern).
+
+**EPIC 257 DONE — all 3 slices merged (A #490, C #491, B #492); all 7 findings resolved
+(H7, H26, M23, M41, L1, L5, L14). L5 = trust badge satisfied; fuller gamification deferred
+per the finding's own guidance.**
 
 ## Notes
 


### PR DESCRIPTION
Archives todo 257 — all three slices merged (A #490, C #491, B #492). Marks the H7 AC done, adds the epic-closeout work log, moves the todo to `todos/archive/`, and checks off all 7 findings (H7, H26, M23, M41, L1, L5, L14) in the 2026-07-11 forum-modernization manifest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)