### PR TITLE
forum(tests): pin bulk-unpublish user override with a direct unit test (todo 265)

### DIFF
--- a/backend/packages/wagtail_forum/wagtail_forum/tests/test_admin.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/tests/test_admin.py
@@ -298,6 +298,42 @@ def test_bulk_unpublish_action_unpublishes_selected_posts(client):
 
 
 @pytest.mark.django_db
+def test_bulk_unpublish_action_execution_context_carries_acting_user():
+    """Pins `ForumUnpublishBulkAction.get_execution_context()`'s
+    `user=self.request.user` override directly (todo 265).
+
+    The end-to-end `ModelLogEntry` assertion in the test above CANNOT catch
+    this override's removal. `wagtail.admin.auth.require_admin_access` wraps
+    every admin view in `LogContext(user=request.user)`, and
+    `LogActionRegistry.log()` does `user = user or
+    get_active_log_context().user` — so a bulk unpublish dispatched through a
+    real admin view is attributed to the acting moderator whether or not the
+    override exists. The override is load-bearing only against a future caller
+    outside that ambient context (the DRF paths pinned by
+    test_actor_attribution.py have no LogContext at all).
+
+    Same shape as test_schema.py::test_topic_list_view_guards_schema_generation:
+    when an ambient framework fallback supplies the same value, only a direct
+    unit test can pin the explicit override. Drop the override and this fails
+    with `None != <admin>` (`super()` returns `{"self": self}`, no user key).
+    """
+    from django.test import RequestFactory
+    from wagtail_forum.models import Post
+    from wagtail_forum.wagtail_hooks import ForumUnpublishBulkAction
+
+    admin = User.objects.create_superuser(username="ctxroot", email="ctx@x.io")
+    request = RequestFactory().post("/cms/bulk/wagtail_forum/post/unpublish/")
+    request.user = admin
+
+    action = ForumUnpublishBulkAction(request, Post)
+
+    # .get(), not ["user"]: with the override dropped this must be an
+    # unambiguous value mismatch, not a KeyError that could be mistaken for
+    # an unrelated crash during mutation verification.
+    assert action.get_execution_context().get("user") == admin
+
+
+@pytest.mark.django_db
 def test_bulk_unpublish_action_blocks_user_without_change_permission(client):
     # check_perm gates on wagtail_forum.change_post — a staff user who can
     # reach /cms/ (access_admin) but lacks that specific permission must not

--- a/docs/LEARNINGS.md
+++ b/docs/LEARNINGS.md
@@ -1935,3 +1935,50 @@ unproven. Adding the integration test before declaring the finding resolved is
 what turns "I found the file" into evidence. It also exposed that the test's
 `vi.mock` of `TipTapEditor` dropped the `content` prop, which would have made any
 restore assertion structurally unobservable (see `web/docs/patterns/testing.md`).
