### PR TITLE
forum(ai): 503 is not one failure — code-gate the compose-assist latch (todo 275 follow-up)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1448,42 +1448,42 @@
         "filename": "web/src/contexts/AuthContext.test.tsx",
         "hashed_secret": "cbfdac6008f9cab4083784cbd1874f76618d2a97",
         "is_verified": false,
-        "line_number": 105
+        "line_number": 138
       },
       {
         "type": "Secret Keyword",
         "filename": "web/src/contexts/AuthContext.test.tsx",
         "hashed_secret": "a4b48a81cdab1e1a5dd37907d6c85ca1c61ddc7c",
         "is_verified": false,
-        "line_number": 133
+        "line_number": 166
       },
       {
         "type": "Secret Keyword",
         "filename": "web/src/contexts/AuthContext.test.tsx",
         "hashed_secret": "3179a65eff2523bbde53c99b299b719c10a35235",
         "is_verified": false,
-        "line_number": 220
+        "line_number": 253
       },
       {
         "type": "Secret Keyword",
         "filename": "web/src/contexts/AuthContext.test.tsx",
         "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
         "is_verified": false,
-        "line_number": 304
+        "line_number": 337
       },
       {
         "type": "Secret Keyword",
         "filename": "web/src/contexts/AuthContext.test.tsx",
         "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
         "is_verified": false,
-        "line_number": 481
+        "line_number": 514
       },
       {
         "type": "Secret Keyword",
         "filename": "web/src/contexts/AuthContext.test.tsx",
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
-        "line_number": 596
+        "line_number": 629
       }
     ],
     "web/src/services/authService.test.ts": [
@@ -1514,5 +1514,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-30T00:08:11Z"
+  "generated_at": "2026-07-30T01:26:11Z"
 }

--- a/backend/apps/forum_host/compose_assist.py
+++ b/backend/apps/forum_host/compose_assist.py
@@ -48,6 +48,21 @@ from .api import _throttled
 
 logger = logging.getLogger(__name__)
 
+# Machine-readable discriminators on the 503 body. The endpoint returns 503 for
+# THREE different reasons and only one of them is permanent, so the status code
+# alone is not enough for a client to decide whether retrying can ever work:
+#
+#   CODE_DISABLED    - the deployment has the feature off. Permanent for the
+#                      session; a client should stop offering the action.
+#   CODE_UNAVAILABLE - the provider errored, timed out, or returned an empty
+#                      completion. TRANSIENT; the next call may well succeed.
+#
+# The web client latched on the bare 503 and permanently disabled its toolbar
+# button on the first provider blip (todo 275 code review). Codes, not statuses,
+# because the transient/permanent split is a product fact, not an HTTP one.
+CODE_DISABLED = "disabled"
+CODE_UNAVAILABLE = "unavailable"
+
 
 # Block boundaries in the composer's HTML. Substituted with a newline BEFORE
 # tags are stripped: ``strip_tags`` deletes markup without putting anything in
@@ -105,13 +120,19 @@ class ComposeAssistView(APIView):
             "the forum-wide AI budget is exhausted (with Retry-After); 503 when "
             "composer assist is disabled for this deployment or the provider is "
             "unavailable. Requires a premium account. Nothing is persisted — the "
-            "client decides whether to accept the rewrite."
+            "client decides whether to accept the rewrite.\n\n"
+            "A 503 body carries a 'code' discriminating the two cases, because "
+            "only one of them is worth giving up on: 'disabled' (the deployment "
+            "has the feature off — permanent, stop offering the action) versus "
+            "'unavailable' (provider error, timeout, or empty completion — "
+            "TRANSIENT, a retry may succeed). Clients must branch on 'code', not "
+            "on the 503 status."
         ),
     )
     def post(self, request):
         if not getattr(settings, "FORUM_COMPOSE_ASSIST_ENABLED", False):
             return Response(
-                {"detail": "AI composer assist is not enabled."},
+                {"detail": "AI composer assist is not enabled.", "code": CODE_DISABLED},
                 status=status.HTTP_503_SERVICE_UNAVAILABLE,
             )
 
