### PR TITLE
ops(backend): compile translation catalogs at image build (todo 262 follow-up)

### DIFF
--- a/.claude/hooks/test-format-on-edit.sh
+++ b/.claude/hooks/test-format-on-edit.sh
@@ -82,7 +82,7 @@ chmod +x "$STUB"
 mkfixture backend/apps/residual.py 'import os\n'
 ERR=$(printf '{"tool_name":"Edit","tool_input":{"file_path":"backend/apps/residual.py"}}' \
       | FORMAT_ON_EDIT_RUFF="$STUB" FORMAT_ON_EDIT_ROOT="$ROOT" bash "$HOOK" 2>&1 >/dev/null); RC=$?
-if [ "$RC" -eq 2 ] && printf '%s' "$ERR" | grep -qi 'F401\|unused'; then
+if [ "$RC" -eq 2 ] && grep -qi 'F401\|unused' <<< "$ERR"; then
   ok "unfixable F401 → exit 2 with feedback"
 else
   no "unfixable F401 → exit 2 with feedback" "rc=$RC err=$ERR"
@@ -107,7 +107,7 @@ ESLINT_ERR="$ROOT/eslint-err"
 mkfixture web/src/bad.ts 'const y = z;\n'
 ERR=$(printf '{"tool_name":"Edit","tool_input":{"file_path":"web/src/bad.ts"}}' \
       | FORMAT_ON_EDIT_ESLINT="$ESLINT_ERR" FORMAT_ON_EDIT_ROOT="$ROOT" bash "$HOOK" 2>&1 >/dev/null); RC=$?
-if [ "$RC" -eq 2 ] && printf '%s' "$ERR" | grep -qi 'eslint'; then
+if [ "$RC" -eq 2 ] && grep -qi 'eslint' <<< "$ERR"; then
   ok "TS residual error → exit 2 with feedback"
 else
   no "TS residual error → exit 2 with feedback" "rc=$RC err=$ERR"
@@ -171,7 +171,7 @@ PY
     local m=""
     while IFS= read -r p; do
       [ -z "$p" ] && continue
-      printf '%s\n' "$2" | grep -qxF "$p" || m="$m $p"
+      grep -qxF "$p" <<< "$2" || m="$m $p"
     done <<< "$1"
     printf '%s' "$m"
   }
@@ -184,7 +184,7 @@ PY
     no "skip-list ⊇ setup.cfg F401 ignores (in sync)" "missing:$REAL_MISSING cfg_empty?=$([ -z "$CFG" ] && echo yes || echo no)"
   fi
   # (b) Teeth: a setup.cfg F401 entry NOT in the skip-list is detected as missing.
-  if printf '%s' "$(check_subset 'apps/fake_reexport.py' "$SKIP")" | grep -q 'fake_reexport'; then
+  if grep -q 'fake_reexport' <<< "$(check_subset 'apps/fake_reexport.py' "$SKIP")"; then
     ok "sync check detects an unmirrored F401 ignore"
   else
     no "sync check detects an unmirrored F401 ignore" "fake entry not flagged"