+
+## 2026-07-29 — An ambient framework fallback makes an explicit override unfalsifiable end-to-end (todo 265, wagtail/testing)
+
+Todo 265 sat blocked for two weeks on a single acceptance criterion: prove the
+new attribution test is non-vacuous by deleting the thing it pins. Deleting it
+didn't fail the test. Not a flaky test and not a bug — a fact about Wagtail
+worth writing down, because nothing in the code we own hints at it.
+
+`ForumUnpublishBulkAction.get_execution_context()`
+(`wagtail_forum/wagtail_hooks.py`) overrides `{"user": self.request.user}` so
+bulk take-downs attribute to the acting moderator. An end-to-end test asserting
+the resulting `ModelLogEntry.user == admin` passes **with or without that
+override**, because of this chain inside Wagtail:
+
+1. `wagtail/admin/auth.py::require_admin_access` — wraps *every* admin view
+   (a `BulkAction` is a `FormView` dispatched through the normal admin URL
+   conf, so it is included) in `with LogContext(user=user):`.
+2. `wagtail/log_actions.py::LogActionRegistry.log()` — `user = user or
+   get_active_log_context().user`.
+3. `UnpublishAction._unpublish_object()` passes `user=self.user` straight to
+   `log()`. With the override gone `self.user` is `None`, step 2's fallback
+   supplies the same admin user, and the assertion still holds.
+
+So the override is genuinely redundant *on the admin path* — and load-bearing
+everywhere else. `LogContext` only activates inside admin views, which is
+exactly why the DRF paths must pass the user explicitly (see
+`tests/test_actor_attribution.py`). Keep the override: it costs nothing and it
+is the correct thing for any future non-admin caller.
+
+**The generalizable lesson** (now in `docs/rules/testing.md`, as the second
+instance of a shape the `swagger_fake_view` bullet already recorded): when your
+code sets a value the framework would also supply by default on the path under
+test, an *outcome* assertion pins the framework, not your override. Unit-test
+the override's own return value. In that unit test prefer `.get(key)` over
+`[key]` — with the override dropped, `super()` returns `{"self": self}`, and a
+`KeyError` crash is weaker mutation evidence than `assert None == <User>`; the
+earlier session on this todo was nearly misled by exactly that confusion, having
+mistaken a `NameError` from a forgotten import for a red test.
+
+**Process note.** The 2026-07-13 session was right to refuse to flip the box —
+Safety Rail #4 has no `--force-complete`, and "the mutation didn't fail it" is
+not evidence of correctness. But refusing to flip is only half the move: the
+criterion's *text* encoded an assumption (that an end-to-end assertion could pin
+this) that investigation had disproved. Closing it required rewriting the
+criterion to state what is actually provable, then satisfying *that*. A todo
+that stalls on an unfalsifiable criterion usually needs its criterion repaired,
+not its evidence stretched.

--- a/docs/rules/testing.md
+++ b/docs/rules/testing.md
@@ -83,6 +83,22 @@ Compact checklist auto-injected before edits.
   call `get_queryset()` with no request/kwargs wired: it only survives if the
   guard short-circuits (guard missing → `KeyError` on `self.kwargs` → red).
   See `wagtail_forum/tests/api/test_schema.py`.
+- **An ambient framework fallback makes an explicit override
+  unfalsifiable-by-omission end-to-end — pin the override with a direct unit
+  test.** Generalization of the bullet above (second instance, so treat it as
+  the rule, not a one-off). Wagtail's `require_admin_access` wraps every admin
+  view in `LogContext(user=request.user)` and `LogActionRegistry.log()` does
+  `user = user or get_active_log_context().user`, so
+  `ForumUnpublishBulkAction.get_execution_context()`'s
+  `user=self.request.user` override can be deleted and the end-to-end
+  `ModelLogEntry` assertion still passes. Whenever your code sets a value the
+  framework would also supply by default on the tested path, an outcome
+  assertion pins the *framework*, not your override: unit-test the override's
+  own return value instead. Prefer `.get(key)` to `[key]` in that assertion —
+  a missing-key `KeyError` is weaker mutation evidence than a value mismatch,
+  and is easy to misread as an unrelated crash. See
+  `wagtail_forum/tests/test_admin.py::test_bulk_unpublish_action_execution_context_carries_acting_user`
+  (todo 265).
 - **"Comment out `permission_classes`" can be a NO-OP mutation.** With
   `DEFAULT_PERMISSION_CLASSES = IsAuthenticatedOrReadOnly`, a view with its
   `permission_classes` removed still blocks anonymous writes — the 401 test

--- a/docs/rules/testing.md
+++ b/docs/rules/testing.md
@@ -85,20 +85,13 @@ Compact checklist auto-injected before edits.
   See `wagtail_forum/tests/api/test_schema.py`.
 - **An ambient framework fallback makes an explicit override
   unfalsifiable-by-omission end-to-end — pin the override with a direct unit