@@ -175,7 +196,10 @@ class ComposeAssistView(APIView):
             # Degrade, never 500: the composer keeps working without assist.
             logger.exception("[ERROR] Forum compose assist provider call failed")
             return Response(
-                {"detail": "AI assist is unavailable right now."},
+                {
+                    "detail": "AI assist is unavailable right now.",
+                    "code": CODE_UNAVAILABLE,
+                },
                 status=status.HTTP_503_SERVICE_UNAVAILABLE,
             )
 
@@ -198,7 +222,10 @@ class ComposeAssistView(APIView):
             # replaced content with it.
             logger.warning("[ERROR] Forum compose assist returned an empty rewrite")
             return Response(
-                {"detail": "AI assist could not improve this draft."},
+                {
+                    "detail": "AI assist could not improve this draft.",
+                    "code": CODE_UNAVAILABLE,
+                },
                 status=status.HTTP_503_SERVICE_UNAVAILABLE,
             )
 

--- a/backend/apps/forum_host/tests/test_compose_assist.py
+++ b/backend/apps/forum_host/tests/test_compose_assist.py
@@ -51,6 +51,9 @@ def test_disabled_returns_503_without_calling_the_provider():
             ASSIST_URL, {"text": "my tomato plant is sad"}, format="json"
         )
     assert resp.status_code == 503
+    # PERMANENT: the client must be able to tell this apart from a provider blip
+    # and stop offering the action (todo 275 code review).
+    assert resp.json()["code"] == "disabled"
     mock_generate.assert_not_called()
 
 
@@ -286,11 +289,14 @@ def test_provider_call_carries_the_hard_deadline():
 
 @override_settings(FORUM_COMPOSE_ASSIST_ENABLED=True)
 @pytest.mark.django_db
-def test_provider_exception_returns_503():
+def test_provider_exception_returns_503_marked_transient():
+    """TRANSIENT, not permanent: latching on the bare 503 meant one provider blip
+    permanently disabled the client's button (todo 275 code review)."""
     client = _premium_client()
     with patch(GENERATE, side_effect=RuntimeError("provider down")):
         resp = client.post(ASSIST_URL, {"text": "draft"}, format="json")
     assert resp.status_code == 503
+    assert resp.json()["code"] == "unavailable"
 
 
 @override_settings(FORUM_COMPOSE_ASSIST_ENABLED=True)
@@ -301,6 +307,11 @@ def test_empty_completion_returns_503_rather_than_a_blank_rewrite():
     with patch(GENERATE, return_value="   "):
         resp = client.post(ASSIST_URL, {"text": "draft"}, format="json")
     assert resp.status_code == 503
+    # Also TRANSIENT — the next draft may well come back fine. This one matters
+    # doubly because the budget IS charged for it (the call was billed), so a
+    # permanent latch here would have the user pay for the request that killed
+    # their button.
+    assert resp.json()["code"] == "unavailable"
 
 
 @override_settings(FORUM_COMPOSE_ASSIST_ENABLED=True)

--- a/docs/LEARNINGS.md
+++ b/docs/LEARNINGS.md
@@ -2272,3 +2272,44 @@ target is neither; only `Range.prototype` is on the path.
 `Errors 1` still exits non-zero, so CI fails on a suite that reads green locally
 at a glance. Always check the exit code — `vitest --run …; echo $?` — after adding
 a test that dispatches editor transactions; do not trust the pass count.
