### PR TITLE
forum(docs): close read-state edge cases — dispositions for #1/#2 (todo 271)

### DIFF
--- a/backend/packages/wagtail_forum/wagtail_forum/api/views.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/api/views.py
@@ -512,8 +512,38 @@ class TopicDetailView(PrivateForumReadCacheMixin, generics.RetrieveAPIView):
     def retrieve(self, request, *args, **kwargs):
         response = super().retrieve(request, *args, **kwargs)
         # Increment view_count after a successful 200, deduplicated per viewer.
-        # Uses on_commit so the UPDATE runs outside the serialization transaction
-        # and does not inflate the pinned query count for the response itself.
+        #
+        # on_commit timing — accepted as-is, decided 2026-07-29 (todo 271 #2).
+        # Read the `on_commit` calls in this method as ordering/fail-safe
+        # constructs, NOT as "this write is deferred past the request." This
+        # project runs ATOMIC_REQUESTS=False and nothing wraps retrieve() in an
+        # explicit atomic(), so `connection.in_atomic_block` is False here and
+        # Django's autocommit branch (db/backends/base/base.py::on_commit,
+        # verified against Django 6.0.7) executes the callback IMMEDIATELY,
+        # inline, inside this same request. Both callbacks below are therefore
+        # a real, uncounted cost on every qualifying topic-detail GET in
+        # production.
+        #
+        # Note the asymmetry that hides this: under @pytest.mark.django_db the
+        # test body IS inside an atomic block, so on_commit takes the deferring
+        # branch and the callback is rolled back without ever running. That is why
+        # test_topic_detail.py's read-recording tests need the
+        # django_capture_on_commit_callbacks fixture at all — and why its
+        # test_view_count_does_not_add_queries_to_response can legitimately pin
+        # 4 queries. That pin is honest about the test and says nothing about
+        # production; do not read it as evidence these callbacks are free.
+        #
+        # Accepted rather than wrapped in atomic() or moved to Celery: an
+        # atomic() wrap buys deferral-to-commit and isolation hygiene, not a
+        # smaller production query count (the work still happens in-request);
+        # and the writes are two cheap dedup-gated UPDATEs on a read path with
+        # no user-facing symptom.
+        # `robust=True` on _mark_read is still load-bearing on this path —
+        # the autocommit branch honors it (same source), so a failure logs
+        # instead of turning an already-successful 200 into a 500. Revisit
+        # trigger: topic-detail p99 regressing, or a third callback landing
+        # here. Do not re-litigate per-slice.
+        #
         # The cache key is scoped per (topic, viewer) — authenticated users key on
         # their pk; anonymous requests key on the client IP so a single browser
         # session doesn't multi-count. The TTL is host-configurable via

--- a/backend/packages/wagtail_forum/wagtail_forum/models/profiles.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/models/profiles.py
@@ -53,13 +53,34 @@ class ForumProfile(models.Model):
     # showed up," since `user.date_joined` is off-limits here (AbstractUser-
     # only, not part of the AbstractBaseUser contract this package assumes).
     #
