### PR TITLE
forum(ops): deploy tombstone-prune cron to prod + fix runbook env gaps (todo 261)

### DIFF
--- a/backend/docs/deployment/railway.md
+++ b/backend/docs/deployment/railway.md
@@ -130,24 +130,46 @@ run that doesn't terminate skips the next one). Config lives in
 `restartPolicyType: NEVER` (a failed prune waits for tomorrow, it does not
 crash-loop).
 
-Steps 1 and 4 are already done in `production`: the empty service
-`forum-prune-cron` was created via `railway add` on 2026-07-26 with all
-variables below set as cross-service references. Steps 2, 3 and 5 are
-dashboard-only — the CLI exposes no flag for Root Directory or the
-config-as-code path (`railway add --help`, `railway service source connect
---help`), which is why the source is deliberately left **disconnected** until
-2 and 3 are set: connecting it first would deploy gunicorn under the inherited
-`railway.json`.
+**Status: LIVE in `production` since 2026-07-26** as service
+`forum-prune-cron`, verified pruning on schedule (evidence below).
 
-1. **New → Empty Service** in the same project. *(done — `forum-prune-cron`)*
-2. **Settings → Root Directory** = `backend`.
-3. **Settings → Config-as-code file** = `railway.cron.json`. This is
-   load-bearing: a service left on the default `railway.json` inherits the web
-   service's gunicorn `startCommand` **and** `healthcheckPath` (the cron would
-   try to serve gunicorn and never pass a healthcheck). The separate config
-   file is how the cron avoids that inheritance.
-   **Only after 2 and 3:** Settings → Source → connect this repo (branch
-   `main`), which triggers the first deploy.
+#### How it was actually deployed — snapshot upload, not a GitHub source
+
+Root Directory and config-as-code file are **dashboard-only** settings: no CLI
+flag exists (`railway add --help`, `railway service source connect --help`),
+and the public GraphQL API rejects the CLI's stored token (see todo 261 —
+introspection succeeds because Railway's schema is public, which is a false
+positive; every authenticated call returns `Not Authorized`).
+
+Both settings become unnecessary if you deploy the snapshot directly, because
+**Railway reads config-as-code from the root of the uploaded build context**:
+
+```bash
+cd backend
+cp railway.json /tmp/railway.json.bak
+cp railway.cron.json railway.json          # cron config becomes THE config
+railway up --service forum-prune-cron --detach
+cp /tmp/railway.json.bak railway.json      # restore (use a trap — see below)
+```
+
+Upload root *is* `backend/`, so Root Directory is moot; the snapshot's
+`railway.json` *is* the cron config, so the config-as-code setting is moot.
+Always guard the swap with `trap '…' EXIT` so a failed upload cannot leave the
+web service's `railway.json` overwritten in the working tree.
+
+**Tradeoff:** the service's source is an uploaded snapshot, so pushes to `main`
+do **not** redeploy the cron. Re-run the command above to ship changes, or
+attach the GitHub repo in the dashboard (Root Directory + config-as-code must
+then be set as in the original steps 2–3).
+
+1. **New → Empty Service** in the same project. *(done — `forum-prune-cron`,
+   created with `railway add --service forum-prune-cron`)*
+2. ~~**Settings → Root Directory** = `backend`~~ — not needed with the snapshot
+   upload above; required only if you attach a GitHub source.
+3. ~~**Settings → Config-as-code file** = `railway.cron.json`~~ — same. Note why
+   it would matter: a service left on the default `railway.json` inherits the
+   web service's gunicorn `startCommand` **and** `healthcheckPath`, so the cron
+   would try to serve gunicorn and never pass a healthcheck.
 4. **Variables — the cron needs nearly the full production set, not just the
    database.** `validate_environment()` runs at settings *import* time
    (`plant_community_backend/settings.py:1553`) and raises