--- a/.claude/hooks/test-guard-worktree-isolation.sh
+++ b/.claude/hooks/test-guard-worktree-isolation.sh
@@ -11,7 +11,7 @@ run_hook() { echo "$1" | bash "$HOOK" 2>/dev/null; }
 assert_deny() {
   local name="$1" out
   out=$(run_hook "$2")
-  if echo "$out" | grep -q '"permissionDecision": "deny"'; then
+  if grep -q '"permissionDecision": "deny"' <<< "$out"; then
     echo "PASS: $name"; PASS=$((PASS+1))
   else
     echo "FAIL: $name (expected a deny decision)"

--- a/.claude/hooks/test-inject-patterns.sh
+++ b/.claude/hooks/test-inject-patterns.sh
@@ -24,7 +24,7 @@ run_hook() {
 check() {
   local name="$1" input="$2" pattern="$3" combined
   combined=$(run_hook "$input")
-  if echo "$combined" | grep -q "$pattern"; then
+  if grep -q "$pattern" <<< "$combined"; then
     echo "PASS: $name"; PASS=$((PASS + 1))
   else
     echo "FAIL: $name"; echo "  expected to find: $pattern"; FAIL=$((FAIL + 1))
@@ -34,7 +34,7 @@ check() {
 check_no_match() {
   local name="$1" input="$2" pattern="$3" combined
   combined=$(run_hook "$input")
-  if echo "$combined" | grep -q "$pattern"; then
+  if grep -q "$pattern" <<< "$combined"; then
     echo "FAIL: $name (expected NOT to find: $pattern)"; FAIL=$((FAIL + 1))
   else
     echo "PASS: $name"; PASS=$((PASS + 1))
@@ -161,12 +161,12 @@ TRIG_EVENT=$(jq -n --arg sid "$TRIG_SESSION" \
 rm -f "/tmp/inject-${TRIG_SESSION}-"* 2>/dev/null
 OUT1=$(printf '%s' "$TRIG_EVENT" | INJECT_FIRES_LOG=/dev/null bash "$HOOK" 2>/dev/null)
 OUT2=$(printf '%s' "$TRIG_EVENT" | INJECT_FIRES_LOG=/dev/null bash "$HOOK" 2>/dev/null)
-if echo "$OUT1" | grep -q "systemMessage" && echo "$OUT1" | grep -q "RECENT MISTAKES"; then
+if grep -q "systemMessage" <<< "$OUT1" && grep -q "RECENT MISTAKES" <<< "$OUT1"; then
   echo "PASS: trigger match → systemMessage + RECENT MISTAKES"; PASS=$((PASS + 1))
 else
   echo "FAIL: trigger match → systemMessage + RECENT MISTAKES"; FAIL=$((FAIL + 1))
 fi
-if echo "$OUT2" | grep -q "RECENT MISTAKES"; then
+if grep -q "RECENT MISTAKES" <<< "$OUT2"; then
   echo "FAIL: repeat trigger in same session → deduped"; FAIL=$((FAIL + 1))
 else
   echo "PASS: repeat trigger in same session → deduped"; PASS=$((PASS + 1))

--- a/.claude/hooks/test-kimi-review.sh
+++ b/.claude/hooks/test-kimi-review.sh
@@ -56,7 +56,7 @@ run_hook() {
 
 assert_contains() {
   local name="$1" haystack="$2" needle="$3"
-  if echo "$haystack" | grep -q "$needle"; then
+  if grep -q "$needle" <<< "$haystack"; then
     echo "PASS: $name"; PASS=$((PASS+1))
   else
     echo "FAIL: $name (expected to find: $needle)"
@@ -67,7 +67,7 @@ assert_contains() {
 
 assert_not_contains() {
   local name="$1" haystack="$2" needle="$3"
-  if echo "$haystack" | grep -q "$needle"; then
+  if grep -q "$needle" <<< "$haystack"; then
     echo "FAIL: $name (expected NOT to find: $needle)"
     echo "  got: $(echo "$haystack" | head -3)"
     FAIL=$((FAIL+1))

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -13,9 +13,12 @@
 FROM python:3.13-slim
 
 # System deps: libpq for psycopg, build-essential as a safety net for any
-# dependency that lacks a cp313 wheel. Apt lists are dropped to keep the layer small.
+# dependency that lacks a cp313 wheel, gettext for `msgfmt` (the compilemessages
+# step below). It must be `gettext`, NOT `gettext-base` — the latter ships only
+# gettext/ngettext/envsubst and omits msgfmt, which fails compilemessages with
+# "Can't find msgfmt". Apt lists are dropped to keep the layer small.
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends build-essential libpq-dev \
+    && apt-get install -y --no-install-recommends build-essential libpq-dev gettext \
     && rm -rf /var/lib/apt/lists/*
 
 ENV PYTHONUNBUFFERED=1 \
@@ -30,6 +33,19 @@ WORKDIR /app
 COPY . .
 
 RUN pip install --upgrade pip && pip install -r requirements.txt
+
+# Compile translation catalogs at BUILD time. Django reads the compiled `.mo`,
+# never the `.po`, and `.mo` is gitignored as a build artifact — so without this
+# step wagtail_forum's catalogs ship inert and every locale silently falls back
+# to the msgid. compilemessages walks the tree from cwd collecting `locale/`
+# dirs; here that resolves to exactly packages/wagtail_forum/wagtail_forum/locale
+# (verified: it is the only `locale/` in the COPY'd context, and `venv/` is
+# .dockerignored so Django's and Wagtail's own pre-compiled catalogs are outside
+# the walk). `-i venv` is belt-and-braces in case that .dockerignore entry ever
+# goes away. Runs BEFORE collectstatic so the walk doesn't traverse the 262
+# freshly-collected static files. Same throwaway build-only env prefix as the
+# collectstatic line below — see that comment for why it's inline and safe.
+RUN DEBUG=True JWT_SECRET_KEY=build-only-throwaway-value-not-a-real-key-000000000000000 DATABASE_URL=sqlite:////tmp/build.sqlite3 python manage.py compilemessages -i venv --verbosity 1  # pragma: allowlist secret
 
 # Collect static assets at BUILD time so the runtime start command is gunicorn-only.
 # Why: in Railway's runtime container under python:3.13-slim, `collectstatic` copies

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -42,8 +42,8 @@ RUN pip install --upgrade pip && pip install -r requirements.txt
 # (verified: it is the only `locale/` in the COPY'd context, and `venv/` is
 # .dockerignored so Django's and Wagtail's own pre-compiled catalogs are outside
 # the walk). `-i venv` is belt-and-braces in case that .dockerignore entry ever
-# goes away. Runs BEFORE collectstatic so the walk doesn't traverse the 262
-# freshly-collected static files. Same throwaway build-only env prefix as the
+# goes away. Runs BEFORE collectstatic so the walk doesn't traverse the
+# freshly-collected static tree. Same throwaway build-only env prefix as the
 # collectstatic line below — see that comment for why it's inline and safe.
 RUN DEBUG=True JWT_SECRET_KEY=build-only-throwaway-value-not-a-real-key-000000000000000 DATABASE_URL=sqlite:////tmp/build.sqlite3 python manage.py compilemessages -i venv --verbosity 1  # pragma: allowlist secret
 

--- a/backend/packages/wagtail_forum/README.md
+++ b/backend/packages/wagtail_forum/README.md
@@ -377,14 +377,24 @@ The committed `en` catalog is an extraction **snapshot**, not a translation
 
 Compiled `.mo` files are not committed — Django reads the compiled catalog, not
 the `.po` — so `compilemessages` must run as part of your build or deploy step.
+A build that skips it ships the catalogs **inert**: every locale silently falls
+back to the msgid, with no error to notice.
 
-**Nothing in this repository runs it today, deliberately.** The reference host
-is English-only, and its image (`python:3.13-slim`) installs no `gettext`, so
-`msgfmt` is unavailable there and adding the step would fail the build. A host
-adopting a non-English locale must install `gettext` in its image and run
-`compilemessages` alongside `collectstatic`; until then the shipped catalogs
-are inert at runtime — which is correct for an English-only deployment, but is
-the step to remember when that changes.
+The reference host wires this into its image build (`backend/Dockerfile`), and a
+reusing host needs the same two pieces:
+
+1. **`gettext` in the image** — it provides `msgfmt`. `gettext-base` is *not*
+   enough; it omits `msgfmt` and `compilemessages` fails with "Can't find
+   msgfmt".
+2. **`python manage.py compilemessages`** as a build step. It walks the tree
+   from the working directory collecting `locale/` dirs, so running it from the
+   project root picks up this package's catalog automatically — no
+   `LOCALE_PATHS` entry needed. Run it *before* `collectstatic` so the walk does
+   not traverse the collected static tree.
+
+Today this compiles only the `en` snapshot, which is a no-op at runtime — the
+point is that the pipeline is live, so adding `locale/de/` is the only step
+required to get real translations.
 
 Two deliberate omissions:
 

--- a/docs/LEARNINGS.md
+++ b/docs/LEARNINGS.md
@@ -1851,3 +1851,40 @@ Lesson: a passing mutation-check proves the test *can* fail; it does not prove
 you put the file back. And a coverage test that matches by substring is weaker
 than it reads — the failure mode is a green test over broken content, which is
 worse than no test.
+
+## 2026-07-26 — Translation catalogs shipped inert; two wrong assumptions about compilemessages (todo 262 follow-up)
+
+Todo 262 added `gettext_lazy` across `wagtail_forum` and committed a `.po`
+catalog, but nothing ever compiled it. Django reads the compiled `.mo`, never
+the `.po`, and `.mo` is gitignored as a build artifact — so a clean-checkout
+build shipped catalogs that were **silently inert**: every locale falls back to
+the msgid with no error, no warning, and a green test suite. The failure mode is
+invisible, which is why it survived a full review.
+
+Two assumptions I made along the way were wrong, both worth remembering:
+
+1. **`compilemessages` DOES walk the whole tree from cwd.** I first asserted it
+   only inspects `./conf/locale`, `./locale`, and `settings.LOCALE_PATHS` — which
+   would have meant `cd`-ing into the package or adding a `LOCALE_PATHS` entry.
+   Reading `django/core/management/commands/compilemessages.py` shows an explicit
+   `os.walk(".", topdown=True)` collecting every dir named `locale`. So running it
+   from the project root picks up installed-in-tree packages automatically. Verify
+   against the installed source, not memory — the basedirs list is only the start.
+   Corollary: run it **before** `collectstatic` so the walk doesn't traverse the
+   collected static tree, and pass `-i venv` locally or it descends into
+   site-packages and tries to compile Django's and Wagtail's own catalogs.
+2. **The apt package is `gettext`, not `gettext-base`.** `gettext-base` ships
+   only `gettext`/`ngettext`/`envsubst`; `/usr/bin/msgfmt` is in `gettext`
+   (confirmed against Debian's package index, then in the built image:
+   `msgfmt (GNU gettext-tools) 0.23.1`). Picking the wrong one fails the build
+   with compilemessages' own "Can't find msgfmt".
+
+Fix: `gettext` in the apt layer + `manage.py compilemessages` before
+`collectstatic` in `backend/Dockerfile`.
+
+Verification note worth repeating: **no CI job builds this image** (grep
+`.github/workflows/` for `docker build` — nothing), so Railway's build is
+otherwise the first exercise of any Dockerfile change, on a file that already
+needed four prod-only fixes during todo 261. Build it locally before merging.
+The proof that the step really ran is the timestamp: `django.mo` at build time vs
+`django.po` at checkout time — a copied-in artifact would share the source's.


### PR DESCRIPTION
Follow-up to #502 (todo 262). That PR shipped the forum i18n catalogs; **nothing compiled them.**

Django reads the compiled `.mo`, never the `.po`, and `.mo` is gitignored as a build artifact — so the catalogs shipped **inert**: every locale falls back to the msgid, with no error, no warning, and a green test suite. This wires the missing half.

## The change

Two lines in `backend/Dockerfile`:

1. **`gettext` in the apt layer** for `msgfmt`. Not `gettext-base` — that ships only `gettext`/`ngettext`/`envsubst` and omits `msgfmt`, failing the build with compilemessages' own "Can't find msgfmt".
2. **`manage.py compilemessages` before `collectstatic`**, using the same inline throwaway build-only env prefix as the existing collectstatic line (nothing baked into layers, `SecretsUsedInArgOrEnv` stays clean).

`compilemessages` walks the tree from cwd collecting `locale/` dirs, so running from `/app` finds the package catalog with no `LOCALE_PATHS` entry needed. Ordered before `collectstatic` so the walk doesn't traverse the 274 collected static files.

## Verified with a real `docker build`

This matters because **no CI job builds this image** — I grepped `.github/workflows/` for `docker build`/`build-push-action`: nothing. Railway's build would otherwise be the first exercise of these lines, on a Dockerfile that needed four prod-only fixes during todo 261. So I built it locally:

```
$ docker build -f backend/Dockerfile backend/ -t forum-verify
=> naming to docker.io/library/forum-verify:latest    DONE

$ docker run --rm forum-verify ls -l .../locale/en/LC_MESSAGES/
-rw-r--r-- 1 root root  380 Jul 26 21:15 django.mo     <- build time
-rw-r--r-- 1 root root 5903 Jul 26 17:10 django.po     <- checkout time

$ docker run --rm forum-verify sh -c "which msgfmt && msgfmt --version"
/usr/bin/msgfmt
msgfmt (GNU gettext-tools) 0.23.1
```

The **timestamp gap is the proof the step actually ran** — a copied-in artifact would share the source's mtime.

Also confirmed in the image:

- `compilemessages` processes **exactly one** catalog — forced it by touching the `.po`: `processing file django.po in /app/packages/wagtail_forum/wagtail_forum/locale/en/LC_MESSAGES`. It's the only `.po` in the context.
- Django discovers it at runtime: `all_locale_paths()` → `['/app/packages/wagtail_forum/wagtail_forum/locale']`
- The compiled catalog loads via `gettext.GNUTranslations` without error
- Re-running is idempotent (skips when `.mo` is newer)

## No visible effect today

The only catalog is `en` with every `msgstr` empty, so the compiled artifact is a no-op — which is why the reviewer should not expect any behaviour change. The point is that the pipeline is **live**: adding `locale/de/` is now the only step needed for real translations.

## Also

- README updated — #502 shipped text saying no build step compiled catalogs, which this makes false. It now documents the two pieces a reusing host needs.
- `docs/LEARNINGS.md` entry covering the inert-catalog trap and two assumptions I got wrong along the way (compilemessages *does* `os.walk` the tree — verified against the installed command source; and `gettext` vs `gettext-base`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)