-    # Known gap (todo 271): for_user() is called from several trigger points
-    # beyond "this user opened a topic" — MeProfileView and the push-delivery
-    # task (forum_host/tasks.py) both create a profile as a side effect of
-    # unrelated actions. For a pre-ship "sleeper" account, whichever of these
-    # fires first stamps read_watermark_at=now and silently collapses that
-    # user's entire pre-existing unread backlog, not just the topic (if any)
-    # they were actually looking at. Not fixed here — see the todo.
+    # Accepted tradeoff, decided 2026-07-29 (todo 271 #1) — read this as the
+    # standing disposition, not a stale TODO. for_user() is the package's lazy
+    # profile-creation entry point and is reached from five non-test calls
+    # across four modules, only ONE of which means "this user read something":
+    #   * api/views.py TopicDetailView.retrieve   — a genuine read
+    #   * api/views.py MeProfileView.get_object   — fetching one's own profile
+    #   * workflow.py (x2)                        — trust check when the user
+    #                                               submits a post
+    #   * forum_host/tasks.py                     — push delivery, i.e. a
+    #                                               THIRD PARTY's action
+    # And for_user() is not even the only creation path: signals.py's
+    # _refresh_profile calls ForumProfile.objects.get_or_create(user_id=...)
+    # directly on every post-count/trust recount, bypassing this classmethod.
+    # Whichever fires first stamps read_watermark_at=now, so for a pre-ship
+    # "sleeper" account (no profile row yet) an unrelated trigger can collapse
+    # that user's whole pre-existing unread backlog forest-wide, not just the
+    # topic they were looking at (a push delivery involves no looking at all).
+    # Accepted because: no live complaint; the blast radius is one cohort
+    # (accounts predating the profile row) times one cosmetic signal (badge
+    # state); and the genuine read path (TopicDetailView.retrieve's _mark_read
+    # on_commit callback) already collapses the backlog forest-wide by design,
+    # per its own comment there — so the non-read triggers differ in
+    # propriety, not in effect. Re-scope trigger: an actual "why did my unread
+    # badges disappear" report. The concrete candidate fix — seed the initial
+    # watermark from `getattr(user, "date_joined", None)` so it derives from a
+    # stable per-user fact instead of wall-clock-at-first-touch — is tracked
+    # as todo 285, deliberately NOT bundled here (it changes unread semantics
+    # for every existing account).
     read_watermark_at = models.DateTimeField(default=timezone.now)
 
     @classmethod