@@ -159,7 +181,8 @@ config-as-code path (`railway add --help`, `railway service source connect
    |----------|-------|--------------------|
    | `DATABASE_URL` | `${{Postgres.DATABASE_URL}}` | the rows being pruned (private networking; no public domain needed) |
    | `REDIS_URL` | `${{Redis.REDIS_URL}}` | **critical error if unset when `DEBUG=False`, and the value is live-`ping`ed at import** |
-   | `SECRET_KEY` | `${{plant_id_community.SECRET_KEY}}` | `config("SECRET_KEY")` raises outright in production (`settings.py:48`) |
+   | `SECRET_KEY` | `${{plant_id_community.SECRET_KEY}}` | `config("SECRET_KEY")` raises outright in production (`settings.py:48`); also min 50 chars + no insecure patterns |
+   | `JWT_SECRET_KEY` | `${{plant_id_community.JWT_SECRET_KEY}}` | **no default, required in ALL environments** (`settings.py:596`); min 50 chars and must differ from `SECRET_KEY`. This one is *not* covered by `validate_environment()` — it raises earlier, and omitting it crash-looped the first real cron run |
    | `PLANT_ID_API_KEY` | `${{plant_id_community.PLANT_ID_API_KEY}}` | critical in production; also length-validated (min 32) |
    | `ALLOWED_HOSTS` | `${{plant_id_community.ALLOWED_HOSTS}}` | critical when unset or left at the localhost default |
    | `CSRF_TRUSTED_ORIGINS` | `${{plant_id_community.CSRF_TRUSTED_ORIGINS}}` | critical in production |
@@ -172,13 +195,25 @@ config-as-code path (`railway add --help`, `railway service source connect
    crash-looped nightly.
 
 5. Deploy. **Verify two separate things:**
-   - *The schedule is registered* — the service instance reports
+   - *The schedule is registered* — the deployment manifest reports
      `cronSchedule: "0 3 * * *"` (`railway status --json`). Checkable at once.
-   - *The command actually runs in the prod container* — the service log shows
+     Note the manifest field is the reliable one; the service-instance-level
+     `cronSchedule` reads `None` even when the cron is working.
+   - *The command actually runs in the prod container* — the deploy log shows
      `Pruned N tombstone row(s) older than 30 day(s).` and the run exits 0.
-     Railway's cron docs do not state whether a deploy also triggers an
-     immediate run, so treat the deploy-time log as a bonus if it appears and
-     otherwise confirm after the first 03:00 UTC fire.
+
+   **A deploy does NOT trigger a run** (confirmed empirically 2026-07-26: a
+   successful deploy left the deploy log completely empty). Only the schedule
+   fires it, roughly 1–2 minutes after the nominal time — a `32 14 * * *` test
+   schedule fired at `14:34:15Z`. To verify without waiting for 03:00 UTC,
+   temporarily deploy with a `cronSchedule` a few minutes out, capture the log,
+   then redeploy with `railway.cron.json` unchanged to restore `0 3 * * *`.
+
+   Reading logs: `railway logs <deployment-id> --service forum-prune-cron
+   --deployment --lines 60`. Pass the deployment id explicitly — the default
+   ("most recent successful deployment") can resolve to a superseded one and
+   return nothing. Also note the log stream tags ordinary INFO lines as
+   `[ERRO]`; that prefix is not a real error.
 
 ### Add the worker later (when push/email/summaries are enabled)
 

--- a/backend/docs/deployment/railway.md
+++ b/backend/docs/deployment/railway.md
@@ -130,17 +130,55 @@ run that doesn't terminate skips the next one). Config lives in
 `restartPolicyType: NEVER` (a failed prune waits for tomorrow, it does not
 crash-loop).
 
-1. **New → Empty Service** in the same project, pointing at this repo.
+Steps 1 and 4 are already done in `production`: the empty service
+`forum-prune-cron` was created via `railway add` on 2026-07-26 with all
+variables below set as cross-service references. Steps 2, 3 and 5 are
+dashboard-only — the CLI exposes no flag for Root Directory or the
+config-as-code path (`railway add --help`, `railway service source connect
+--help`), which is why the source is deliberately left **disconnected** until
+2 and 3 are set: connecting it first would deploy gunicorn under the inherited
+`railway.json`.
+
+1. **New → Empty Service** in the same project. *(done — `forum-prune-cron`)*
 2. **Settings → Root Directory** = `backend`.
 3. **Settings → Config-as-code file** = `railway.cron.json`. This is
    load-bearing: a service left on the default `railway.json` inherits the web
    service's gunicorn `startCommand` **and** `healthcheckPath` (the cron would
    try to serve gunicorn and never pass a healthcheck). The separate config
    file is how the cron avoids that inheritance.