+
+## [2026-07-29] A fix for one review finding created a worse one: status-as-taxonomy + a session-scoped latch (todo 275)
+
+**What broke**: two findings from `/code-review` on the already-merged PR #509, which
+compound into one bug:
+
+1. `ComposeAssistError.permanent = status === 403 || status === 503`. But
+   `compose_assist.py` returns 503 for **three** unrelated reasons and only one is
+   permanent: the feature flag being off, versus a provider exception, versus an
+   empty completion. So one provider blip made `permanent` true.
+2. The latch that consumes `permanent` was module-scoped, and nothing in production
+   ever cleared it.
+
+Net effect: a single provider timeout permanently disabled the composer's AI button
+for the rest of the tab's life, with a tooltip blaming the user's account — and the
+empty-completion path *charges the budget first*, so the user paid for the request
+that killed their own button.
+
+**The instructive part**: finding 2's module scope was introduced *by the repair for
+an earlier reviewer finding* in the same session. A per-component latch was correctly
+identified as broken (the composer remounts after every reply, resetting it), and
+hoisting it to module scope fixed that — while silently converting a per-composer
+annoyance into a session-long dead control. **Widening a value's scope widens the
+blast radius of every wrong value it can hold.** When a review says "this state is
+too short-lived", check what happens if the state is *wrong*, not only if it is lost.
+
+**Root causes, both reusable**:
+
+- **An HTTP status is not a failure taxonomy.** If one status code covers both
+  "give up" and "try again", clients cannot branch correctly and will pick wrong.
+  Emit a stable machine-readable `code` in the body and branch on that.
+- **A cached failure verdict must be keyed to what it depends on.** A 403 meaning
+  "this account is not premium" is only valid for that account. The fix clears the
+  latch from a single `useEffect` on `user?.id` in `AuthContext` rather than at each
+  of login/register/logout/refresh, so a future auth path cannot forget it.
+
+**Also note where it was caught**: three domain reviewers, a security review and a
+full test suite all passed this. The bundled `/code-review` correctness pass found
+it — after merge. That is the todo-244 "the two passes are complementary" evidence
+showing up again, and an argument for running the correctness pass *before* merging,
+not after.

--- a/docs/rules/api.md
+++ b/docs/rules/api.md
@@ -91,3 +91,12 @@ Compact checklist auto-injected before edits. Long-form:
   after the provider actually returned, so an outage cannot drain the cap through
   failed attempts. An empty-but-successful response IS a charge — it was billed.
   See `backend/docs/patterns/domain/forum.md`.
+- **One status covering both permanent and transient failures needs a machine-readable
+  `code`.** `compose_assist` returned 503 for three unrelated reasons — feature flag
+  off (permanent) vs provider error/timeout/empty completion (transient) — so the web
+  client's `permanent = status === 503` disabled its button for the whole session on
+  the first provider blip, blaming the user's account. Add a stable `code` to the body
+  (`"disabled"` vs `"unavailable"`) and have clients branch on THAT; the
+  transient/permanent split is a product fact, not an HTTP one. Corollary: a client
+  latch that caches a failure verdict must be keyed to (or cleared on) whatever the
+  verdict depends on — a 403 meaning "not premium" must not outlive the account.

--- a/web/src/components/forum/TipTapEditor.test.tsx
+++ b/web/src/components/forum/TipTapEditor.test.tsx
@@ -435,6 +435,44 @@ describe('TipTapEditor', () => {
     expect(screen.getByTitle(/not available for this account/i)).toBeDisabled();
   });
 