--- a/backend/packages/wagtail_forum/wagtail_forum/tests/api/test_topic_detail.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/tests/api/test_topic_detail.py
@@ -200,6 +200,12 @@ def test_view_count_recounts_after_dedup_window_expires(
 def test_view_count_does_not_add_queries_to_response():
     # on_commit fires AFTER the response transaction; the pinned query count
     # for the response itself must be unchanged (still 4).
+    # This pin is about THIS TEST, not about production. django_db wraps the
+    # body in an atomic block, so on_commit really does defer here (and rolls
+    # back unrun) — in production, autocommit + ATOMIC_REQUESTS=False makes the
+    # same callback run inline. See TopicDetailView.retrieve's comment and
+    # docs/LEARNINGS.md (todo 271, 2026-07-29). Do not cite this 4 as evidence
+    # that the view_count/TopicRead writes are free in production.
     cache.clear()
     board = _board(slug="vc-board5")
     author = User.objects.create_user(username="vcq")

--- a/docs/LEARNINGS.md
+++ b/docs/LEARNINGS.md
@@ -2058,3 +2058,62 @@ anchor beside the number — a function name or a JSX comment such as
 `{/* Toolbar */}` — so a drifted line can be re-found by searching for the anchor
 instead of silently pointing at unrelated code. Three citations in this very doc
 had drifted onto an empty line, a `useState`, and an extension import.
+
+## Django `on_commit` under autocommit (todo 271, 2026-07-29)
+
+**`transaction.on_commit(fn)` does not defer anything when there is no open
+transaction.** This project runs `ATOMIC_REQUESTS = False`, so unless a view
+explicitly opens `transaction.atomic()`, `connection.in_atomic_block` is
+`False` — and Django's autocommit branch
+(`db/backends/base/base.py::on_commit`, read against the installed Django
+6.0.7) executes the callback **immediately and inline**, in the same request,
+on the same connection:
+
+```python
+def on_commit(self, func, robust=False):
+    if self.in_atomic_block:
+        self.run_on_commit.append((set(self.savepoint_ids), func, robust))
+    elif not self.get_autocommit():
+        raise TransactionManagementError(...)
+    else:
+        # No transaction in progress and in autocommit mode; execute immediately.
+        if robust: ... try/except/logger.error ...
+        else: func()
+```
+
+**Lesson**: "I moved that write to `on_commit`, so it's outside the request /
+doesn't count against the query pin" is false in production here, and it is an
+easy thing to write into a docstring and have nobody re-check.
+
+**And a pinned-query test cannot catch it, because the test suite is the one
+place where the deferral is real.** Under `@pytest.mark.django_db` (and Django's
+`TestCase`) the test body runs *inside* an atomic block, so `on_commit` takes
+the deferring branch and the callback is rolled back without ever running. So a
+`CaptureQueriesContext` assertion legitimately measures N queries while
+production runs N+2 — the test is honest about itself and silent about
+production. The tell that a suite is in this situation: tests that need
+`django_capture_on_commit_callbacks` (or `TestCase.captureOnCommitCallbacks`) to
+observe the write at all, sitting next to a query-count pin that doesn't use it.
+Verify empirically before asserting deferral — `connection.in_atomic_block` in a
+`manage.py shell` around a real `APIClient` call settles the production side in
+one line. Concretely wrong-then-corrected instance:
+`wagtail_forum/api/views.py`'s `TopicDetailView.retrieve()` claimed its
+`view_count` increment "runs outside the serialization transaction and does not
+inflate the pinned query count"; both its callbacks are in fact real, uncounted
+per-request cost. Now documented as an accepted tradeoff at that call site.
+
+**The one guarantee that does survive autocommit**: `robust=True` is honored on
+the immediate path too (see the `if robust:` branch above), so a fail-safe
+`on_commit(fn, robust=True)` still prevents a side-effect exception from
+turning an already-successful 200 into a 500. That property is real; the
+deferral is not.
+
+**Corollary for reusable packages**: `on_commit` behavior is a property of the
+*host's* transaction configuration, not the package's. A package view that
+needs its callbacks to actually defer-until-commit must open its own `atomic()`
+rather than assume the host set `ATOMIC_REQUESTS`. Note what that does and does
+not buy: `atomic()` restores the deferral `on_commit` advertises (run after this
+transaction commits, skip if it rolls back), which is a correctness/isolation
+property. It does **not** move the work out of the request — the callback still
+runs synchronously before the response returns. Getting work off the request
+needs a real task queue (Celery), not `atomic()`.

--- a/docs/rules/database.md
+++ b/docs/rules/database.md
@@ -89,3 +89,21 @@ Compact checklist auto-injected before edits. Long-form:
   `AlterField` for it, and do not avoid i18n out of migration fear. This is the
   opposite of a *value* change (`("spam", "Spam")` -> `("spam", "Junk")`), which
   DOES generate one — see migration `wagtail_forum/0015_alter_notification_verb`.
+- **`transaction.on_commit()` defers NOTHING when no transaction is open — and
+  the test suite is the one place where it does defer, so no pinned-query test
+  can catch the difference.** This project runs `ATOMIC_REQUESTS = False`, so
+  unless a view opens an explicit `atomic()`, Django's autocommit branch
+  (`db/backends/base/base.py::on_commit`, verified against Django 6.0.7) runs
+  the callback IMMEDIATELY and inline, inside the request. Under
+  `@pytest.mark.django_db` (and `TestCase`) the body IS inside an atomic block,
+  so the same callback defers and is rolled back unrun — which is why observing
+  it needs `django_capture_on_commit_callbacks`. Consequence: a
+  `CaptureQueriesContext`/`assertNumQueries` pin can honestly read N while
+  production runs N+2. Never write "moved to on_commit, so it's outside the
+  request / doesn't count against the pin" — check `connection.in_atomic_block`
+  instead. `robust=True` IS still honored on the immediate path, so the
+  don't-500-an-already-successful-200 fail-safe survives; only the deferral
+  doesn't. For a reusable package this is the HOST's configuration, not yours:
+  open your own `atomic()` if you need real defer-until-commit, and reach for
+  Celery if you need the work off the request — `atomic()` does not do that.
+  See `docs/LEARNINGS.md` 2026-07-29 (todo 271).

--- a/docs/rules/triggers.json
+++ b/docs/rules/triggers.json
@@ -722,5 +722,24 @@
     "source": "codify: todo/270-forum-mobile-roadmap-reaudit",
     "added": "2026-07-29",
     "severity": "warn"
+  },
+  {
+    "id": "on_commit-no-deferral-claim",
+    "added": "2026-07-29",
+    "domains": [
+      "database",
+      "testing"
+    ],
+    "path_glob": [
+      "backend/**/views.py",
+      "backend/**/tasks.py",
+      "backend/**/signals.py",
+      "backend/**/models/*.py"
+    ],
+    "content_present": "transaction\\.on_commit|connection\\.on_commit",
+    "message": "transaction.on_commit() does NOT defer here: ATOMIC_REQUESTS=False and no explicit atomic() means Django's autocommit branch runs the callback immediately, inline, in-request. Do not claim it is deferred, outside the request, or free of the pinned query count. Note the trap: under @pytest.mark.django_db the callback DOES defer (and rolls back unrun), so a green assertNumQueries pin cannot detect the production cost. robust=True is still honored on the immediate path.",
+    "pattern_ref": "docs/rules/database.md",
+    "severity": "warn",
+    "source": "todos/archive 271"
   }
 ]

