### PR TITLE
docs: codify todo 258 findings (idempotency replay + package reverse gotchas)

### DIFF
--- a/backend/docs/patterns/domain/forum.md
+++ b/backend/docs/patterns/domain/forum.md
@@ -198,3 +198,45 @@ wall-clock timeout (`SPAM_LLM_TIMEOUT_SECONDS`, a `ThreadPoolExecutor` +
 Definitive `CLEAN`/`SPAM` verdicts are cached in Redis by
 `sha256(text)` + prompt version; transient failures are never cached. All
 tunables live in `apps/forum_host/constants.py` (`SPAM_LLM_*`).
+
+## Idempotency contract on new write surfaces (todo 258)
+
+The reusable idempotency helpers (`api/idempotency.py` — `idempotency_cache_key`,
+`fingerprint`, `reserve`, `remember`, `_replay_or_none`) apply to any unsafe write
+in the same 6 steps: extract key → fingerprint → replay-or-none (409 in-flight /
+422 payload-mismatch) → validate → `reserve()` right before the mutation →
+`remember()` after. The package README's "Idempotency" section is authoritative;
+three non-obvious points learned wiring PATCH + image upload:
+
+- **Multipart uploads fingerprint on a CONTENT hash, not the request body.**
+  `request.data` holds the `UploadedFile`, not JSON, so name+size can collide.
+  `fingerprint({"name": …, "sha256": hashlib.sha256(file.read()).hexdigest()})`,
+  with `file.seek(0)` BEFORE hashing (validation may have consumed the stream) AND
+  after (so `.create()` stores the full file).
+- **A replay must be response-faithful, not just body-faithful.** A 201 with a
+  `Location` header must replay WITH that header — `remember(..., headers={…})`
+  persists it and `_replay_or_none` re-applies it. See `docs/rules/api.md` +
+  `docs/LEARNINGS.md` 2026-07-24.
+- **`Location` reverse is namespace-agnostic** (`_created_location`): resolve
+  within `request.resolver_match.namespace`, never a hardcoded `app_name` — the
+  package mounts under a bare root OR a nested host namespace.
+
+## Reference error-envelope handler ships in the package (audit M39)
+
+`api/exception_handler.py::forum_exception_handler` produces the consistent
+envelope (`{error, message, code, status_code, errors?}`) so a host that mounts
+the package gets it by default instead of bare DRF `{"detail": …}`. The package
+cannot import host code, so it DUPLICATES the host's envelope logic
+(`apps/core/exceptions.py`) rather than sharing it — the two are byte-compatible
+and interchangeable. Package tests run under the host settings, so the enveloped
+shape can be pinned directly (`tests/api/test_error_envelope.py` +
+`test_topic_create.py::test_oversized_body_is_rejected`).
+
+## Cross-boundary drift guard when there is no codegen (audit L16)
+
+There is no OpenAPI→TS codegen, so a shared literal that must match on both sides
+(the web `REACTION_TYPES` vs backend `Reaction.REACTION_CHOICES`) is single-sourced
+per-side and guarded by a **backend test that reads the committed web file** and
+asserts equality (`apps/forum_host/tests/test_reaction_contract.py`). Honest
+framing: a drift GUARD (fails CI if either side changes alone), not true
+single-sourcing.

--- a/docs/LEARNINGS.md
+++ b/docs/LEARNINGS.md
@@ -1669,3 +1669,33 @@ reserved for the `author` field where the distinction is unambiguous. Lesson: a
 "consistent representation everywhere" AC can collide with a "pins unchanged" AC
 when a field is denormalized — pick the pin, and document the field that can't
 carry the finer distinction rather than adding a query to force it.
+
+## 2026-07-24 — Idempotency-replay + package-`reverse()` gotchas (todo 258, API)
+
+Two bugs surfaced during forum API contract hardening (todo 258), both caught by
+review/testing before merge:
+
+1. **An idempotent replay dropped the `Location` header.** Adding a `Location`
+   header to the 201 create responses (L19) worked for the FIRST request, but a
+   same-key retry returned a 201 with NO `Location`: `_replay_or_none` rebuilt the
+   response from the cached `{data, status, fingerprint}` only — headers were never
+   persisted, so the replay was not byte-identical to the original (which the IETF
+   idempotency-key draft requires). Root cause: `remember()` cached body + status
+   but not headers. Fix: `remember()` now stores an optional `headers` dict and the
+   replay helper re-applies it. Lesson: when you add a response header to an
+   idempotent endpoint, the idempotency cache must carry it too, or replays
+   silently differ from the original response.
+
+2. **A hardcoded URL namespace in `reverse()` 500'd under the host mount.** The
+   Location header used `reverse("wagtail_forum_api:topic-detail", …)`. It passed
+   under the package's flat test urlconf but raised `NoReverseMatch` under the real
+   project mount: the host re-declares the routes nested under `v1:wagtail_forum_api`,
+   and mounting the urlconf as a bare root has NO namespace at all (`app_name`
+   creates a namespace only when the module is `include()`d, not when it is the
+   ROOT_URLCONF). The forum-host throttle suite caught it (500 instead of 201 on
+   topic-create) — the package's own tests were green because they run under the
+   flat urlconf. Fix: a `_created_location` helper resolves the route within
+   `request.resolver_match.namespace` (falling back to no-namespace for a root
+   mount). Lesson: a package that can be mounted under arbitrary namespaces must
+   derive the namespace from the live request, never hardcode it — and a
+   package-only test suite will not catch it; run the host-mounted suite too.

--- a/docs/rules/api.md
+++ b/docs/rules/api.md
@@ -58,3 +58,15 @@ Compact checklist auto-injected before edits. Long-form:
   pinned-first lists) and 500 via dotted serializer sources
   (`?ordering=author__get_username` → `FieldError`). List order is a package
   contract, not client-selectable (audit 2026-07-11 Phase 6 R1).