+  it('keeps the button after a TRANSIENT 503 (provider blip) (M14)', async () => {
+    // The regression this guards: `permanent` used to include any 503, so a single
+    // provider error/timeout/empty-completion killed the button for the whole tab
+    // — with a tooltip blaming the user's account (todo 275 code review).
+    vi.spyOn(logger, 'error').mockImplementation(() => {});
+    vi.spyOn(forumService, 'improveDraft').mockRejectedValue(
+      new forumService.ComposeAssistError(503, 'AI assist is unavailable right now.', 'unavailable')
+    );
+    const { container } = render(
+      <TipTapEditor content="<p>draft</p>" onChange={vi.fn()} editable />
+    );
+    await waitFor(() => expect(container.querySelector('.ProseMirror')).toBeInTheDocument());
+
+    await userEvent.click(screen.getByTitle(AI_TITLE));
+
+    expect(await screen.findByText(/unavailable right now/i)).toBeInTheDocument();
+    expect(screen.getByTitle(AI_TITLE)).toBeEnabled();
+    expect(forumService.isComposeAssistUnavailable()).toBe(false);
+  });
+
+  it('disables the button on a 503 that means the feature is off (M14)', async () => {
+    vi.spyOn(logger, 'error').mockImplementation(() => {});
+    vi.spyOn(forumService, 'improveDraft').mockRejectedValue(
+      new forumService.ComposeAssistError(503, 'AI composer assist is not enabled.', 'disabled')
+    );
+    const { container } = render(
+      <TipTapEditor content="<p>draft</p>" onChange={vi.fn()} editable />
+    );
+    await waitFor(() => expect(container.querySelector('.ProseMirror')).toBeInTheDocument());
+
+    await userEvent.click(screen.getByTitle(AI_TITLE));
+
+    await waitFor(() =>
+      expect(screen.getByTitle(/not available for this account/i)).toBeDisabled()
+    );
+    expect(forumService.isComposeAssistUnavailable()).toBe(true);
+  });
+
   it('keeps the button after a transient 429 (M14)', async () => {
     vi.spyOn(logger, 'error').mockImplementation(() => {});
     vi.spyOn(forumService, 'improveDraft').mockRejectedValue(

--- a/web/src/contexts/AuthContext.test.tsx
+++ b/web/src/contexts/AuthContext.test.tsx
@@ -9,6 +9,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, waitFor, act } from '@testing-library/react';
 import { AuthProvider, useAuth, AuthErrorCode } from './AuthContext';
 import * as authService from '../services/authService';
+import * as forumService from '../services/forumService';
 import type { User, LoginCredentials, SignupData } from '../types/auth';
 
 // Mock the auth service
@@ -30,6 +31,38 @@ describe('AuthContext', () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+  });
+
+  describe('Per-account API capability latches (todo 275 code review)', () => {
+    it('clears the compose-assist latch when the identity changes', async () => {
+      // The latch caches "this ACCOUNT is not premium" for the session. Without
+      // this, a non-premium user who clicks AI assist (403 → latched), then logs
+      // out and back in as a premium account in the same SPA session, keeps a
+      // permanently disabled button the server would now allow — only a hard
+      // reload recovered.
+      const first: User = { id: 1, email: 'basic@example.com', name: 'Basic' };
+      const second: User = { id: 2, email: 'premium@example.com', name: 'Premium' };
+      vi.mocked(authService.getStoredUser).mockReturnValue(first);
+      vi.mocked(authService.getCurrentUser).mockResolvedValue(first);
+
+      const { result } = renderHook(() => useAuth(), { wrapper: AuthProvider });
+      await waitFor(() => expect(result.current.user).toEqual(first));
+
+      // Simulate the 403 that latches the flag for account #1.
+      forumService.markComposeAssistUnavailable();
+      expect(forumService.isComposeAssistUnavailable()).toBe(true);
+
+      vi.mocked(authService.login).mockResolvedValue(second);
+      await act(async () => {
+        await result.current.login({
+          email: 'premium@example.com',
+          password: 'x',
+        } as LoginCredentials);
+      });
+
+      await waitFor(() => expect(result.current.user).toEqual(second));
+      expect(forumService.isComposeAssistUnavailable()).toBe(false);
+    });
   });
 
   describe('Initialization', () => {

--- a/web/src/contexts/AuthContext.tsx
+++ b/web/src/contexts/AuthContext.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable react-refresh/only-export-components */
 import { createContext, useContext, useState, useEffect, useMemo, useRef, ReactNode } from 'react';
 import * as authService from '../services/authService';
+import { resetComposeAssistAvailability } from '../services/forumService';
 import { logger } from '../utils/logger';
 import { rotateRequestId } from '../utils/requestId';
 import { AuthErrorCode } from '../types/auth';
@@ -171,6 +172,18 @@ export function AuthProvider({ children }: AuthProviderProps) {
 
     initAuth();
   }, []);
+
+  // Clear per-account API capability latches whenever the identity changes.
+  // One effect keyed on the user id rather than a call in each of login/register/
+  // logout/refresh, so a future auth path cannot forget it. The forum
+  // compose-assist latch caches "this account is not premium" for the session, so
+  // it must not outlive the account: without this, a non-premium user who clicks
+  // AI assist, then upgrades or logs out and back in as someone else in the same
+  // SPA session, keeps a disabled button the server would now allow
+  // (todo 275 code review).
+  useEffect(() => {
+    resetComposeAssistAvailability();
+  }, [user?.id]);
 
   // Automatic token refresh for authenticated users
   // SECURITY: OWASP-compliant 15-minute access tokens require automatic refresh

--- a/web/src/services/forumService.test.ts
+++ b/web/src/services/forumService.test.ts
@@ -521,23 +521,28 @@ describe('forumService (wagtail_forum API contract)', () => {
     expect(init.credentials).toBe('include');
   });
 
-  it('improveDraft marks 403 and 503 as permanent, 429 as retryable', async () => {
-    // The status IS the product behaviour: the composer permanently hides its
-    // button for the first two but keeps it for a transient capacity error.
-    for (const [status, permanent] of [
-      [403, true],
-      [503, true],
-      [429, false],
-      [400, false],
+  it('improveDraft marks only 403 and code:disabled as permanent', async () => {
+    // A bare 503 must NOT be permanent: the endpoint returns it for a provider
+    // error, a timeout and an empty completion as well as for the feature flag
+    // being off, so latching on the status disabled the button on the first blip
+    // (todo 275 code review). The `code` is the discriminator.
+    for (const [status, code, permanent] of [
+      [403, undefined, true], // not a premium account
+      [503, 'disabled', true], // deployment has the feature off
+      [503, 'unavailable', false], // provider error / timeout / empty completion
+      [503, undefined, false], // unlabelled 503 → assume transient, don't give up
+      [429, undefined, false], // at capacity, retry later
+      [400, undefined, false], // bad draft
     ] as const) {
       fetchMock.mockResolvedValueOnce({
         ok: false,
         status,
-        json: async () => ({ detail: `failed ${status}` }),
+        json: async () => ({ detail: `failed ${status}`, ...(code && { code }) }),
       });
       await expect(improveDraft('<p>draft</p>')).rejects.toMatchObject({
         name: 'ComposeAssistError',
         status,
+        code,
         permanent,
         message: `failed ${status}`,
       });

--- a/web/src/services/forumService.ts
+++ b/web/src/services/forumService.ts
@@ -353,24 +353,38 @@ export async function searchForum(options: SearchForumOptions): Promise<SearchFo
 // ---------------------------------------------------------------------------
 
 /**
- * Error from the compose-assist endpoint, carrying the HTTP status.
+ * Error from the compose-assist endpoint, carrying the HTTP status and the
+ * backend's machine-readable `code`.
  *
  * `authenticatedFetch` collapses every failure to a bare `Error`, which is fine
- * for endpoints whose only failure mode is "it broke". Here the status IS the
- * product behaviour — 403 means "premium perk", 503 means "not enabled for this
- * deployment", 429 means "try later" — and the composer hides the button
- * permanently for the first two but not the third.
+ * for endpoints whose only failure mode is "it broke". Here the failure kind IS
+ * the product behaviour, and the composer permanently stops offering its button
+ * for a permanent failure but not a transient one.
+ *
+ * **`permanent` deliberately does NOT include a bare 503.** The endpoint returns
+ * 503 for three different reasons and only one is permanent: the feature flag
+ * being off (`code: "disabled"`), versus a provider error, timeout, or empty
+ * completion (`code: "unavailable"`). Latching on the status meant a single
+ * provider blip disabled the button for the whole tab, with a tooltip blaming
+ * the user's account — and the session-scoped latch below made that stick
+ * (todo 275 code review).
  */
 export class ComposeAssistError extends Error {
   readonly status: number;
-  /** True when retrying can never succeed for this user/deployment (403/503). */
+  /** Backend discriminator: 'disabled' | 'unavailable' | undefined (non-503). */
+  readonly code?: string;
+  /** True only when retrying can never succeed for this user/deployment. */
   readonly permanent: boolean;
 
-  constructor(status: number, message: string) {
+  constructor(status: number, message: string, code?: string) {
     super(message);
     this.name = 'ComposeAssistError';
     this.status = status;
-    this.permanent = status === 403 || status === 503;
+    this.code = code;
+    // 403 = not a premium account (permanent until the entitlement changes, which
+    // clears the latch — see resetComposeAssistAvailability's callers).
+    // 503 = permanent ONLY when the deployment has the feature off.
+    this.permanent = status === 403 || code === 'disabled';
   }
 }
 
@@ -396,7 +410,16 @@ export function markComposeAssistUnavailable(): void {
   composeAssistUnavailable = true;
 }
 
-/** Test-only reset — module state otherwise leaks between cases in a file. */
+/**
+ * Clear the latch. Called by `AuthContext` on every auth-state change, and by
+ * tests (module state otherwise leaks between cases in a file).
+ *
+ * Production callers matter: the 403 latch means "this ACCOUNT is not premium",
+ * so it must not outlive the account. Without this, a non-premium user who
+ * clicks the button, then upgrades or logs out and back in as someone else in
+ * the same SPA session (no page reload), keeps a permanently disabled button the
+ * server would now allow (todo 275 code review).
+ */
 export function resetComposeAssistAvailability(): void {
   composeAssistUnavailable = false;
 }
@@ -426,7 +449,8 @@ export async function improveDraft(draftHtml: string): Promise<string> {
     const body = await response.json().catch(() => ({}));
     throw new ComposeAssistError(
       response.status,
-      body.detail || body.message || `HTTP ${response.status}`
+      body.detail || body.message || `HTTP ${response.status}`,
+      body.code
     );
   }
   const data = (await response.json()) as { text?: string };


### PR DESCRIPTION
Repairs both findings from `/code-review medium PR #509`, which ran against the merged code. Follow-up to #509.

## Finding 1 — a status code used as a failure taxonomy

`compose_assist` returns **503 for three unrelated reasons** and only one is permanent:

| Cause | Permanent? |
|-------|-----------|
| `FORUM_COMPOSE_ASSIST_ENABLED` off | yes |
| provider exception / timeout | **no** |
| empty completion | **no** |

The web client had `permanent = status === 403 || status === 503`, so **one provider blip disabled the composer's ✨ button for the rest of the tab's life**, with a tooltip blaming the user's account. The empty-completion path charges the budget *before* returning 503, so the user paid for the request that killed their own button.

**The instructive part: my own earlier repair made this worse.** An earlier reviewer correctly flagged that the latch was per-component and reset on `ThreadDetailPage`'s post-reply remount. Hoisting it to module scope fixed that — and silently converted a per-composer annoyance into a session-long dead control. Widening a value's scope widens the blast radius of every wrong value it can hold.

**Fix:** the backend emits a stable `code` on the 503 body (`disabled` vs `unavailable`); `permanent` becomes `status === 403 || code === 'disabled'`. An *unlabelled* 503 is assumed transient — the safe direction, since retrying a working feature beats permanently hiding it.

## Finding 2 — a cached verdict outliving what it depends on

`resetComposeAssistAvailability()` was only ever called from tests. A 403 means "this **account** is not premium", so a user who upgraded — or logged out and back in as someone else in the same SPA session — kept a disabled button the server would now allow. Only a hard reload recovered.

**Fix:** cleared from a single `useEffect` on `user?.id` in `AuthContext`, rather than a call at each of login/register/logout/refresh, so a future auth path cannot forget it.

## Impact

**Nothing was user-visible.** The feature ships behind `FORUM_COMPOSE_ASSIST_ENABLED` (off), where every click 503s and a disabled button is the intended outcome. This had to land before the flag is ever enabled, which is why it's a fix rather than a backlog item.

## Codified

- `docs/rules/api.md` — a status covering both permanent and transient failures needs a machine-readable `code`; a cached failure verdict must be keyed to (or cleared on) whatever it depends on.
- `docs/LEARNINGS.md` — the scope-widening trap, plus a note worth keeping: three domain reviewers, a `/security-review`, and ~2,000 tests all passed this. Only the bundled correctness pass caught it, *after* merge. That's the todo-244 "the two passes are complementary" evidence again, and an argument for running the correctness pass before merging.

## Verification

```
$ python -m pytest --create-db -q            # 1305 passed, 8 skipped
$ python -m pytest apps/forum_host -q        # 219 passed
$ python manage.py spectacular --file /dev/null   # exit 0
$ npm run type-check                          # clean
$ npm run lint                                # 0 errors
$ ./node_modules/.bin/vitest --run            # 708 passed (+3), exit 0
```

New tests: the three 503 causes each pin their `code`; the web mapping table covers 403/`disabled`/`unavailable`/unlabelled-503/429/400; a transient 503 keeps the button enabled while a `disabled` 503 disables it; and an `AuthContext` test latches the flag, switches account, and asserts it cleared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)