-  test.** Generalization of the bullet above (second instance, so treat it as
-  the rule, not a one-off). Wagtail's `require_admin_access` wraps every admin
-  view in `LogContext(user=request.user)` and `LogActionRegistry.log()` does
-  `user = user or get_active_log_context().user`, so
-  `ForumUnpublishBulkAction.get_execution_context()`'s
-  `user=self.request.user` override can be deleted and the end-to-end
-  `ModelLogEntry` assertion still passes. Whenever your code sets a value the
-  framework would also supply by default on the tested path, an outcome
-  assertion pins the *framework*, not your override: unit-test the override's
-  own return value instead. Prefer `.get(key)` to `[key]` in that assertion —
-  a missing-key `KeyError` is weaker mutation evidence than a value mismatch,
-  and is easy to misread as an unrelated crash. See
+  test.** Second instance of the bullet above, so treat it as the rule: when
+  your code sets a value the framework would also supply by default on the
+  tested path, an outcome assertion pins the *framework*, not your override.
+  Prefer `.get(key)` to `[key]` there — a `KeyError` is weaker mutation
+  evidence than a value mismatch. See
   `wagtail_forum/tests/test_admin.py::test_bulk_unpublish_action_execution_context_carries_acting_user`
-  (todo 265).
+  and `docs/LEARNINGS.md` 2026-07-29 (todo 265).
 - **"Comment out `permission_classes`" can be a NO-OP mutation.** With
   `DEFAULT_PERMISSION_CLASSES = IsAuthenticatedOrReadOnly`, a view with its
   `permission_classes` removed still blocks anonymous writes — the 401 test

--- a/todos/archive/265-completed-p3-forum-moderation-test-gaps.md
+++ b/todos/archive/265-completed-p3-forum-moderation-test-gaps.md
@@ -1,5 +1,5 @@
 ---
-status: in_progress
+status: completed
 priority: p3
 issue_id: "265"
 tags: [forum, testing, moderation]
@@ -76,13 +76,18 @@ regression test pinning them.
       in `ModelLogEntry` after `ForumUnpublishBulkAction` runs
 - [x] A test asserts unauthenticated `POST` to the report endpoint returns
       401
-- [ ] Both new tests are non-vacuous: the mutations described in
-      Recommended Action step 3 make them fail — **partially true, see
-      "Cannot honestly flip" note in Work Log**: the 401 test's mutation
-      (`permission_classes` → `AllowAny`) does make it fail, verified. The
-      attribution test's prescribed mutation (dropping the
-      `get_execution_context()` override) does NOT make it fail — root
-      cause identified, not a defect in the test or the code.
+- [x] Both behaviors are pinned by a non-vacuous test — each prescribed
+      mutation makes a test fail with a real behavioral difference, not a
+      crash. **Scope correction (2026-07-29, see Work Log)**: the 401 test
+      satisfies this as originally written (`permission_classes` →
+      `[AllowAny]` → `assert 400 == 401`). The attribution behavior does NOT
+      — the *end-to-end* `ModelLogEntry` assertion is unfalsifiable-by-
+      omission on the admin path, because Wagtail's ambient `LogContext`
+      supplies the same user when the override is gone. It is instead pinned
+      by a direct unit test on `get_execution_context()`
+      (`test_bulk_unpublish_action_execution_context_carries_acting_user`),
+      which the prescribed mutation *does* fail (`assert None == <User>`),
+      mirroring `test_schema.py`'s `swagger_fake_view` precedent.
 - [x] Full `wagtail_forum` + `forum_host` suite green
 
 ## Work Log
@@ -195,6 +200,92 @@ box or invent an artificial mutation to make it "pass."
   override itself (not just the outcome) is judged worth the extra test.
 - Left in `in_progress` state (filename unchanged) per the skill's
   skip-todo protocol; NOT moved to `todos/archive/`.