+- **An idempotent endpoint's replay must re-attach response headers, not just
+  body + status.** A retried create that returns a `Location` drops it on replay
+  unless the idempotency cache stores headers too — persist them
+  (`remember(..., headers={"Location": ...})`) and re-apply them in the replay
+  helper, or the replayed 201 silently differs from the original (todo 258 M35/L19).
+- **Never hardcode a URL namespace in `reverse()` inside a reusable/mountable
+  package.** `reverse("wagtail_forum_api:topic-detail", …)` 500s
+  (`NoReverseMatch`) when the package is a bare root urlconf (no namespace) or
+  nested under a host namespace (`v1:wagtail_forum_api`) — `app_name` only makes a
+  namespace when `include()`d. Resolve within the live request instead:
+  `ns = request.resolver_match.namespace; reverse(f"{ns}:name" if ns else "name", …)`
+  (see `_created_location`, todo 258 L19).

--- a/docs/rules/triggers.json
+++ b/docs/rules/triggers.json
@@ -655,5 +655,21 @@
     "source": "codify: chore/complete-todo-255",
     "added": "2026-07-22",
     "severity": "warn"
+  },
+  {
+    "id": "forum-reverse-hardcoded-namespace",
+    "domains": [
+      "api",
+      "forum"
+    ],
+    "path_glob": [
+      "backend/packages/wagtail_forum/**/*.py"
+    ],
+    "content_present": "reverse\\(['\"]wagtail_forum_api:",
+    "message": "Hardcoded URL namespace in reverse() — a mountable package must resolve within request.resolver_match.namespace (see _created_location), else NoReverseMatch 500 under the nested/root host mount.",
+    "pattern_ref": "backend/docs/patterns/domain/forum.md",
+    "source": "codify: docs/codify-forum-258",
+    "added": "2026-07-24",
+    "severity": "warn"
   }
 ]


### PR DESCRIPTION
Codification pass for todo 258 (forum API contract hardening). Routes this session's durable learnings:

- **docs/rules/api.md** (write-time prevention): an idempotent replay must re-attach response headers; never hardcode a URL namespace in `reverse()` in a mountable package.
- **docs/LEARNINGS.md**: the two real bugs caught in review/testing — replay dropping `Location`, and `reverse("wagtail_forum_api:…")` 500ing under the nested/root host mount — with root cause + fix.
- **backend/docs/patterns/domain/forum.md**: idempotency-on-new-surface pattern (multipart content-hash fingerprint, header-faithful replay, namespace-agnostic Location), the reference exception handler, and the cross-boundary drift guard.
- **docs/rules/triggers.json**: a write-time trigger for hardcoded `reverse("wagtail_forum_api:…")` in the package.

Docs-only. Trigger index validates (`test_match_triggers.py` 40 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)