### PR TITLE
forum: web type cleanup + reaction single-source (todo 258 PR2)

### DIFF
--- a/backend/apps/forum_host/tests/test_reaction_contract.py
+++ b/backend/apps/forum_host/tests/test_reaction_contract.py
@@ -1,0 +1,32 @@
+"""L16 (todo 258): the web `REACTION_TYPES` literal must stay in sync with the
+backend `Reaction.REACTION_CHOICES`. There is no OpenAPI->TS codegen in this
+repo, so this is the cross-boundary DRIFT GUARD (not true single-sourcing): it
+reads the committed web literal and fails CI if the two lists diverge, so neither
+side can change the reaction set without the other.
+"""
+
+import re
+from pathlib import Path
+
+from django.conf import settings
+from wagtail_forum.models import Reaction
+
+# settings.BASE_DIR is the backend/ dir; its parent is the repo root.
+WEB_REACTION_LITERAL = (
+    Path(settings.BASE_DIR).parent / "web" / "src" / "utils" / "forumReactions.ts"
+)
+
+
+def test_web_reaction_types_match_backend_choices():
+    assert (
+        WEB_REACTION_LITERAL.exists()
+    ), f"web reaction literal not found at {WEB_REACTION_LITERAL} (moved/renamed?)"
+    source = WEB_REACTION_LITERAL.read_text()
+    match = re.search(r"REACTION_TYPES\s*=\s*\[([^\]]*)\]", source)
+    assert match, "could not find `REACTION_TYPES = [...]` in the web literal"
+    web_types = re.findall(r"'([^']+)'", match.group(1))
+    backend_types = [choice[0] for choice in Reaction.REACTION_CHOICES]
+    assert web_types == backend_types, (
+        f"web REACTION_TYPES {web_types} != backend REACTION_CHOICES "
+        f"{backend_types} — update both (audit L16)."
+    )

