### PR TITLE
test(users): freeze time in the count-to-limit rate-limit tests

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -479,14 +479,14 @@
         "filename": "backend/apps/users/tests/test_rate_limiting.py",
         "hashed_secret": "382caa7c44ee23ee25616f7e303af33c591efc3a",
         "is_verified": false,
-        "line_number": 27
+        "line_number": 57
       },
       {
         "type": "Secret Keyword",
         "filename": "backend/apps/users/tests/test_rate_limiting.py",
         "hashed_secret": "98e540ffae8223c143f1453da4c8604ca943213e",
         "is_verified": false,
-        "line_number": 46
+        "line_number": 80
       }
     ],
     "backend/apps/users/tests/test_token_refresh.py": [
@@ -1514,5 +1514,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-30T01:26:11Z"
+  "generated_at": "2026-07-30T16:30:13Z"
 }

--- a/backend/apps/users/tests/test_rate_limiting.py
+++ b/backend/apps/users/tests/test_rate_limiting.py
@@ -6,11 +6,41 @@ Tests per-IP and per-user rate limits for authentication endpoints including:
 - Registration rate limiting (3/h per IP)
 - Token refresh rate limiting (10/h)
 - Authenticated vs anonymous rate limits
+
+WHY EVERY COUNT-TO-LIMIT TEST HERE FREEZES TIME
+-----------------------------------------------
+django-ratelimit buckets by a window END computed per key, not by a sliding
+count (`django_ratelimit/core.py::_get_window`)::
+
+    ts = int(time.time())
+    w  = ts - (ts % period) + (zlib.crc32(value) % period)
+
+That `w` is a fixed wall-clock instant (the crc32 term only jitters WHICH
+instant, per key), and `_make_cache_key` folds the window into the cache key.
+So when wall-clock crosses `w` the key changes and the counter RESETS to zero.
+A test that fires N requests and expects the N+1th to be blocked therefore
+fails with the endpoint's normal status (401/201) instead of 429 whenever the
+hammer straddles that boundary — rare per run, but this suite runs on every
+push, and it took down `main` on 2026-07-30 (backend CI run 30550373085) with
+`AssertionError: 401 != 429`.
+
+`freeze_time` pins `time.time()` so every request in one test shares one
+window, which is the condition the assertions actually describe.
+
+Use the CONTEXT-MANAGER form, never the bare `@freeze_time()` decorator:
+`freeze_time()` resolves "now" when the object is CONSTRUCTED, and a decorator
+is constructed at import time — so the whole suite would freeze to whenever
+this module was imported, not to when each test runs.
+
+Freezing is safe for these assertions: `Retry-After` is derived from the rate
+STRING (`apps/core/exceptions.py::_retry_after_seconds`, e.g. 15m -> 900), not
+from time remaining in the window, so it stays positive under a freeze.
 """
 
 from django.contrib.auth import get_user_model
 from django.core.cache import cache
 from django.test import TestCase
+from freezegun import freeze_time
 from rest_framework import status
 from rest_framework.test import APIClient
 
@@ -35,71 +65,96 @@ class LoginRateLimitingTestCase(TestCase):
 
     def test_login_rate_limit_per_ip(self):
         """Test that login is rate limited to 5 attempts per 15 minutes per IP."""
-        # Get CSRF token
-        csrf_response = self.client.get("/api/v1/auth/csrf/")
-        csrf_token = csrf_response.cookies.get("csrftoken").value
+        # freeze_time so all N requests share ONE rate-limit window (see
+        # module docstring). Context-manager form, NOT @freeze_time() —
+        # the decorator captures "now" at import time, not call time.
+        with freeze_time():
+            # Get CSRF token
+            csrf_response = self.client.get("/api/v1/auth/csrf/")
+            csrf_token = csrf_response.cookies.get("csrftoken").value
 
-        # Make 5 login attempts (should succeed)
-        for i in range(5):
+            # Make 5 login attempts (should succeed)
+            for i in range(5):
+                response = self.client.post(
+                    "/api/v1/auth/login/",
+                    data={"username": "testuser", "password": "WrongPassword123!"},
+                    HTTP_X_CSRFTOKEN=csrf_token,
+                )
+                # Should fail due to wrong password but not rate limited
+                self.assertIn(response.status_code, [status.HTTP_401_UNAUTHORIZED])
+
+            # 6th attempt should be rate limited
+            csrf_response = self.client.get("/api/v1/auth/csrf/")
+            csrf_token = csrf_response.cookies.get("csrftoken").value
+
             response = self.client.post(
                 "/api/v1/auth/login/",
                 data={"username": "testuser", "password": "WrongPassword123!"},
                 HTTP_X_CSRFTOKEN=csrf_token,
             )
-            # Should fail due to wrong password but not rate limited
-            self.assertIn(response.status_code, [status.HTTP_401_UNAUTHORIZED])
 
-        # 6th attempt should be rate limited
-        csrf_response = self.client.get("/api/v1/auth/csrf/")
-        csrf_token = csrf_response.cookies.get("csrftoken").value
-
-        response = self.client.post(
-            "/api/v1/auth/login/",
-            data={"username": "testuser", "password": "WrongPassword123!"},
-            HTTP_X_CSRFTOKEN=csrf_token,
-        )
-
-        self.assertEqual(response.status_code, status.HTTP_429_TOO_MANY_REQUESTS)
+            self.assertEqual(response.status_code, status.HTTP_429_TOO_MANY_REQUESTS)
 
     def test_login_rate_limit_different_ips(self):
         """Test that rate limit is per-IP (different IPs have separate limits)."""
-        # Get CSRF token
-        csrf_response = self.client.get("/api/v1/auth/csrf/")
-        csrf_token = csrf_response.cookies.get("csrftoken").value
+        # freeze_time so all N requests share ONE rate-limit window (see
+        # module docstring). Context-manager form, NOT @freeze_time() —
+        # the decorator captures "now" at import time, not call time.
+        with freeze_time():
+            # Get CSRF token
+            csrf_response = self.client.get("/api/v1/auth/csrf/")
+            csrf_token = csrf_response.cookies.get("csrftoken").value
 
-        # Make 5 attempts from first IP
-        for i in range(5):
-            self.client.post(
+            # Make 5 attempts from first IP
+            for i in range(5):
+                self.client.post(
+                    "/api/v1/auth/login/",
+                    data={"username": "testuser", "password": "WrongPassword123!"},
+                    HTTP_X_CSRFTOKEN=csrf_token,
+                    REMOTE_ADDR="192.168.1.1",
+                )
+
+            # Attempt from different IP should not be rate limited
+            csrf_response = self.client.get("/api/v1/auth/csrf/")
+            csrf_token = csrf_response.cookies.get("csrftoken").value
+
+            response = self.client.post(
                 "/api/v1/auth/login/",
                 data={"username": "testuser", "password": "WrongPassword123!"},
                 HTTP_X_CSRFTOKEN=csrf_token,
-                REMOTE_ADDR="192.168.1.1",
+                REMOTE_ADDR="192.168.1.2",
             )
 
-        # Attempt from different IP should not be rate limited
-        csrf_response = self.client.get("/api/v1/auth/csrf/")
-        csrf_token = csrf_response.cookies.get("csrftoken").value
-
-        response = self.client.post(
-            "/api/v1/auth/login/",
-            data={"username": "testuser", "password": "WrongPassword123!"},
-            HTTP_X_CSRFTOKEN=csrf_token,
-            REMOTE_ADDR="192.168.1.2",
-        )
-
-        # Should fail due to wrong password but NOT rate limited
-        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+            # Should fail due to wrong password but NOT rate limited
+            self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
     def test_login_rate_limit_counts_successful_attempts(self):
         """The login rate limit (5/15m) counts every attempt by IP, including
         successful ones — the 6th login in the window is blocked with 429."""
-        # Get CSRF token
-        csrf_response = self.client.get("/api/v1/auth/csrf/")
-        csrf_token = csrf_response.cookies.get("csrftoken").value
+        # freeze_time so all N requests share ONE rate-limit window (see
+        # module docstring). Context-manager form, NOT @freeze_time() —
+        # the decorator captures "now" at import time, not call time.
+        with freeze_time():
+            # Get CSRF token
+            csrf_response = self.client.get("/api/v1/auth/csrf/")
+            csrf_token = csrf_response.cookies.get("csrftoken").value
 
-        # Make 5 successful logins
-        for i in range(5):
-            # Logout if logged in
+            # Make 5 successful logins
+            for i in range(5):
+                # Logout if logged in
+                self.client.post("/api/v1/auth/logout/", HTTP_X_CSRFTOKEN=csrf_token)
+
+                csrf_response = self.client.get("/api/v1/auth/csrf/")
+                csrf_token = csrf_response.cookies.get("csrftoken").value
+
+                response = self.client.post(
+                    "/api/v1/auth/login/",
+                    data={"username": "testuser", "password": "TestPassword123!"},
+                    HTTP_X_CSRFTOKEN=csrf_token,
+                )
+                self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+            # 6th successful login should still work (not rate limited)
             self.client.post("/api/v1/auth/logout/", HTTP_X_CSRFTOKEN=csrf_token)
 
             csrf_response = self.client.get("/api/v1/auth/csrf/")
@@ -110,24 +165,11 @@ class LoginRateLimitingTestCase(TestCase):
                 data={"username": "testuser", "password": "TestPassword123!"},
                 HTTP_X_CSRFTOKEN=csrf_token,
             )
-            self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        # 6th successful login should still work (not rate limited)
-        self.client.post("/api/v1/auth/logout/", HTTP_X_CSRFTOKEN=csrf_token)
-
-        csrf_response = self.client.get("/api/v1/auth/csrf/")
-        csrf_token = csrf_response.cookies.get("csrftoken").value
-
-        response = self.client.post(
-            "/api/v1/auth/login/",
-            data={"username": "testuser", "password": "TestPassword123!"},
-            HTTP_X_CSRFTOKEN=csrf_token,
-        )
-
-        # The @ratelimit(5/15m) decorator counts ALL login POSTs by IP, not just
-        # failed ones, so the 6th attempt in the window is blocked regardless of
-        # whether the credentials are valid.
-        self.assertEqual(response.status_code, status.HTTP_429_TOO_MANY_REQUESTS)
+            # The @ratelimit(5/15m) decorator counts ALL login POSTs by IP, not just
+            # failed ones, so the 6th attempt in the window is blocked regardless of
+            # whether the credentials are valid.
+            self.assertEqual(response.status_code, status.HTTP_429_TOO_MANY_REQUESTS)
 
 
 class RegistrationRateLimitingTestCase(TestCase):
@@ -144,78 +186,86 @@ class RegistrationRateLimitingTestCase(TestCase):
 
     def test_registration_rate_limit_per_ip(self):
         """Test that registration is rate limited to 3 per hour per IP."""
-        # Get CSRF token
-        csrf_response = self.client.get("/api/v1/auth/csrf/")
-        csrf_token = csrf_response.cookies.get("csrftoken").value
+        # freeze_time so all N requests share ONE rate-limit window (see
+        # module docstring). Context-manager form, NOT @freeze_time() —
+        # the decorator captures "now" at import time, not call time.
+        with freeze_time():
+            # Get CSRF token
+            csrf_response = self.client.get("/api/v1/auth/csrf/")
+            csrf_token = csrf_response.cookies.get("csrftoken").value
 
-        # Make 3 registration attempts (should succeed)
-        for i in range(3):
+            # Make 3 registration attempts (should succeed)
+            for i in range(3):
+                response = self.client.post(
+                    "/api/v1/auth/register/",
+                    data={
+                        "username": f"testuser{i}",
+                        "email": f"test{i}@example.com",
+                        "password": "TestPassword123!",
+                        "confirmPassword": "TestPassword123!",
+                    },
+                    HTTP_X_CSRFTOKEN=csrf_token,
+                )
+                self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+            # 4th attempt should be rate limited
+            csrf_response = self.client.get("/api/v1/auth/csrf/")
+            csrf_token = csrf_response.cookies.get("csrftoken").value
+
             response = self.client.post(
                 "/api/v1/auth/register/",
                 data={
-                    "username": f"testuser{i}",
-                    "email": f"test{i}@example.com",
+                    "username": "testuser4",
+                    "email": "test4@example.com",
                     "password": "TestPassword123!",
                     "confirmPassword": "TestPassword123!",
                 },
                 HTTP_X_CSRFTOKEN=csrf_token,
             )
-            self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
-        # 4th attempt should be rate limited
-        csrf_response = self.client.get("/api/v1/auth/csrf/")
-        csrf_token = csrf_response.cookies.get("csrftoken").value
-
-        response = self.client.post(
-            "/api/v1/auth/register/",
-            data={
-                "username": "testuser4",
-                "email": "test4@example.com",
-                "password": "TestPassword123!",
-                "confirmPassword": "TestPassword123!",
-            },
-            HTTP_X_CSRFTOKEN=csrf_token,
-        )
-
-        self.assertEqual(response.status_code, status.HTTP_429_TOO_MANY_REQUESTS)
+            self.assertEqual(response.status_code, status.HTTP_429_TOO_MANY_REQUESTS)
 
     def test_registration_rate_limit_different_ips(self):
         """Test that registration rate limit is per-IP."""
-        # Get CSRF token
-        csrf_response = self.client.get("/api/v1/auth/csrf/")
-        csrf_token = csrf_response.cookies.get("csrftoken").value
+        # freeze_time so all N requests share ONE rate-limit window (see
+        # module docstring). Context-manager form, NOT @freeze_time() —
+        # the decorator captures "now" at import time, not call time.
+        with freeze_time():
+            # Get CSRF token
+            csrf_response = self.client.get("/api/v1/auth/csrf/")
+            csrf_token = csrf_response.cookies.get("csrftoken").value
 
-        # Make 3 registrations from first IP
-        for i in range(3):
-            self.client.post(
+            # Make 3 registrations from first IP
+            for i in range(3):
+                self.client.post(
+                    "/api/v1/auth/register/",
+                    data={
+                        "username": f"testuser{i}",
+                        "email": f"test{i}@example.com",
+                        "password": "TestPassword123!",
+                        "confirmPassword": "TestPassword123!",
+                    },
+                    HTTP_X_CSRFTOKEN=csrf_token,
+                    REMOTE_ADDR="192.168.1.1",
+                )
+
+            # Registration from different IP should work
+            csrf_response = self.client.get("/api/v1/auth/csrf/")
+            csrf_token = csrf_response.cookies.get("csrftoken").value
+
+            response = self.client.post(
                 "/api/v1/auth/register/",
                 data={
-                    "username": f"testuser{i}",
-                    "email": f"test{i}@example.com",
+                    "username": "testuser_different_ip",
+                    "email": "test_different@example.com",
                     "password": "TestPassword123!",
                     "confirmPassword": "TestPassword123!",
                 },
                 HTTP_X_CSRFTOKEN=csrf_token,
-                REMOTE_ADDR="192.168.1.1",
+                REMOTE_ADDR="192.168.1.2",
             )
 
-        # Registration from different IP should work
-        csrf_response = self.client.get("/api/v1/auth/csrf/")
-        csrf_token = csrf_response.cookies.get("csrftoken").value
-
-        response = self.client.post(
-            "/api/v1/auth/register/",
-            data={
-                "username": "testuser_different_ip",
-                "email": "test_different@example.com",
-                "password": "TestPassword123!",
-                "confirmPassword": "TestPassword123!",
-            },
-            HTTP_X_CSRFTOKEN=csrf_token,
-            REMOTE_ADDR="192.168.1.2",
-        )
-
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+            self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
 
 class TokenRefreshRateLimitingTestCase(TestCase):
@@ -245,28 +295,33 @@ class TokenRefreshRateLimitingTestCase(TestCase):
 
     def test_token_refresh_rate_limit(self):
         """Test that token refresh is rate limited to 10 per hour."""
-        # Make 10 refresh requests (should succeed)
-        for i in range(10):
+        # freeze_time so all N requests share ONE rate-limit window (see
+        # module docstring). Context-manager form, NOT @freeze_time() —
+        # the decorator captures "now" at import time, not call time.
+        with freeze_time():
+            # Make 10 refresh requests (should succeed)
+            for i in range(10):
+                csrf_response = self.client.get("/api/v1/auth/csrf/")
+                csrf_token = csrf_response.cookies.get("csrftoken").value
+
+                response = self.client.post(
+                    "/api/v1/auth/token/refresh/", HTTP_X_CSRFTOKEN=csrf_token
+                )
+                # Some may fail if token is blacklisted, but should not be rate limited
+                self.assertIn(
+                    response.status_code,
+                    [status.HTTP_200_OK, status.HTTP_401_UNAUTHORIZED],
+                )
+
+            # 11th attempt should be rate limited
             csrf_response = self.client.get("/api/v1/auth/csrf/")
             csrf_token = csrf_response.cookies.get("csrftoken").value
 
             response = self.client.post(
                 "/api/v1/auth/token/refresh/", HTTP_X_CSRFTOKEN=csrf_token
             )
-            # Some may fail if token is blacklisted, but should not be rate limited
-            self.assertIn(
-                response.status_code, [status.HTTP_200_OK, status.HTTP_401_UNAUTHORIZED]
-            )
 
-        # 11th attempt should be rate limited
-        csrf_response = self.client.get("/api/v1/auth/csrf/")
-        csrf_token = csrf_response.cookies.get("csrftoken").value
-
-        response = self.client.post(
-            "/api/v1/auth/token/refresh/", HTTP_X_CSRFTOKEN=csrf_token
-        )
-
-        self.assertEqual(response.status_code, status.HTTP_429_TOO_MANY_REQUESTS)
+            self.assertEqual(response.status_code, status.HTTP_429_TOO_MANY_REQUESTS)
 
 
 class RateLimitHeadersTestCase(TestCase):
@@ -287,27 +342,31 @@ class RateLimitHeadersTestCase(TestCase):
     def test_rate_limit_response_includes_retry_after(self):
         """A rate-limited (429) login response must carry a Retry-After header
         with a positive integer seconds value (RFC 6585 / CLAUDE.md gotcha #4)."""
-        csrf_response = self.client.get("/api/v1/auth/csrf/")
-        csrf_token = csrf_response.cookies.get("csrftoken").value
+        # freeze_time so all N requests share ONE rate-limit window (see
+        # module docstring). Context-manager form, NOT @freeze_time() —
+        # the decorator captures "now" at import time, not call time.
+        with freeze_time():
+            csrf_response = self.client.get("/api/v1/auth/csrf/")
+            csrf_token = csrf_response.cookies.get("csrftoken").value
 
-        # 5 attempts stay within the 5/15m per-IP login limit.
-        for _ in range(5):
-            self.client.post(
+            # 5 attempts stay within the 5/15m per-IP login limit.
+            for _ in range(5):
+                self.client.post(
+                    "/api/v1/auth/login/",
+                    data={"username": "testuser", "password": "WrongPassword123!"},
+                    HTTP_X_CSRFTOKEN=csrf_token,
+                )
+
+            # The 6th attempt in the window is rate limited.
+            response = self.client.post(
                 "/api/v1/auth/login/",
                 data={"username": "testuser", "password": "WrongPassword123!"},
                 HTTP_X_CSRFTOKEN=csrf_token,
             )
 
-        # The 6th attempt in the window is rate limited.
-        response = self.client.post(
-            "/api/v1/auth/login/",
-            data={"username": "testuser", "password": "WrongPassword123!"},
-            HTTP_X_CSRFTOKEN=csrf_token,
-        )
-
-        self.assertEqual(response.status_code, status.HTTP_429_TOO_MANY_REQUESTS)
-        self.assertTrue(
-            response.has_header("Retry-After"),
-            "429 response must include a Retry-After header",
-        )
-        self.assertGreater(int(response["Retry-After"]), 0)
+            self.assertEqual(response.status_code, status.HTTP_429_TOO_MANY_REQUESTS)
+            self.assertTrue(
+                response.has_header("Retry-After"),
+                "429 response must include a Retry-After header",
+            )
+            self.assertGreater(int(response["Retry-After"]), 0)

--- a/docs/rules/testing.md
+++ b/docs/rules/testing.md
@@ -28,7 +28,18 @@ Compact checklist auto-injected before edits.
 - Web: Vitest for units, Playwright for e2e. Mobile: `flutter test`.
 - **Freeze time in count-to-limit rate-limit tests** (`freezegun.freeze_time`) so
   all N requests share one window — django-ratelimit's jittered window can roll
-  over mid-hammer and flake the `assertEqual(..., 429)`.
+  over mid-hammer and flake the `assertEqual(..., 429)`. Mechanism (verified in
+  `_get_window`): the limiter buckets by a window END (`ts - (ts % period) +
+  crc32(key) % period`) that `_make_cache_key` folds into the cache key, so
+  crossing it swaps the key and RESETS the count to zero — the request that
+  should be the (N+1)th is seen as the 1st and returns the endpoint's normal
+  status. Took down `main` on 2026-07-30 with `401 != 429`.
+  **Use the context-manager form, never the bare `@freeze_time()` decorator**:
+  `freeze_time()` resolves "now" when the object is CONSTRUCTED, and a decorator
+  is constructed at import time — so `@freeze_time()` pins the test to whenever
+  the module was imported, not to when the test runs (measured: a decorator
+  built 1.2s before the call froze to the construction instant). `with
+  freeze_time():` resolves in `__enter__`, which is what you want.
 - **DraftStateMixin fixtures: `objects.create()` is born `live=True`** — it
   bypasses the draft→moderation→publish flow entirely, so workflow/counter
   tests built on it can stay green while the real API path (born `live=False`)


### PR DESCRIPTION
Fixes the flake that turned `main` red immediately after #511 merged — backend CI run [30550373085](https://github.com/Xertox1234/plant_id_community/actions/runs/30550373085), `AssertionError: 401 != 429` in `test_login_rate_limit_per_ip`. That run passed on re-run with no code change, on the same SHA.

## Root cause (verified, not inferred)

django-ratelimit does **not** keep a sliding count. `_get_window` computes a window **end**:

```python
ts = int(time.time())
w  = ts - (ts % period) + (zlib.crc32(value) % period)   # crc32 only jitters WHICH instant
```

and `_make_cache_key` folds that window into the cache key. So crossing the boundary **swaps the key and resets the counter to zero** — the request that should be the 6th is seen as the 1st and returns the endpoint's normal status. Demonstrated directly against the installed package:

```
window end for key '127.0.0.1': 1785429032
cache key 1s BEFORE boundary: rl:b80370cbb67df7237...
cache key 1s AFTER  boundary: rl:485a113e91748479...
keys differ across the boundary -> True
```

## Reproduced before fixing

I didn't want to ship a fix for a failure I'd only reasoned about. With a ticking clock advancing 200s per request (5 × 200s = 1000s, guaranteed to cross a 900s window whatever the per-key jitter):

```
[TICKING clock, crosses boundary] 6th request -> 401     <- production's exact failure, on demand
[FROZEN clock, one window]        6th request -> 429     <- correct
```

## The fix

Wrapped the seven count-to-limit tests in `with freeze_time():` so every request in a test shares one window — the condition the assertions actually describe.

That includes the two `*_different_ips` tests, which assert *not*-rate-limited. A rollover can't fail those, but it **can** make them pass while per-IP keying is broken, so freezing removes a false-pass path too.

### Why the context-manager form, not `@freeze_time()`

`freeze_time()` resolves "now" when the object is **constructed**, and a decorator is constructed at *import* time — so `@freeze_time()` would pin each test to whenever the module was imported rather than to when it runs. Measured:

```
constructed at: 1785426049.4
frozen value  : 1785426049.4      # 1.2s sleep between construction and call
lazy (resolves at call time): False
```

`with freeze_time():` resolves in `__enter__`. This trap is now in `docs/rules/testing.md`, since the pre-existing rule said "use freezegun" without saying which form.

## Safety

Freezing can't invalidate these assertions: `Retry-After` is derived from the rate **string** (`_retry_after_seconds`, `15m` → 900), not from time remaining in the window, so it stays positive under a freeze.

## Verification

- `pytest apps/users -q --create-db` → **127 passed**
- `pytest apps packages -q --create-db` → **1322 passed, 0 failed, 8 skipped**
- `flake8` clean; Black + detect-secrets applied via pre-commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)