+
+### 2026-07-29 - Resumed and closed by completing-todos skill (run 2026-07-29-0207)
+
+Took option (b) from the 2026-07-13 skip note — write a differently-shaped
+test that pins the override directly — rather than option (a) (close by
+analysis). The prior session's root cause was correct and is now the
+*documented reason* for the test's shape rather than a reason to leave the
+criterion open.
+
+**The repair.** Added
+`test_bulk_unpublish_action_execution_context_carries_acting_user` to
+`tests/test_admin.py`: instantiate `ForumUnpublishBulkAction(request, Post)`
+with a `RequestFactory` request (no admin view, therefore no ambient
+`LogContext`) and assert `get_execution_context().get("user") == admin`.
+This is the same shape `docs/rules/testing.md` already prescribes for the
+`swagger_fake_view` guard (`tests/api/test_schema.py::test_topic_list_view_guards_schema_generation`)
+— when an end-to-end test can't detect a guard's removal, pin the guard
+directly. `.get("user")`, not `["user"]`, deliberately: with the override
+dropped `super()` returns `{"self": self}`, and a `KeyError` crash would be
+weaker mutation evidence than a value mismatch (the 2026-07-13 session was
+nearly misled by exactly that — a `NameError` mistaken for a red test).
+
+**Mutation check 1 — the override (the one that was unfalsifiable before).**
+Dropped `"user": self.request.user` from `get_execution_context()`:
+
+```
+test_bulk_unpublish_action_unpublishes_selected_posts PASSED   [ 33%]
+test_bulk_unpublish_action_execution_context_carries_acting_user FAILED [ 66%]
+test_bulk_unpublish_action_blocks_user_without_change_permission PASSED [100%]
+
+E   AssertionError: assert None == <User: ctxroot>
+E    +      where {'self': <...ForumUnpublishBulkAction object...>} = get_execution_context()
+1 failed, 2 passed, 10 deselected
+```
+
+Note the first line: the end-to-end `ModelLogEntry` test still passes under
+the mutation, independently reproducing the 2026-07-13 finding. The new test
+is what turns the override falsifiable. Restored from a pre-mutation backup;
+`git status` confirmed `wagtail_hooks.py` clean.
+
+**Mutation check 2 — the 401 test, re-verified first-hand** (not taken on
+the prior session's word). Mutated `PostReportView.permission_classes` to
+`[AllowAny]`, with the import added in the same write as its use (the
+formatter strips orphaned imports between edits — the 2026-07-13 `NameError`):
+
+```
+E   assert 400 == 401
+E    +  where 400 = <Response status_code=400, "application/json">.status_code
+FAILED tests/api/test_reports.py::test_unauthenticated_report_is_rejected
+1 failed, 9 passed
+```
+
+A real behavioral difference (the anonymous request reaches the serializer and
+trips the self-report validator), not a crash. Restored; `git status` clean.
+
+**Full suite (criterion 4, re-confirmed).**
+`pytest packages/wagtail_forum/ apps/forum_host/ -q --create-db` →
+`533 passed, 2 warnings in 40.28s`. Baseline on `main` before the change was
+`532 passed`; the delta is exactly the one new test. (`--create-db`, not
+`--reuse-db`: these tests create Wagtail pages under root, and a reused DB
+can carry a truncated page tree.)
+
+**Scope correction, not a box-flip.** Criterion 3's text was rewritten before
+checking it, so the record says what was actually proven: the attribution
+*behavior* is pinned, but by a unit test on the override rather than by the
+end-to-end assertion the finding originally assumed. The override itself was
+left in place — it is correct, costs nothing, and is load-bearing for any
+future caller outside an admin view's `LogContext`.
+
+### 2026-07-29 - Completed by completing-todos skill (run 2026-07-29-0207)
+
+- Verification: all 4 acceptance criteria met. Criterion 3 required rewriting
+  its own text (it encoded a disproved assumption) before it could be
+  honestly satisfied — see the entry above for both mutation transcripts.
+- Review: `code-review-orchestrator` returned **0 findings** — "Test is
+  correct, non-vacuous, follows all conventions, and docstring claims are
+  factually accurate." Nothing blocking, nothing to repair, no `Known issues`.
+- Codified: generalized rule added to `docs/rules/testing.md` (an ambient
+  framework fallback makes an explicit override unfalsifiable-by-omission —
+  pin it with a direct unit test; prefer `.get(key)` to `[key]` there), and a
+  `docs/LEARNINGS.md` entry documenting the
+  `require_admin_access` → `LogContext` → `log(user=user or
+  get_active_log_context().user)` chain. Both docs-only, added after the
+  review dispatch, so they are outside its scope.
+- No `source_review`/`source_finding` in frontmatter (see Notes), so the
+  skill's source-review check-off step is a deliberate no-op.
 
 ## Notes
 


### PR DESCRIPTION
Closes todo 265's last open acceptance criterion, which had blocked archival since 2026-07-13.

## The blocker

Todo 265 asked for a mutation check: delete `ForumUnpublishBulkAction.get_execution_context()`'s `user=self.request.user` override and confirm the attribution test goes red. It didn't. The July 13 session correctly refused to flip the box on unproven evidence and left the todo `in_progress`.

That turned out to be a fact about Wagtail, not a defect:

1. `wagtail/admin/auth.py::require_admin_access` wraps **every** admin view — a `BulkAction` is a `FormView` on the normal admin URL conf, so it's included — in `with LogContext(user=user):`.
2. `wagtail/log_actions.py::LogActionRegistry.log()` does `user = user or get_active_log_context().user`.
3. `UnpublishAction._unpublish_object()` passes `user=self.user` straight through. With the override gone `self.user` is `None`, step 2's fallback supplies the same admin user, and the end-to-end `ModelLogEntry` assertion still holds.

So the override is redundant *on the admin path* and load-bearing on every other one — `LogContext` only activates inside admin views, which is exactly why the DRF paths in `test_actor_attribution.py` must pass the user explicitly. **The override stays.** It costs nothing and is correct for any future non-admin caller.

## The repair

Adds `test_bulk_unpublish_action_execution_context_carries_acting_user`, which unit-tests the override's return value directly against a `RequestFactory` request (no admin view → no ambient `LogContext`). This is the same shape `docs/rules/testing.md` already prescribes for the `swagger_fake_view` guard, where an end-to-end test likewise can't detect a guard's removal — so this is the second instance of the pattern, not a one-off.

Asserts via `.get("user")` rather than `["user"]`: with the override dropped `super()` returns `{"self": self}`, and a `KeyError` is weaker mutation evidence than a value mismatch. The prior session was nearly misled by exactly that confusion, having mistaken a `NameError` from a forgotten import for a red test.

## Verification

Both mutations run first-hand, each restored from a pre-mutation backup with `git status` confirmed clean after:

| mutation | result |
|---|---|
| drop the `user` override | `assert None == <User: ctxroot>` — new test red, **end-to-end test still green**, independently reproducing the original finding |
| `permission_classes = [AllowAny]` | `assert 400 == 401` — the 401 test red with a real behavioral difference, not a crash |

Suite: `533 passed` (baseline on `main` was `532`; the delta is exactly the new test). Run with `--create-db` — these tests create Wagtail pages under root and a reused DB can carry a truncated page tree.

`code-review-orchestrator`: **0 findings.**

## Record integrity

Acceptance criterion 3's text was rewritten *before* checking it. It previously read "...does NOT make it fail"; a checked box over that text would be a false record that nobody re-audits. It now states what is actually provable: the behavior is pinned, but by a unit test on the override rather than by the end-to-end assertion the original finding assumed.

## Codified

- `docs/rules/testing.md` — generalized rule: when an ambient framework fallback supplies the same value your code sets explicitly, an outcome assertion pins the *framework*, not your override; unit-test the override's own return value.
- `docs/LEARNINGS.md` — the `require_admin_access` → `LogContext` → `log(user=user or ...)` chain, which isn't derivable from the code we own and cost a full session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)