-4. Reference `DATABASE_URL` = `${{Postgres.DATABASE_URL}}` (private networking;
-   no public domain needed). `REDIS_URL` is not required for pruning.
-5. Deploy. **Verify:** after a scheduled run, the service log shows
-   `Pruned N tombstone row(s) older than 30 day(s).`
+   **Only after 2 and 3:** Settings → Source → connect this repo (branch
+   `main`), which triggers the first deploy.
+4. **Variables — the cron needs nearly the full production set, not just the
+   database.** `validate_environment()` runs at settings *import* time
+   (`plant_community_backend/settings.py:1553`) and raises
+   `ImproperlyConfigured` when `DEBUG=False`, so a management command that
+   never serves a request still fails to boot without these. Set them as
+   cross-service references (no secret duplication):
+
+   | Variable | Value | Why it is required |
+   |----------|-------|--------------------|
+   | `DATABASE_URL` | `${{Postgres.DATABASE_URL}}` | the rows being pruned (private networking; no public domain needed) |
+   | `REDIS_URL` | `${{Redis.REDIS_URL}}` | **critical error if unset when `DEBUG=False`, and the value is live-`ping`ed at import** |
+   | `SECRET_KEY` | `${{plant_id_community.SECRET_KEY}}` | `config("SECRET_KEY")` raises outright in production (`settings.py:48`) |
+   | `PLANT_ID_API_KEY` | `${{plant_id_community.PLANT_ID_API_KEY}}` | critical in production; also length-validated (min 32) |
+   | `ALLOWED_HOSTS` | `${{plant_id_community.ALLOWED_HOSTS}}` | critical when unset or left at the localhost default |
+   | `CSRF_TRUSTED_ORIGINS` | `${{plant_id_community.CSRF_TRUSTED_ORIGINS}}` | critical in production |
+   | `CORS_ALLOWED_ORIGINS` | `${{plant_id_community.CORS_ALLOWED_ORIGINS}}` | critical when unset or left at the placeholder default |
+   | `DEBUG` | `${{plant_id_community.DEBUG}}` | keeps the cron on the same branch as the web service |
+
+   An earlier revision of this runbook said "`REDIS_URL` is not required for
+   pruning" — that was wrong. Pruning itself touches no cache, but settings
+   import refuses to complete without a reachable Redis, so the cron would have
+   crash-looped nightly.
+
+5. Deploy. **Verify two separate things:**
+   - *The schedule is registered* — the service instance reports
+     `cronSchedule: "0 3 * * *"` (`railway status --json`). Checkable at once.
+   - *The command actually runs in the prod container* — the service log shows
+     `Pruned N tombstone row(s) older than 30 day(s).` and the run exits 0.
+     Railway's cron docs do not state whether a deploy also triggers an
+     immediate run, so treat the deploy-time log as a bonus if it appears and
+     otherwise confirm after the first 03:00 UTC fire.
 
 ### Add the worker later (when push/email/summaries are enabled)
 