--- a/todos/285-pending-p3-forum-read-watermark-from-date-joined.md
+++ b/todos/285-pending-p3-forum-read-watermark-from-date-joined.md
@@ -1,0 +1,95 @@
+---
+status: pending
+priority: p3
+issue_id: "285"
+tags: [backend, forum, notifications]
+dependencies: []
+---
+
+# Forum unread: seed `read_watermark_at` from a stable per-user fact, not first-touch wall clock
+
+## Problem
+
+Re-scoped out of todo 271 #1 (2026-07-29). `ForumProfile.read_watermark_at`
+defaults to `timezone.now` at row-creation time, and `ForumProfile.for_user()`
+— the lazy creation entry point — is reached from four non-test call sites,
+only one of which means "this user read something":
+
+| Call site | Is it a read? |
+|---|---|
+| `wagtail_forum/api/views.py` `TopicDetailView.retrieve` | yes |
+| `wagtail_forum/api/views.py` `MeProfileView.get_object` | no — fetching own profile |
+| `wagtail_forum/workflow.py` (x2) | no — trust check when submitting a post |
+| `apps/forum_host/tasks.py` | no — **a third party's** push delivery |
+
+For a pre-ship "sleeper" account (no profile row yet), whichever fires first
+stamps `read_watermark_at = now()` and collapses that user's whole
+pre-existing unread backlog forest-wide. Todo 271 accepted this as a
+documented tradeoff (see the field comment in
+`wagtail_forum/models/profiles.py`) — this todo tracks the actual fix.
+
+## Recommended Action
+
+Seed the initial watermark from a stable per-user fact instead of
+wall-clock-at-first-touch, so *which* trigger creates the row stops mattering:
+
+```python
+joined = getattr(user, "date_joined", None)
+defaults = {"read_watermark_at": joined} if joined else {}
+profile, _ = cls.objects.get_or_create(user=user, defaults=defaults)
+```
+
+`getattr` with a fallback keeps this host-agnostic — `date_joined` is
+`AbstractUser`-only, not part of the `AbstractBaseUser` contract the package
+assumes, so a host without it falls back to today's exact behavior. Effects:
+
+- **Sleeper account** — `date_joined` predates launch, so `Coalesce(TopicRead,
+  watermark, UNREAD_LAUNCH_AT)` resolves to a pre-launch watermark and they
+  correctly see their real backlog (there is no pre-launch forum content, so
+  the flood stays bounded by launch either way).
+- **Genuinely new signup** — `date_joined ≈ now`, i.e. unchanged from today.
+
+Decide explicitly whether existing rows get a data migration or are left
+alone; leaving them alone is defensible (migration 0016 already backfilled
+them to a sane value).
+
+## Technical Details
+
+- `backend/packages/wagtail_forum/wagtail_forum/models/profiles.py` —
+  `read_watermark_at` field + `ForumProfile.for_user()`.
+- `backend/packages/wagtail_forum/wagtail_forum/api/views.py` —
+  `_annotate_topic_unread` is the only consumer of the watermark.
+- **Test wrinkle to fix while here**: `tests/test_profiles.py::
+  test_for_user_stamps_read_watermark_at_creation_time` asserts
+  `before <= profile.read_watermark_at <= after` around a
+  `User.objects.create_user(...)` call. `create_user` sets `date_joined` to
+  now, *inside* that window — so the test would keep passing under the change
+  above while no longer testing what its name says. Rewrite it to create the
+  user with an explicit backdated `date_joined` and assert the watermark
+  tracks that, plus a case for a user object with no `date_joined` at all.
+
+## Acceptance Criteria
+
+- [ ] `for_user()` seeds `read_watermark_at` from `date_joined` when the host
+      user model exposes it, falling back to today's behavior when it doesn't
+- [ ] `test_for_user_stamps_read_watermark_at_creation_time` rewritten so it
+      fails if the derivation regresses (backdated `date_joined`, not a
+      coincidentally-in-window `now`)
+- [ ] A test covering a user model without `date_joined` (fallback path)
+- [ ] An explicit decision recorded on existing rows: data migration or leave
+- [ ] `wagtail_forum/models/profiles.py`'s todo-271 acceptance comment updated
+      to reflect that the gap is now closed
+
+## Work Log
+
+### 2026-07-29 - Created
+
+- Re-scoped out of todo 271 #1 rather than bundled into it: todo 271 is a p3
+  doc-closure item and this changes unread semantics for every existing
+  account, which wants its own diff and its own review.
+
+## Notes
+
+p3 — no live user complaint behind it; the symptom is cosmetic (badge state)
+and bounded to accounts predating their own profile row. Related: todo 271
+(origin), todo 253 slice 5 / audit H10 (the unread feature itself).