--- a/docs/audits/2026-07-11-forum-modernization.md
+++ b/docs/audits/2026-07-11-forum-modernization.md
@@ -332,17 +332,17 @@ Deferred findings converted to todos (Review Doc Tracking convention — the
 - [ ] #M25 reply-focus-drop → todo 259
 - [ ] #M26 live-region-announcements → todo 259
 - [ ] #M27 unsaved-edit-discard → todo 259
-- [ ] #M28 author-type-casts → todo 258
+- [x] #M28 author-type-casts → todo 258 (completed 2026-07-24, PR2; casts already removed by 257, dead types deleted here)
 - [ ] #M29 upload-precheck → todo 259
 - [ ] #M30 thread-pagination-ux → todo 259
 - [ ] #M31 scroll-to-top → todo 259
 - [ ] #M34 write-path-e2e → todo 261
-- [ ] #M35 patch-idempotency → todo 258
-- [ ] #M36 image-upload-idempotency → todo 258
-- [ ] #M37 openapi-response-codes → todo 258
-- [ ] #M38 meprofile-schema → todo 258
-- [ ] #M39 error-envelope-ownership → todo 258
-- [ ] #M40 envelope-shapes → todo 258
+- [x] #M35 patch-idempotency → todo 258 (completed 2026-07-24, PR #494)
+- [x] #M36 image-upload-idempotency → todo 258 (completed 2026-07-24, PR #494)
+- [x] #M37 openapi-response-codes → todo 258 (completed 2026-07-24, PR #494)
+- [x] #M38 meprofile-schema → todo 258 (completed 2026-07-24, PR #494)
+- [x] #M39 error-envelope-ownership → todo 258 (completed 2026-07-24, PR #494)
+- [ ] #M40 envelope-shapes → todo 277 (re-pointed 2026-07-24; out of 258 acceptance gate — breaking, needs web coordination; partly stale)
 - [x] #M41 deleted-author-convention → todo 257 (completed 2026-07-24, PR #490)
 - [ ] #M42 http-caching → todo 261
 - [x] #L1 anon-reaction-counts → todo 257 (completed 2026-07-24, PR #491; shipped Wave 1 #473, test-proven)
@@ -357,11 +357,11 @@ Deferred findings converted to todos (Review Doc Tracking convention — the
 - [ ] #L12 timestamp-accessibility → todo 259
 - [ ] #L13 tautological-composer-tests → todo 259
 - [x] #L14 identity-polish → todo 257 (completed 2026-07-24, PR #491; trust_level render #474, emoji aria-hidden #491, reactions flex-wrap shipped Wave 1 #473)
-- [ ] #L16 reaction-types-duplication → todo 258
+- [x] #L16 reaction-types-duplication → todo 258 (completed 2026-07-24, PR2; shared web literal + backend drift-guard)
 - [ ] #L17 migrations-check-ci → todo 261
-- [ ] #L18 write-path-query-profiling → todo 258
-- [ ] #L19 location-header-201 → todo 258
-- [ ] #L20 versioning-comment → todo 258
+- [x] #L18 write-path-query-profiling → todo 258 (completed 2026-07-24, PR #494; PATCH 71 / DELETE 33, cascade not elidable)
+- [x] #L19 location-header-201 → todo 258 (completed 2026-07-24, PR #494)
+- [ ] #L20 versioning-comment → todo 277 (re-pointed 2026-07-24; out of 258 acceptance gate)
 - [x] #L21 image-reuse-privacy-decision → todo 254 (completed 2026-07-13)
 
 ## Phase 6 code review (2026-07-11)

--- a/todos/277-pending-p3-forum-envelope-versioning.md
+++ b/todos/277-pending-p3-forum-envelope-versioning.md
@@ -1,0 +1,61 @@
+---
+status: pending
+priority: p3
+issue_id: "277"
+tags: [forum, api, drf, openapi]
+dependencies: []
+source_review: "docs/audits/2026-07-11-forum-modernization.md"
+source_finding: "M40, L20"
+---
+
+# Forum: list-envelope normalization + versioning-rationale comment
+
+## Problem
+
+Split out of todo 258 (forum-api-contract-hardening) on 2026-07-24 — both findings
+are in 258's Recommended Action but were **not** 258 acceptance criteria, and both
+are breaking / broad enough to warrant their own change window.
+
+## Findings
+
+Path shorthand: `W` = `backend/packages/wagtail_forum/wagtail_forum`.
+
+- **M40** — The forum API ships four list-envelope shapes: cursor
+  `{results,next,previous}` (topic/post/notification lists), flat `{results}`
+  (`BoardListView`), search `{topics,posts,topics_has_more,posts_has_more,page}`
+  (`SearchView`), and the sync custom shape (`SyncView`). **Partly stale as of
+  2026-07-24**: PR #473 already added `reply_count`/`view_count`/`last_post_at`
+  to the search *topic* item, so of the four originally-named dropped fields only
+  `is_pinned` is still missing there. The genuinely-divergent remainder is the
+  **search post item** — an entirely separate lightweight shape vs `PostSerializer`
+  (`W/api/views.py` search builders + `W/api/serializers.py`). Normalizing is a
+  BREAKING response change — coordinate the web mappers
+  (`web/src/services/forumMappers.ts`) and document.
+- **L20** — `versioning_class = None` appears on **17** views across
+  `W/api/{views,notifications,subscriptions,user_search}.py`, with the opt-out
+  rationale commented on exactly one (`BoardListView`). Factor the rationale to a
+  shared base/mixin (or a single referenced comment) so it is stated once.
+
+## Recommended Action
+
+1. **M40**: decide the target — converge search/sync onto the cursor envelope
+   where feasible, and enrich the search *post* item to the `PostSerializer` field
+   set (or explicitly document the lightweight search shape as intentional).
+   Breaking: update `web/src/services/forumMappers.ts` + a full-suite grep for the
+   old keys, and document the contract. `versioning_class = None` today, so a
+   documented break is cheap pre-deploy.
+2. **L20**: introduce a shared `versioning_class = None` base/mixin carrying the
+   rationale comment once; refactor the 17 views to inherit it (mechanical).
+
+## Acceptance Criteria
+
+- [ ] Either a single documented list-envelope contract (search/sync converged
+      onto cursor) OR the divergence explicitly documented as intentional; web
+      mappers updated + full web/backend suites green
+- [ ] The versioning-opt-out rationale is stated once (shared base/mixin), not
+      duplicated or absent across the 17 views
+
+## Notes
+
+p3. Deferred from 258 — see
+`todos/archive/258-completed-p2-forum-api-contract-hardening.md`.

--- a/todos/archive/258-completed-p2-forum-api-contract-hardening.md
+++ b/todos/archive/258-completed-p2-forum-api-contract-hardening.md
@@ -1,5 +1,5 @@
 ---
-status: pending
+status: completed
 priority: p2
 issue_id: "258"
 tags: [forum, api, drf, openapi]
@@ -102,7 +102,7 @@ Path shorthand: `W` = `backend/packages/wagtail_forum/wagtail_forum`, `H` = `bac
       single shape — PR1
 - [x] `manage.py spectacular` clean with complete response codes on the named
       endpoints; 201s carry `Location` — PR1
-- [ ] No `as unknown as` casts in forum mappers; no dead exported forum types;
+- [x] No `as unknown as` casts in forum mappers; no dead exported forum types;
       reaction types single-sourced — PR2 (web)
 - [x] L18 profiling results recorded in this todo's work log — PR1
 
@@ -208,6 +208,38 @@ cross-cutting-reviewer (all three, staged diff). Findings (0 critical/high):
 
 Re-verified: `pytest apps/forum_host packages/wagtail_forum` → **507 passed**;
 flake8 clean; `spectacular` exit 0.
+
+### 2026-07-24 - PR2 web (M28 + L16) + review + archival
+
+Branch `fix/forum-258-web-types` off fresh main (after PR1 #494 merged).
+
+- **M28** — the `as unknown as ForumAuthor` casts were already gone (todo 257);
+  deleted the 8 dead exported types from `web/src/types/forum.ts`
+  (CreateThreadData, CreatePostData, FetchThreadsOptions, FetchPostsOptions,
+  CreateThreadInput, CreatePostInput, AddReactionInput, the legacy `Reaction`
+  interface), removed the orphaned `import type { User }`, and pruned the
+  `types/index.ts` re-exports.
+- **L16** — extracted `REACTION_TYPES` from `PostCard.tsx` into a shared
+  `web/src/utils/forumReactions.ts` (single-sourced on the web side); added a
+  **cross-boundary drift guard** `apps/forum_host/tests/test_reaction_contract.py`
+  that reads the web literal and fails CI if it diverges from
+  `Reaction.REACTION_CHOICES`. Honest framing: this is a drift GUARD, not codegen
+  single-sourcing (no OpenAPI→TS pipeline exists).
+
+Review: `react-typescript-reviewer` — 1 LOW (the new `ReactionType` export was
+itself unused); repaired by dropping it (kept only the `REACTION_TYPES` value).
+
+Verification: web `tsc --noEmit` clean; `eslint` clean; `vitest run` → **663
+passed**; backend `test_reaction_contract.py` PASSED; flake8 clean.
+
+### 2026-07-24 - Completed by completing-todos skill (run 2026-07-24-1946)
+
+- Verification: all 6 acceptance criteria passed (PR1 #494 + PR2).
+- Review: 2 PRs reviewed (backend orchestrator 3-reviewer pass + web
+  react-typescript-reviewer); all blocking-severity findings addressed via repair;
+  0 critical/high across both.
+- Deferred M40 + L20 (not acceptance criteria) → todo 277; re-pointed in the
+  audit Finding Status.
 
 ## Notes
 

--- a/web/src/components/forum/PostCard.tsx
+++ b/web/src/components/forum/PostCard.tsx
@@ -4,6 +4,7 @@ import { formatDistanceToNow } from 'date-fns';
 import StreamFieldRenderer from '../StreamFieldRenderer';
 import { userProfilePath } from '../../utils/forumUrls';
 import { DELETED_AUTHOR_USERNAME, TRUST_LEVEL_LABELS } from '../../utils/forumAuthor';
+import { REACTION_TYPES } from '../../utils/forumReactions';
 import type { Post } from '@/types';
 
 interface PostCardProps {
@@ -13,9 +14,6 @@ interface PostCardProps {
   onReact?: (postId: string, reactionType: string) => void;
   onReport?: (postId: string, reason: string) => Promise<void>;
 }
-
-// The four reaction types the backend supports.
-const REACTION_TYPES = ['like', 'love', 'helpful', 'thanks'] as const;
 
 // Mirrors wagtail_forum Report.REASON_CHOICES.
 const REPORT_REASONS = [

--- a/web/src/types/forum.ts
+++ b/web/src/types/forum.ts
@@ -2,7 +2,6 @@
  * Forum Entity Types
  */
 
-import type { User } from './auth';
 import type { StreamFieldBlock as BlogStreamFieldBlock } from './blog';
 
 /**
@@ -100,24 +99,6 @@ export interface Post {
 }
 
 /**
- * Thread creation data
- */
-export interface CreateThreadData {
-  title: string;
-  category: string;
-  content: string;
-}
-
-/**
- * Post creation data
- */
-export interface CreatePostData {
-  thread: string;
-  content: string;
-  attachments?: File[];
-}
-
-/**
  * Paginated list response
  */
 export interface PaginatedResponse<T> {
@@ -127,47 +108,6 @@ export interface PaginatedResponse<T> {
     next?: string | null;
     previous?: string | null;
   };
-}
-
-/**
- * Fetch threads options
- */
-export interface FetchThreadsOptions {
-  page?: number;
-  limit?: number;
-  category?: string;
-  search?: string;
-  ordering?: string;
-}
-
-/**
- * Fetch posts options
- */
-export interface FetchPostsOptions {
-  thread: string;
-  page?: number;
-  limit?: number;
-  ordering?: string;
-}
-
-/**
- * Create thread data
- */
-export interface CreateThreadInput {
-  title: string;
-  category: string;
-  excerpt: string;
-  first_post_content: string;
-  first_post_format?: 'plain' | 'draftail' | 'html';
-}
-
-/**
- * Create post input
- */
-export interface CreatePostInput {
-  thread: string;
-  content_raw: string;
-  content_format?: 'plain' | 'draftail' | 'html';
 }
 
 /**
@@ -207,25 +147,6 @@ export interface CreateReplyResult {
 export interface EditPostResult {
   post: Post;
   status: 'published' | 'pending';
-}
-
-/**
- * Add reaction input
- */
-export interface AddReactionInput {
-  post: string;
-  reaction_type: 'like' | 'love' | 'helpful' | 'thanks';
-}
-
-/**
- * Reaction
- */
-export interface Reaction {
-  id: string;
-  post: string;
-  user: User;
-  reaction_type: string;
-  created_at: string;
 }
 
 /**

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -12,14 +12,7 @@ export type { ApiResponse, WagtailApiResponse, DRFPaginatedResponse, ApiError } 
 export type { User, LoginCredentials, SignupData, AuthResponse } from './auth';
 
 // Forum types
-export type {
-  Category,
-  Thread,
-  Post,
-  CreateThreadData,
-  CreatePostData,
-  SearchForumResponse,
-} from './forum';
+export type { Category, Thread, Post, SearchForumResponse } from './forum';
 
 // Blog types
 export type {

--- a/web/src/utils/forumReactions.ts
+++ b/web/src/utils/forumReactions.ts
@@ -1,0 +1,11 @@
+/**
+ * The forum reaction types, single-sourced for the web client.
+ *
+ * MUST stay in sync with the backend's `Reaction.REACTION_CHOICES`
+ * (`backend/packages/wagtail_forum/wagtail_forum/models/reactions.py`), which is
+ * also the enum exposed in the OpenAPI schema. There is no OpenAPI→TS codegen in
+ * this app, so a backend drift-guard test
+ * (`backend/apps/forum_host/tests/test_reaction_contract.py`) reads THIS literal
+ * and fails CI if the two lists diverge (audit L16).
+ */
+export const REACTION_TYPES = ['like', 'love', 'helpful', 'thanks'] as const;


### PR DESCRIPTION
Second of two PRs for todo 258; completes the epic. (PR 1 = #494, backend.)

## What changed
- **M28** — deletes 8 genuinely-unused exported types from `web/src/types/forum.ts` (CreateThreadData, CreatePostData, FetchThreadsOptions, FetchPostsOptions, CreateThreadInput, CreatePostInput, AddReactionInput, the legacy `Reaction` interface), removes the orphaned `import type { User }`, and prunes the barrel re-exports. (The `as unknown as ForumAuthor` casts M28 also named were already removed by todo 257.)
- **L16** — extracts `REACTION_TYPES` from PostCard.tsx into a shared `web/src/utils/forumReactions.ts` (single-sourced on the web side); a backend drift guard (`apps/forum_host/tests/test_reaction_contract.py`) reads that literal and fails CI if it diverges from `Reaction.REACTION_CHOICES`. Honest framing: a drift guard, not codegen single-sourcing (no OpenAPI→TS pipeline exists).

## Bookkeeping
Completes todo 258 (all 6 acceptance criteria) — archived, audit findings checked off (M28/M35–M39/L16/L18/L19). M40 + L20 (not acceptance criteria; breaking / broad) re-pointed to new **todo 277**.

## Verification
web `tsc --noEmit` + `eslint` clean; `vitest run` → 663 passed; backend drift-check PASSED; flake8 clean. Reviewed by react-typescript-reviewer (1 LOW, repaired).

🤖 Generated with [Claude Code](https://claude.com/claude-code)