--- a/docs/audits/2026-07-11-forum-modernization.md
+++ b/docs/audits/2026-07-11-forum-modernization.md
@@ -306,7 +306,7 @@ Deferred findings converted to todos (Review Doc Tracking convention — the
 - [x] #H15 semantic-similar-topics → todo 255 (completed 2026-07-22, slice 4)
 - [x] #H16 admin-moderation-queue → todo 254 (completed 2026-07-13)
 - [x] #H18 error-retry-affordance → todo 259 (completed 2026-07-24)
-- [ ] #H21 tombstone-prune-scheduling → todo 261
+- [x] #H21 tombstone-prune-scheduling → todo 261 (completed 2026-07-26)
 - [x] #H26 author-shape-inconsistency → todo 257 (completed 2026-07-24, PR #490)
 - [ ] #M1 quote-reply → todo 276 (re-pointed 2026-07-23; split out of 256)
 - [ ] #M2 bookmarks → todo 263
@@ -337,7 +337,7 @@ Deferred findings converted to todos (Review Doc Tracking convention — the
 - [x] #M29 upload-precheck → todo 259 (completed 2026-07-24)
 - [x] #M30 thread-pagination-ux → todo 259 (completed 2026-07-24)
 - [x] #M31 scroll-to-top → todo 259 (completed 2026-07-24)
-- [ ] #M34 write-path-e2e → todo 261
+- [x] #M34 write-path-e2e → todo 261 (completed 2026-07-26)
 - [x] #M35 patch-idempotency → todo 258 (completed 2026-07-24, PR #494)
 - [x] #M36 image-upload-idempotency → todo 258 (completed 2026-07-24, PR #494)
 - [x] #M37 openapi-response-codes → todo 258 (completed 2026-07-24, PR #494)
@@ -345,7 +345,7 @@ Deferred findings converted to todos (Review Doc Tracking convention — the
 - [x] #M39 error-envelope-ownership → todo 258 (completed 2026-07-24, PR #494)
 - [ ] #M40 envelope-shapes → todo 277 (re-pointed 2026-07-24; out of 258 acceptance gate — breaking, needs web coordination; partly stale)
 - [x] #M41 deleted-author-convention → todo 257 (completed 2026-07-24, PR #490)
-- [ ] #M42 http-caching → todo 261
+- [x] #M42 http-caching → todo 261 (completed 2026-07-26)
 - [x] #L1 anon-reaction-counts → todo 257 (completed 2026-07-24, PR #491; shipped Wave 1 #473, test-proven)
 - [ ] #L2 onboarding-empty-states → todo 278 (re-pointed 2026-07-24; deferred from 259 — "L", no AC, needs backend Wagtail work)
 - [x] #L4 markdown-board-picker → todo 259 (completed 2026-07-24)
@@ -359,7 +359,7 @@ Deferred findings converted to todos (Review Doc Tracking convention — the
 - [x] #L13 tautological-composer-tests → todo 259 (completed 2026-07-24)
 - [x] #L14 identity-polish → todo 257 (completed 2026-07-24, PR #491; trust_level render #474, emoji aria-hidden #491, reactions flex-wrap shipped Wave 1 #473)
 - [x] #L16 reaction-types-duplication → todo 258 (completed 2026-07-24, PR2; shared web literal + backend drift-guard)
-- [ ] #L17 migrations-check-ci → todo 261
+- [x] #L17 migrations-check-ci → todo 261 (completed 2026-07-26)
 - [x] #L18 write-path-query-profiling → todo 258 (completed 2026-07-24, PR #494; PATCH 71 / DELETE 33, cascade not elidable)
 - [x] #L19 location-header-201 → todo 258 (completed 2026-07-24, PR #494)
 - [ ] #L20 versioning-comment → todo 277 (re-pointed 2026-07-24; out of 258 acceptance gate)

--- a/todos/261-in_progress-p2-forum-ops-infra.md
+++ b/todos/261-in_progress-p2-forum-ops-infra.md
@@ -220,6 +220,10 @@ API suite); authed E2E `2 passed` again.
   repo source connected on purpose** — connecting a source before Root
   Directory + config-as-code are set would deploy gunicorn under the inherited
   `railway.json` and crash-loop against a healthcheck.
+- **No compute allocated yet** (verified, since the service is billable once it
+  deploys): `forum-prune-cron` reports `activeDeployments=0`,
+  `latestDeployment=None`, `instances=0`. Nothing accrues until the source is
+  connected in step 3 of the handoff.
 - **Runbook bug found and fixed** (`backend/docs/deployment/railway.md`). The
   previous step 4 said "`REDIS_URL` is not required for pruning" — **wrong**.
   `validate_environment()` runs at settings *import* (`settings.py:1553`) and,

--- a/todos/261-in_progress-p2-forum-ops-infra.md
+++ b/todos/261-in_progress-p2-forum-ops-infra.md
@@ -77,10 +77,11 @@ audit.
       tombstones actually pruned on schedule in that topology (DEFERRED — needs a
       live deploy of the cron service + a scheduled run; evidence = the log line
       `Pruned N tombstone row(s)…`, which the command already emits locally)
-- [~] Push-task execution home in prod confirmed — repo evidence confirms NO
-      worker exists (single gunicorn service), so push/email/summaries drop;
-      documented + decided (defer worker). DEFERRED: dashboard confirmation of
-      the live topology is the user's step
+- [x] Push-task execution home in prod confirmed — LIVE topology verified via
+      `railway status --json` (2026-07-26): 1 environment (`production`), 3
+      services (Postgres, Redis, `plant_id_community`), all `cronSchedule=None`,
+      the only app start command being gunicorn. NO Celery worker → push/email/
+      summaries drop; documented + decided (defer worker)
 - [x] Authed E2E covers create → reply → edit → react → delete
 - [x] Anonymous hot reads carry cache headers; authed/user-specific responses
       provably uncached or varied (test)
@@ -196,13 +197,67 @@ critical/high. 2 medium + 4 low, all fixed:
 Re-verified after fixes: `6 passed` (cache tests) + `230 passed` (full forum
 API suite); authed E2E `2 passed` again.
 
+### 2026-07-26 - Live topology verified; cron service provisioned; runbook bug fixed
+
+- **AC2 FLIPPED — live prod topology confirmed** via `railway status --json`
+  (authoritative API, same data the dashboard renders, as the account owner):
+  1 environment (`production`), 3 service instances —
+
+  ```text
+  SERVICES (project-level):   Postgres | plant_id_community | Redis
+  ENV: production
+    service_id=6530094c cron=None start=None                    # Postgres image
+    service_id=676207b7 cron=None start='…redis-server…'         # Redis image
+    service_id=9edd1c89 cron=None start="sh -c 'gunicorn …'"     # web
+  ```
+
+  No Celery worker, no beat, `cronSchedule=None` everywhere. This is exactly
+  the confirmation AC2 deferred to the dashboard, so it is now met by evidence
+  rather than by repo inference. The defer-the-worker decision stands.
+- **Cron service provisioned via CLI** (user chose "I create it via CLI, you
+  finish config"): `railway add --service forum-prune-cron` →
+  `{"id":"7fee2fe0-5b83-46ab-99e4-ccfc001de87e"}`. Created **empty, with no
+  repo source connected on purpose** — connecting a source before Root
+  Directory + config-as-code are set would deploy gunicorn under the inherited
+  `railway.json` and crash-loop against a healthcheck.
+- **Runbook bug found and fixed** (`backend/docs/deployment/railway.md`). The
+  previous step 4 said "`REDIS_URL` is not required for pruning" — **wrong**.
+  `validate_environment()` runs at settings *import* (`settings.py:1553`) and,
+  when `DEBUG=False`, raises `ImproperlyConfigured` without `REDIS_URL` (and
+  live-`ping`s it), plus `SECRET_KEY` (raises at `settings.py:48`),
+  `PLANT_ID_API_KEY`, `ALLOWED_HOSTS`, `CSRF_TRUSTED_ORIGINS`,
+  `CORS_ALLOWED_ORIGINS`. A cron built to that runbook would have crash-looped
+  nightly and never pruned. Doc now carries the full table + the reason each
+  entry is load-bearing.
+- **Variables set as cross-service references** (no secret duplication, and no
+  secret values read): `DATABASE_URL=${{Postgres.DATABASE_URL}}`,
+  `REDIS_URL=${{Redis.REDIS_URL}}`, and `SECRET_KEY` / `PLANT_ID_API_KEY` /
+  `ALLOWED_HOSTS` / `CSRF_TRUSTED_ORIGINS` / `CORS_ALLOWED_ORIGINS` / `DEBUG`
+  from `${{plant_id_community.*}}`. Verified resolved on the new service
+  (`DEBUG=False`, `ALLOWED_HOSTS=plantidcommunity-production.up.railway.app`,
+  origins populated).
+- **Overclaim caught and corrected:** an intermediate draft of the doc asserted
+  Railway runs a cron service's start command once on deploy. Railway's cron
+  docs do not state that (verified against
+  `https://docs.railway.com/reference/cron-jobs`, which covers must-exit,
+  5-min minimum, and UTC only). The doc now separates "schedule is registered"
+  (checkable immediately) from "command ran in the prod container" (deploy-time
+  log if it appears, else after the first 03:00 UTC fire).
+
 ### Handoff — remaining deploy+verify (keeps 261 open)
 
-1. Add the Railway cron service per `railway.md` → "Add the tombstone-pruning
-   cron service" (Config-as-code file = `railway.cron.json`). After the first
-   scheduled fire, confirm the log line `Pruned N tombstone row(s)…` → flips AC1.
-2. Confirm in the Railway dashboard that no Celery worker runs (expected) and
-   decide when to enable one for push/email/summaries → flips AC2.
+AC1 only. The CLI exposes no flag for Root Directory or the config-as-code path
+(confirmed in `railway add --help` and `railway service source connect --help`),
+so these two settings are dashboard-only — on service **`forum-prune-cron`**:
+
+1. **Settings → Root Directory** = `backend`
+2. **Settings → Config-as-code file** = `railway.cron.json`
+3. *Then* **Settings → Source** → connect `Xertox1234/plant_id_community`,
+   branch `main` (this order matters — see the runbook note).
+
+Then I verify and flip AC1: `cronSchedule: "0 3 * * *"` on the service instance,
+plus the log line `Pruned N tombstone row(s) older than 30 day(s).` with a
+clean exit.
 
 ## Notes
 

--- a/todos/261-in_progress-p2-forum-ops-infra.md
+++ b/todos/261-in_progress-p2-forum-ops-infra.md
@@ -248,6 +248,34 @@ API suite); authed E2E `2 passed` again.
   (checkable immediately) from "command ran in the prod container" (deploy-time
   log if it appears, else after the first 03:00 UTC fire).
 
+### 2026-07-26 - GraphQL API route investigated and RULED OUT
+
+Attempted to set the two dashboard-only settings (`rootDirectory`,
+`railwayConfigFile`) via Railway's public GraphQL API so AC1 could be finished
+without the dashboard. **It does not work with the CLI's stored token — do not
+retry this path.**
+
+- Schema introspection *looked* like proof the route was available
+  (`ServiceInstanceUpdateInput` exposes `rootDirectory`, `railwayConfigFile`,
+  `source`; `serviceInstanceUpdate(serviceId, environmentId, input)` exists).
+  That was a **false positive**: Railway's schema is publicly readable, so
+  introspection succeeds unauthenticated.
+- Every authenticated call returns `Not Authorized` — **byte-identical to an
+  unauthenticated control request**, which is the tell. Tried:
+  `Authorization: Bearer <accessToken>`, bare `Authorization: <accessToken>`,
+  `project-access-token`, `x-railway-token`; hosts
+  `backboard.railway.com/graphql/v2`, `backboard.railway.app/graphql/v2`,
+  `backboard.railway.com/graphql/internal`. The token was unexpired
+  (`tokenExpiresAt` = 2026-07-26T05:00:55 UTC) and `railway status` worked
+  throughout, so the CLI authenticates by some other means than a bearer token
+  on the public endpoint.
+- A dashboard-created account/project token would likely authenticate — but
+  creating one is itself a dashboard trip, and it is more steps than just
+  setting the two fields. Not worth it.
+
+Conclusion: Root Directory + config-as-code are genuinely dashboard-only, as
+the runbook already says. The handoff below stands unchanged.
+
 ### Handoff — remaining deploy+verify (keeps 261 open)
 
 AC1 only. The CLI exposes no flag for Root Directory or the config-as-code path

--- a/todos/archive/261-completed-p2-forum-ops-infra.md
+++ b/todos/archive/261-completed-p2-forum-ops-infra.md
@@ -1,5 +1,5 @@
 ---
-status: in_progress
+status: completed
 priority: p2
 issue_id: "261"
 tags: [forum, ops, celery, ci, e2e]
@@ -73,10 +73,16 @@ audit.
 
 ## Acceptance Criteria
 
-- [~] Prod Celery topology documented (DONE: `backend/docs/deployment/railway.md`);
-      tombstones actually pruned on schedule in that topology (DEFERRED — needs a
-      live deploy of the cron service + a scheduled run; evidence = the log line
-      `Pruned N tombstone row(s)…`, which the command already emits locally)
+- [x] Prod Celery topology documented (`backend/docs/deployment/railway.md`);
+      tombstones actually pruned on schedule — LIVE in prod 2026-07-26 as the
+      Railway cron service `forum-prune-cron`. A test schedule (`32 14 * * *`)
+      fired at `14:34:15Z` and logged
+      `Pruned 0 tombstone row(s) older than 30 day(s).` with deployment status
+      `SUCCESS` (container started, ran, exited cleanly as Railway cron
+      requires). Production schedule then restored and verified:
+      `cronSchedule '0 3 * * *'`, `startCommand 'python manage.py
+      prune_forum_tombstones'`, `restartPolicyType NEVER`,
+      `healthcheckPath None`, `preDeployCommand None`
 - [x] Push-task execution home in prod confirmed — LIVE topology verified via
       `railway status --json` (2026-07-26): 1 environment (`production`), 3
       services (Postgres, Redis, `plant_id_community`), all `cronSchedule=None`,
@@ -276,25 +282,80 @@ retry this path.**
 Conclusion: Root Directory + config-as-code are genuinely dashboard-only, as
 the runbook already says. The handoff below stands unchanged.
 
-### Handoff — remaining deploy+verify (keeps 261 open)
+### 2026-07-26 - AC1 CLOSED — cron deployed and verified pruning on schedule
 
-AC1 only. The CLI exposes no flag for Root Directory or the config-as-code path
-(confirmed in `railway add --help` and `railway service source connect --help`),
-so these two settings are dashboard-only — on service **`forum-prune-cron`**:
+The dashboard-only blocker was dissolved by a route none of the earlier four
+attempts covered: **Railway reads config-as-code from the root of the uploaded
+build context**, so `railway up` from `backend/` with the cron config staged as
+`railway.json` makes both Root Directory and config-as-code irrelevant. Swap
+guarded by `trap '…' EXIT` so a failed upload can never leave the web service's
+`railway.json` overwritten (verified clean after every one of the four uploads).
 
-1. **Settings → Root Directory** = `backend`
-2. **Settings → Config-as-code file** = `railway.cron.json`
-3. *Then* **Settings → Source** → connect `Xertox1234/plant_id_community`,
-   branch `main` (this order matters — see the runbook note).
+Sequence and evidence:
 
-Then I verify and flip AC1: `cronSchedule: "0 3 * * *"` on the service instance,
-plus the log line `Pruned N tombstone row(s) older than 30 day(s).` with a
-clean exit.
+1. First deploy (`d23dfeef`) — `SUCCESS`, deploy log **completely empty**. This
+   settles the open question: **a deploy does NOT trigger a cron run.** The
+   earlier draft claim that it does was wrong to remove-on-suspicion and is now
+   disproven outright.
+2. Test-schedule deploy (`5ae63d99`, `16 14 * * *`) — **`CRASHED`**. Cause from
+   the deploy log: `JWT_SECRET_KEY` missing. It has **no default and is required
+   in ALL environments** (`settings.py:596`, min 50 chars, must differ from
+   `SECRET_KEY`) and is raised *before* `validate_environment()`, so my
+   8-variable table missed it. Valuable failure: this is exactly the crash-loop
+   the original `REDIS_URL` doc bug would have caused, caught on a test schedule
+   instead of silently at 03:00.
+3. Added `JWT_SECRET_KEY=${{plant_id_community.JWT_SECRET_KEY}}` (86 chars).
+   Test-schedule deploy (`405b4db3`, `32 14 * * *`) → fired `14:34:15Z`:
+
+   ```text
+   Starting Container
+   [settings] ENABLE_FILE_LOGGING=True (argv=['manage.py', 'prune_forum_tombstones'])
+   [ENV VALIDATION] Configuration warnings detected:   # warnings only, no criticals
+   Pruned 0 tombstone row(s) older than 30 day(s).
+   ```
+
+   Deployment `SUCCESS` — started, ran against prod Postgres, exited cleanly.
+   Cron fires ~1–2 min after nominal (`14:32` → `14:34:15`).
+4. Final deploy (`653dea26`) restored the production schedule. Verified:
+   `cronSchedule '0 3 * * *'`, `startCommand 'python manage.py
+   prune_forum_tombstones'`, `restartPolicyType NEVER`, `healthcheckPath None`,
+   `preDeployCommand None`, status `SUCCESS`.
+
+Runbook updated with all of it: the snapshot-upload method + its
+pushes-don't-redeploy tradeoff, the `JWT_SECRET_KEY` row, deploy-does-not-run,
+the fire delay, the manifest-vs-instance `cronSchedule` discrepancy (the
+instance field reads `None` even when working), and the need to pass an explicit
+deployment id to `railway logs`.
+
+**All 5 acceptance criteria now met.**
+
+### 2026-07-26 - Completed by completing-todos skill (run 2026-07-26-0400)
+
+- Verification: all 5 acceptance criteria passed with quoted evidence — L17 CI
+  migration gate, M42 anon cache headers (`6 passed` + `230 passed` forum API
+  suite), M34 authed E2E (`2 passed`), H21 cron live-verified in prod
+  (`Pruned 0 tombstone row(s) older than 30 day(s).` at `14:34:15Z`), and the
+  prod topology confirmed via `railway status --json`.
+- Review: prior pass (3 reviewers) found 0 critical/high, 2 medium + 4 low, all
+  fixed. This session's diff is documentation + todo bookkeeping only — no code
+  — so no further reviewer dispatch.
+- Corrections made during the run, all recorded above rather than quietly
+  dropped: the "deploy triggers a cron run" claim (disproven empirically), the
+  "GraphQL API route is available" claim (false positive from public-schema
+  introspection), and the `REDIS_URL`/`JWT_SECRET_KEY` gaps in the runbook.
 
 ## Notes
 
 p2. The topology investigation (step 1) is cheap and load-bearing for two
 other epics — do it first even if the rest waits.
+
+Follow-ups deliberately NOT done here (no scope creep):
+
+- The cron's source is an uploaded snapshot, so pushes to `main` do not
+  redeploy it. Re-run the documented `railway up` to ship changes, or attach
+  the GitHub repo in the dashboard.
+- The Celery worker stays deferred until push/email/summaries are enabled;
+  cheapest path remains co-locating it in the existing gunicorn container.
 
 Phase 6 review residue (2026-07-11 audit, celery reviewer, LOW): the FCM
 retry backoff (30/60/120s) has no jitter — a correlated FCM outage retries


### PR DESCRIPTION
Closes todo 261 (forum ops epic). All 5 acceptance criteria met; todo archived.

Docs + bookkeeping only — **no code changes**. The production change is
infrastructure: a Railway cron service that now prunes forum tombstones daily.

## What shipped

Todo 261's code work (CI migration gate, anon cache headers, authed E2E) merged
earlier in #499. This PR closes the two prod-verification criteria that kept it
open, and fixes what deploying actually exposed.

**AC2 — prod topology confirmed.** `railway status --json` shows 1 environment
and 3 services (Postgres, Redis, gunicorn web), no Celery worker, no beat. All
forum `.delay()` tasks drop in prod; the defer-the-worker decision stands.

**AC1 — cron live and verified.** Root Directory and config-as-code are
dashboard-only settings, but Railway reads config-as-code from the root of the
uploaded build context, so `railway up` from `backend/` with the cron config
staged as `railway.json` makes both irrelevant. The swap is guarded by a
`trap '…' EXIT` so a failed upload cannot leave the web service's
`railway.json` overwritten.

Test schedule `32 14 * * *` fired at `14:34:15Z`:

```
Starting Container
[settings] ENABLE_FILE_LOGGING=True (argv=['manage.py', 'prune_forum_tombstones'])
Pruned 0 tombstone row(s) older than 30 day(s).
```

Deployment `SUCCESS` — ran against prod Postgres and exited cleanly. Production
schedule then restored: `cronSchedule '0 3 * * *'`, `restartPolicyType NEVER`,
no inherited `healthcheckPath` or `preDeployCommand`.

## Two runbook bugs that would have failed silently

1. **`REDIS_URL is not required for pruning`** — wrong. `validate_environment()`
   runs at settings import and, with `DEBUG=False`, raises without `REDIS_URL`
   (which it also live-pings). A cron built to that instruction would have
   crash-looped nightly and never pruned.
2. **`JWT_SECRET_KEY` was missing from the variable set** — no default, required
   in ALL environments, and raises *before* `validate_environment()`. This
   crashed the first real cron run. Caught on a 2-minute test window instead of
   silently at 03:00 UTC.

Both fixed; all required vars documented as cross-service references (no secret
duplication).

## Empirical findings now in the runbook

- A deploy does **not** trigger a cron run (first deploy's log was empty).
- The cron fires ~1–2 min after nominal.
- The service-instance `cronSchedule` field reads `None` even when working —
  the deployment manifest is authoritative.
- `railway logs` needs an explicit deployment id; the default can resolve to a
  superseded deployment and return nothing.

## Reviewer notes

- **The `0 3 * * *` schedule has not fired yet.** Every verified run used a test
  schedule; same container, variables and command, only the cron expression
  differs. First production fire is tonight. With `restartPolicyType: NEVER` a
  failure is silent — worth a log glance tomorrow.
- **The cron's source is an uploaded snapshot**, so pushes to `main` do not
  redeploy it. Re-run the documented `railway up`, or attach the GitHub repo in
  the dashboard (which then does require Root Directory + config-as-code).
- Checks off H21, M34, M42, L17 in the forum-modernization audit. 21 findings
  remain open there, so the doc is intentionally not renamed to `-COMPLETED`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)