--- a/todos/archive/271-completed-p3-forum-unread-read-state-edge-cases.md
+++ b/todos/archive/271-completed-p3-forum-unread-read-state-edge-cases.md
@@ -1,5 +1,5 @@
 ---
-status: pending
+status: completed
 priority: p3
 issue_id: "271"
 tags: [backend, forum, notifications, performance]
@@ -114,8 +114,8 @@ already (originally deferred) before being revisited the same day.
 
 ## Acceptance Criteria
 
-- [ ] #1: re-scoped or explicitly accepted as a permanent, documented tradeoff
-- [ ] #2: a decision recorded (atomic-wrap / async / accept-as-is) — doesn't
+- [x] #1: re-scoped or explicitly accepted as a permanent, documented tradeoff
+- [x] #2: a decision recorded (atomic-wrap / async / accept-as-is) — doesn't
       require code if "accept-as-is" is chosen
 - [x] #3: `TopicRead.mark_read` called from the reply-created path so an
       author's own reply doesn't self-flag as unread, with a test
@@ -164,10 +164,134 @@ already (originally deferred) before being revisited the same day.
   `test_topic_created_auto_subscribes_the_author` shapes exactly:
   `test_reply_added_marks_the_repliers_own_topic_as_read`,
   `test_topic_created_marks_the_authors_own_topic_as_read`,
-  `test_topic_created_with_no_opening_post_does_not_mark_read`.
+  `test_topic_created_with_no_opening_post_does_not_mark_read`,
+  `test_reply_added_read_marker_keeps_pace_with_real_publish_timing`.
+  (The 4th was omitted from this list when it was first written — count
+  corrected 2026-07-29 against the file, which has all four.)
 - Re-verified: `apps/forum_host/tests/` + `packages/wagtail_forum/wagtail_forum/tests/`
   full pass, `manage.py check` clean, `makemigrations --check --dry-run` →
   "No changes detected" (no model changes, notifications.py only).
+
+### 2026-07-29 - #1 and #2 dispositioned; completed by completing-todos skill
+
+**Verification note (honest framing):** AC1 and AC2 are decision-type criteria.
+There is no command whose output proves "a decision was recorded" — the
+evidence is the durable artifact, cited by file below, not a test run. No
+command output is quoted for those two flips because none would mean anything.
+The supporting test/lint runs below are evidence that the edits are *safe*, not
+that the decisions are *right*.
+
+**#1 (watermark scope) — accepted as a permanent, documented tradeoff, AND
+the fix re-scoped into its own todo.** Both branches of the AC, deliberately:
+
+- Acceptance record written into
+  `wagtail_forum/models/profiles.py`, on the `read_watermark_at` field —
+  self-contained (date, the full call-site enumeration, rationale, and an
+  explicit re-scope trigger), because this todo file is being archived and a
+  comment that says "see the todo" rots the moment it moves.
+- Enumerated the real triggers by grepping non-test call sites rather than
+  trusting this doc's original two-site claim. There are **five**, not two:
+  `TopicDetailView.retrieve` (the only genuine read), `MeProfileView.get_object`,
+  `workflow.py` x2 (trust check on post submission),
+  `forum_host/tasks.py` (push delivery — a *third party's* action), plus
+  `signals.py::_refresh_profile`, which calls
+  `ForumProfile.objects.get_or_create(user_id=...)` **directly**, bypassing
+  `for_user()` entirely. The last one was caught by the review pass, not by me.
+- Key reason acceptance is defensible and was not obvious from this doc: the
+  *genuine* read path at `views.py` already collapses the backlog forest-wide
+  by design (documented in its own comment). So the non-read triggers differ
+  from the sanctioned one in propriety, not in effect.
+- Re-scoped fix → **todo 285**: seed the initial watermark from
+  `getattr(user, "date_joined", None)` so it derives from a stable per-user
+  fact instead of wall-clock-at-first-touch. Deliberately NOT bundled here —
+  it changes unread semantics for every existing account and wants its own
+  diff and review, and this todo's own Recommended Action said "no action
+  without a concrete complaint." Todo 285 also records a trap: the existing
+  `test_for_user_stamps_read_watermark_at_creation_time` would keep passing
+  under that change by coincidence (`create_user` sets `date_joined` inside
+  the assertion window) while no longer testing its own name.
+
+**#2 (on_commit timing) — decision: ACCEPT AS-IS.** Recorded in
+`wagtail_forum/api/views.py`, in `TopicDetailView.retrieve()`.
+Rationale, and two corrections to this doc's original analysis:
+
+- Verified the load-bearing claim against the *installed* Django (6.0.7,
+  `venv/.../django/db/backends/base/base.py::on_commit`) rather than from
+  memory: the autocommit branch honors `robust=True` (try/except →
+  `logger.error`). So `_mark_read`'s fail-safe genuinely works on the
+  immediate path, which is what makes accept-as-is safe rather than merely
+  convenient.
+- An `atomic()` wrap was rejected: it buys defer-until-commit and isolation
+  hygiene, not a smaller production query count — the work still runs
+  in-request. Celery was rejected as disproportionate for two dedup-gated
+  UPDATEs with no user-facing symptom. Revisit trigger recorded: topic-detail
+  p99 regression, or a third callback landing in that method.
+- **Correction to this doc's #2 text**: it framed the cost as landing inside
+  the pinned-query measurement. That is right for production and *wrong for
+  the test suite*, which is the whole trap. Under `@pytest.mark.django_db`
+  the test body is itself inside an atomic block, so `on_commit` really does
+  defer and the callback is rolled back without ever running. That is why the
+  read-recording tests need the `django_capture_on_commit_callbacks` fixture,
+  and why `test_topic_detail.py::test_view_count_does_not_add_queries_to_response`
+  can legitimately pin 4 queries. The pin is honest about the test and silent
+  about production — so no pinned-query test can ever catch this cost.
+  Annotated that test's own comment accordingly, since it stated the
+  deferral unqualified and was the most likely thing to be re-cited later.
+- Also corrected: this doc pointed at `test_topics_list.py` for the pin.
+  That file has no query-count assertion at all; the pin is in
+  `test_topic_detail.py`.
+
+**Codified** → `docs/LEARNINGS.md`, new section "Django `on_commit` under
+autocommit (todo 271, 2026-07-29)": on_commit does not defer without an open
+transaction; the test-vs-production asymmetry and its tell; `robust=True`
+survives the immediate path; and the reusable-package corollary (on_commit
+behavior is the *host's* configuration, not the package's).
+
+**Doc-accuracy fix:** the 2026-07-16 entry above said "4 new tests" and then
+listed 3. The file has 4 — `test_reply_added_read_marker_keeps_pace_with_real_publish_timing`
+was the omitted one. Enumeration corrected in place.
+
+**AC3 re-verified (was already checked):**
+`TopicRead.mark_read` present in both branches of
+`apps/forum_host/notifications.py` — `reply_added` (line 163) and
+`topic_created` (line 280).
+
+**Evidence (safety of the edits, not correctness of the decisions):**
+
+- `python manage.py check` → `System check identified no issues (0 silenced).`
+- `python manage.py makemigrations --check --dry-run` → `No changes detected`
+  (confirms the profiles.py edit is comment-only and did not touch the field).
+- `python -m pytest apps/forum_host packages/wagtail_forum --create-db` →
+  `533 passed` (single serial invocation, `--create-db` per the page-creating
+  suite rule). Re-run after the review repairs: `533 passed`.
+- `flake8` on all edited Python files → exit 0.
+
+**Review:** `code-review-orchestrator`, 4 findings (2 high, 2 medium), all
+documentation-accuracy findings on a comment-only Python diff. All 4 verified
+against primary evidence before acting — 3 confirmed and repaired (the
+test-vs-production framing, the LEARNINGS "regardless" overstatement, the
+missing `signals.py` creation path), 1 partially rejected in its reasoning
+but repaired anyway (the corollary: `atomic()` *does* deliver on_commit's
+advertised defer-until-commit, so the reviewer's "atomic() doesn't achieve
+deferral" is too strong — but the wording was genuinely ambiguous between
+"deferred past commit" and "off the request", so it was disambiguated).
+Re-review after repair returned `{"findings": []}`.
+
+### 2026-07-29 - Completed by completing-todos skill (run 2026-07-29-0342)
+
+- Verification: all 3 acceptance criteria satisfied. #3 was already done
+  (2026-07-16) and re-verified by code trace; #1 and #2 are decision-type
+  criteria closed by durable recorded decisions at
+  `wagtail_forum/models/profiles.py` (`read_watermark_at`) and
+  `wagtail_forum/api/views.py` (`TopicDetailView.retrieve`) respectively —
+  no command output can prove a decision, so none is claimed for those two.
+  Supporting safety evidence: `manage.py check` clean,
+  `makemigrations --check` "No changes detected", 533 tests passed, flake8
+  exit 0.
+- Review: 4 findings (2 high, 2 medium), all documentation-accuracy on a
+  comment-only Python diff; 4 repaired, 0 accepted-unaddressed; re-review
+  clean.
+- Spun out: todo 285 (seed `read_watermark_at` from `date_joined`).
 
 ## Notes
 


### PR DESCRIPTION
Closes todo 271. Three read-state edge cases came out of the todo 253 slice 5 review; #3 shipped 2026-07-16, and this closes #1 and #2 — both decision-type acceptance criteria.

**No executable line changes.** `makemigrations --check --dry-run` reports "No changes detected"; the 533-test forum suite passes. The review surface here is the factual accuracy of the claims these comments now make.

## #1 — `read_watermark_at` scope: accepted *and* re-scoped

Both branches of the AC, deliberately. The acceptance record moves into the `read_watermark_at` field comment so it survives this todo's archival (a comment saying "see the todo" rots the moment the todo moves).

I re-grepped the triggers instead of trusting the todo's two-site claim. There are **five** non-test calls across four modules — and `for_user()` isn't even the only creation path: `signals.py::_refresh_profile` calls `ForumProfile.objects.get_or_create(user_id=...)` directly, bypassing it. That fifth path was surfaced by the review pass, not by me.

Acceptance is defensible for a reason the todo didn't state: the *sanctioned* read path already collapses the backlog forest-wide by design, so the non-read triggers differ in propriety, not in effect.

The candidate fix — seed the watermark from `getattr(user, "date_joined", None)` — is spun out as **todo 285**. It changes unread semantics for every existing account, so it gets its own diff and review rather than riding along in a p3 doc-closure PR.

## #2 — `on_commit` timing: accept as-is

Recorded in `TopicDetailView.retrieve()`. Verified against the *installed* Django (6.0.7, `db/backends/base/base.py::on_commit`) rather than from memory: the autocommit branch honors `robust=True`, which is what makes accept-as-is safe rather than merely convenient. Rejected `atomic()` (buys defer-until-commit and isolation hygiene, not a smaller production query count) and Celery (disproportionate for two dedup-gated UPDATEs with no user-facing symptom).

This corrects the todo's own analysis on two points:

1. The query pin lives in `test_topic_detail.py`, not `test_topics_list.py` (which has no query assertion at all).
2. The cost does **not** land inside that pin. Under `@pytest.mark.django_db` the test body is itself in an atomic block, so `on_commit` genuinely defers and rolls back unrun — which is why the read-recording tests need `django_capture_on_commit_callbacks`. **The test suite is the one place where the deferral is real, so a green query pin can never detect this production cost.** Annotated that test's own comment, since it stated the deferral unqualified and was the most likely thing to be re-cited later.

## Codified

- `docs/LEARNINGS.md` — new section on the autocommit behavior and the test-vs-production asymmetry, including the tell (tests needing `django_capture_on_commit_callbacks` next to a query pin that doesn't).
- `docs/rules/database.md` — binding rule.
- `docs/rules/triggers.json` — write-time trigger `on_commit-no-deferral-claim`, so the false claim is caught at the keyboard rather than in review. Hook suite still green: 22 passed, 0 failed.

## Verification

| Check | Result |
|---|---|
| `manage.py check` | no issues (0 silenced) |
| `makemigrations --check --dry-run` | No changes detected |
| `pytest apps/forum_host packages/wagtail_forum --create-db` | 533 passed |
| `flake8` (all edited files) | exit 0 |
| `.claude/hooks/test-inject-patterns.sh` | 22 passed, 0 failed |

Review: `code-review-orchestrator` returned 4 findings (2 high, 2 medium), all documentation-accuracy. All verified against primary evidence before acting — 3 confirmed and repaired, 1 partially rejected in its reasoning but repaired anyway (`atomic()` *does* deliver on_commit's advertised defer-until-commit, so "atomic() doesn't achieve deferral" is too strong; the wording was genuinely ambiguous between "past commit" and "off the request", so it was disambiguated). Re-review returned `{"findings": []}`.

Note: AC1 and AC2 are decision-type. No command output can prove "a decision was recorded" — the evidence is the artifact, cited by file. The runs above show the edits are *safe*, not that the decisions are *right*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)