### PR TITLE
test(mobile): AuthService unit-test harness (todo 288)

### DIFF
--- a/plant_community_mobile/lib/services/auth_service.dart
+++ b/plant_community_mobile/lib/services/auth_service.dart
@@ -76,15 +76,16 @@ final currentUserIdProvider = Provider<String?>(
 /// ```
 @riverpod
 class AuthService extends _$AuthService {
-  // NO UNIT-TEST HARNESS (pre-existing gap; todo 272 item 6 -> todo 288).
-  // There is no test/services/auth_service_test.dart, so this notifier's three
-  // push-registration wiring points — syncAfterLogin() after a successful JWT
-  // exchange, clearOnLogout() in signOut(), detach() on a signed-out auth
-  // state — plus the _authGeneration epoch guard and the session-expiry
+  // Harness: test/services/auth_service_test.dart (todo 288, closed 2026-07-31)
+  // pins this notifier's three push-registration wiring points —
+  // syncAfterLogin() after a successful JWT exchange, clearOnLogout() in
+  // signOut(), detach() on a signed-out auth state — plus their ORDER
+  // (clearOnLogout must precede the Firebase sign-out that invalidates the
+  // JWT it needs), the _authGeneration epoch guard, and the session-expiry
   // exemption for signOut()'s own FCM-clear PATCH (ApiService
-  // .skipSessionExpiryKey, see _handleSessionExpired) are pinned only
-  // indirectly, by PushRegistrationService's own tests and the on-device E2E.
-  // A harness built on the firebaseAuth seam below would pin them directly.
+  // .skipSessionExpiryKey, see _handleSessionExpired). Every one of those was
+  // verified to fail the suite when removed, so treat a red test here as a
+  // real regression, not harness noise.
   //
   // Protected getter allows test subclasses to inject a mock FirebaseAuth
   // without triggering Firebase.initializeApp() at construction time.

--- a/plant_community_mobile/test/services/auth_service_test.dart
+++ b/plant_community_mobile/test/services/auth_service_test.dart
@@ -1,0 +1,606 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:dio/dio.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_messaging/firebase_messaging.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:plant_community_mobile/services/api_service.dart';
+import 'package:plant_community_mobile/services/auth_service.dart';
+import 'package:plant_community_mobile/services/push_registration_service.dart';
+
+/// Unit harness for [AuthService] (todo 288).
+///
+/// Modelled on `push_registration_service_test.dart`: hand-rolled fakes, no
+/// mocking library, and the `@visibleForTesting firebaseAuth` seam so the
+/// notifier is constructed without `Firebase.initializeApp()`.
+///
+/// What this pins, and why each mattered before it existed:
+/// - the three push wiring points (`syncAfterLogin` / `clearOnLogout` /
+///   `detach`) — a dropped call is silent in production (a stale FCM token, or
+///   re-registration after logout);
+/// - the ORDER of `clearOnLogout` vs Firebase sign-out — the clear PATCH needs
+///   the still-valid JWT, so swapping them breaks the clear without failing
+///   anything;
+/// - the `_authGeneration` epoch guard — a stale in-flight exchange must not
+///   re-establish state after sign-out;
+/// - the session-expiry exemption, which is REQUEST-side
+///   (`ApiService.skipSessionExpiryKey`), not a notifier flag. There is no
+///   `_signingOut` boolean in `lib/` and there deliberately isn't one: a flag
+///   could not cover a 401 arriving after the clear's timeout abandoned the
+///   request.
+void main() {
+  setUp(() {
+    // In-memory secure storage: the notifier writes/deletes JWTs on nearly
+    // every path, and a real write throws MissingPluginException with no
+    // platform behind the test.
+    FlutterSecureStorage.setMockInitialValues({});
+  });
+
+  group('construction', () {
+    test('builds without touching real Firebase and reports the current user', () async {
+      final harness = _Harness(currentUser: _FakeUser(uid: 'ada'));
+      addTearDown(harness.dispose);
+
+      final state = harness.container.read(authServiceProvider);
+
+      expect(state.firebaseUser?.uid, 'ada');
+      expect(state.isAuthenticated, isFalse); // no JWT until the exchange lands
+
+      // build() kicks off the exchange unawaited; drain it before teardown so
+      // it lands on a live Ref rather than a disposed one.
+      await pumpEventQueue();
+    });
+  });
+
+  group('push registration wiring', () {
+    test('a successful JWT exchange calls syncAfterLogin', () async {
+      final harness = _Harness();
+      addTearDown(harness.dispose);
+      harness.container.read(authServiceProvider); // build the notifier
+
+      await harness.signIn(_FakeUser(uid: 'ada'));
+
+      expect(harness.push.calls, contains('syncAfterLogin'));
+      expect(
+        harness.container.read(authServiceProvider).jwtToken,
+        'django-jwt',
+      );
+    });
+
+    test('a FAILED exchange does not call syncAfterLogin', () async {
+      // Guards the assertion above from passing on a syncAfterLogin that was
+      // moved out of the success branch.
+      final harness = _Harness();
+      addTearDown(harness.dispose);
+      harness.api.postError = ApiException('server down', statusCode: 500);
+      harness.container.read(authServiceProvider);
+
+      await harness.signIn(_FakeUser(uid: 'ada'));
+
+      expect(harness.push.calls, isNot(contains('syncAfterLogin')));
+    });
+
+    test('signOut calls clearOnLogout', () async {
+      final harness = _Harness(currentUser: _FakeUser(uid: 'ada'));
+      addTearDown(harness.dispose);
+
+      await harness.container.read(authServiceProvider.notifier).signOut();
+
+      expect(harness.push.calls, contains('clearOnLogout'));
+    });
+
+    test('a signed-out auth state calls detach', () async {
+      // Session expiry and external sign-outs reach this path WITHOUT
+      // signOut(), so detach must hang off the auth-state listener, not off
+      // the signOut() method.
+      final harness = _Harness(currentUser: _FakeUser(uid: 'ada'));
+      addTearDown(harness.dispose);
+      harness.container.read(authServiceProvider);
+
+      await harness.emitAuthState(null);
+
+      expect(harness.push.calls, contains('detach'));
+    });
+  });
+
+  group('ordering', () {
+    test('clearOnLogout runs BEFORE Firebase sign-out', () async {
+      // The clear PATCH authenticates with the Django JWT, which sign-out
+      // invalidates — reversing these silently breaks the server-side clear
+      // while every other assertion in this file still passes.
+      final harness = _Harness(currentUser: _FakeUser(uid: 'ada'));
+      addTearDown(harness.dispose);
+
+      await harness.container.read(authServiceProvider.notifier).signOut();
+
+      expect(
+        harness.events,
+        containsAllInOrder(<String>['clearOnLogout', 'firebase.signOut']),
+      );
+    });
+  });
+
+  group('_authGeneration epoch guard', () {
+    test('an exchange completing after sign-out does not write state', () async {
+      final harness = _Harness();
+      addTearDown(harness.dispose);
+      harness.container.read(authServiceProvider);
+
+      // Park the exchange on getIdToken, i.e. before the FIRST of the five
+      // generation re-checks.
+      final gate = Completer<String?>();
+      final user = _FakeUser(uid: 'ada', getIdTokenOverride: () => gate.future);
+      // signIn() returns once the stream event is delivered; the exchange it
+      // starts runs unawaited inside the listener, so the pumpEventQueue()
+      // after gate.complete() — not this call — is what resumes and drains it.
+      await harness.signIn(user);
+
+      await harness.container.read(authServiceProvider.notifier).signOut();
+      gate.complete('firebase-id-token');
+      await pumpEventQueue();
+
+      final state = harness.container.read(authServiceProvider);
+      expect(state.jwtToken, isNull, reason: 'stale exchange re-authenticated');
+      expect(harness.api.postCalls, isEmpty, reason: 'aborted too late');
+    });
+
+    test('an exchange parked AFTER the network call also aborts', () async {
+      // The exchange re-checks the generation at five points; parking on
+      // getIdToken alone would leave the later four unpinned.
+      final harness = _Harness();
+      addTearDown(harness.dispose);
+      harness.container.read(authServiceProvider);
+
+      final gate = Completer<void>();
+      harness.api.postGate = gate;
+      await harness.signIn(_FakeUser(uid: 'ada'));
+
+      await harness.container.read(authServiceProvider.notifier).signOut();
+      gate.complete();
+      await pumpEventQueue();
+
+      expect(harness.container.read(authServiceProvider).jwtToken, isNull);
+      expect(harness.push.calls, isNot(contains('syncAfterLogin')));
+    });
+
+    test('the generation bump alone kills a mid-sign-out exchange', () async {
+      // The two tests above are satisfied by _isCurrentExchange's OTHER arm
+      // (currentUser?.uid == user.uid), which Firebase sign-out already
+      // breaks — so signOut()'s `_authGeneration++` could be deleted and both
+      // would stay green (confirmed by mutation).
+      //
+      // This isolates it: resume the exchange while signOut is parked on
+      // clearOnLogout, i.e. BEFORE _firebaseAuth.signOut() has cleared
+      // currentUser. Only the generation guard can stop it there — and it
+      // must, or the resumed exchange re-registers push after the clear.
+      final harness = _Harness();
+      addTearDown(harness.dispose);
+
+      final postGate = Completer<void>();
+      harness.api.postGate = postGate;
+      await harness.signIn(_FakeUser(uid: 'ada'));
+
+      final logoutGate = Completer<void>();
+      harness.push.clearOnLogoutGate = logoutGate;
+      final signOut = harness.container
+          .read(authServiceProvider.notifier)
+          .signOut();
+      await pumpEventQueue();
+      expect(harness.firebaseAuth.currentUser, isNotNull, reason: 'premise');
+
+      postGate.complete();
+      await pumpEventQueue();
+
+      expect(
+        harness.push.calls,
+        isNot(contains('syncAfterLogin')),
+        reason: 'exchange re-registered push during sign-out',
+      );
+
+      logoutGate.complete();
+      await signOut;
+      expect(harness.container.read(authServiceProvider).jwtToken, isNull);
+    });
+  });
+
+  group('session expiry', () {
+    test('build() registers _handleSessionExpired, and it signs the user out', () async {
+      // Without this, the whole exemption group below is unfalsifiable from
+      // AuthService's side: deleting build()'s
+      // `apiService.setSessionExpiredHandler(_handleSessionExpired)` would
+      // leave every other test green while 401s stopped signing anyone out.
+      final harness = _Harness(currentUser: _FakeUser(uid: 'ada'));
+      addTearDown(harness.dispose);
+      await pumpEventQueue(); // let build()'s exchange settle
+
+      final handler = harness.api.sessionExpiredHandler;
+      expect(handler, isNotNull, reason: 'build() registered no handler');
+
+      await handler!();
+      await pumpEventQueue();
+
+      final state = harness.container.read(authServiceProvider);
+      expect(state.error, 'Your session expired. Please sign in again.');
+      expect(state.jwtToken, isNull);
+      expect(harness.events, contains('firebase.signOut'));
+    });
+
+    test('the handler is unregistered when the notifier is disposed', () async {
+      // The handler closes over a Ref; leaving it installed on the shared
+      // ApiService after disposal is how "Cannot use Ref after dispose"
+      // reaches production.
+      final harness = _Harness();
+      await pumpEventQueue();
+      expect(harness.api.sessionExpiredHandler, isNotNull);
+
+      harness.dispose();
+
+      expect(harness.api.sessionExpiredHandler, isNull);
+    });
+  });
+
+  group('session-expiry exemption', () {
+    test('signOut\'s FCM-clear PATCH carries skipSessionExpiryKey', () async {
+      // Asserted through the REQUEST options, not a notifier flag — there is
+      // no `_signingOut` boolean in lib/ and by design there must not be one.
+      final harness = _Harness(
+        currentUser: _FakeUser(uid: 'ada'),
+        useRealPushService: true,
+      );
+      addTearDown(harness.dispose);
+      harness.container.read(authServiceProvider);
+      // clearOnLogout skips the network entirely when this session never
+      // registered, so give it a registration to clear.
+      await harness.realPush!.registerToken('device-token-1');
+
+      await harness.container.read(authServiceProvider.notifier).signOut();
+
+      // Selected by payload, not position: with the real push service the
+      // build-time exchange also PATCHes this endpoint (a registration), so
+      // `.last` would be leaning on production ordering to pick the clear.
+      final clear = harness.api.patchCalls.singleWhere(
+        (c) => c.data?['fcm_token'] == '',
+      );
+      expect(clear.options?.extra?[ApiService.skipSessionExpiryKey], isTrue);
+    });
+
+    test(
+      'a real 401 on an exempt request does not trigger the session-expired '
+      'handler, while an unexempt one does',
+      () async {
+        // Drives the actual Dio interceptor against a local server rather than
+        // trusting the flag's presence: the request-side opt-out is only worth
+        // anything if ApiService honours it.
+        final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+        addTearDown(() => server.close(force: true));
+        unawaited(() async {
+          await for (final request in server) {
+            request.response.statusCode = HttpStatus.unauthorized;
+            request.response.headers.contentType = ContentType.json;
+            request.response.write(jsonEncode({'detail': 'expired'}));
+            await request.response.close();
+          }
+        }());
+
+        final api = ApiService(
+          baseUrl: 'http://${server.address.host}:${server.port}',
+        );
+        var sessionExpiredCalls = 0;
+        api.setSessionExpiredHandler(() async => sessionExpiredCalls++);
+
+        await expectLater(
+          api.patch(
+            '/forum/me/profile/',
+            data: {'fcm_token': ''},
+            options: Options(
+              extra: {ApiService.skipSessionExpiryKey: true},
+            ),
+          ),
+          throwsA(isA<ApiException>()),
+        );
+        expect(
+          sessionExpiredCalls,
+          0,
+          reason: 'exempt 401 converted an intentional sign-out into expiry',
+        );
+
+        await expectLater(
+          api.patch('/forum/me/profile/', data: {'fcm_token': ''}),
+          throwsA(isA<ApiException>()),
+        );
+        expect(
+          sessionExpiredCalls,
+          1,
+          reason: 'the exemption is unfalsifiable — 401 never triggers expiry',
+        );
+      },
+    );
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+/// Wires a [ProviderContainer] with fakes for every collaborator the notifier
+/// reaches: Firebase auth, the API, and push registration.
+class _Harness {
+  _Harness({User? currentUser, bool useRealPushService = false}) {
+    firebaseAuth = _FakeFirebaseAuth(events: events, currentUser: currentUser);
+    api = _FakeApiService(events: events);
+    if (useRealPushService) {
+      messaging = _FakeMessaging();
+      realPush = _TestablePushRegistrationService(api, messaging!);
+    }
+    push = _RecordingPushRegistrationService(api, events);
+
+    container = ProviderContainer(
+      overrides: [
+        apiServiceProvider.overrideWithValue(api),
+        pushRegistrationServiceProvider.overrideWithValue(realPush ?? push),
+        authServiceProvider.overrideWith(
+          () => _TestableAuthService(firebaseAuth),
+        ),
+      ],
+    );
+
+    // authServiceProvider is autoDispose: a bare container.read() builds the
+    // notifier and immediately tears it down, so the NEXT read rebuilds it —
+    // re-running build()'s unawaited token exchange against a disposed Ref.
+    // Hold a listener for the harness's lifetime so there is exactly one
+    // notifier instance, as there is in the app.
+    _subscription = container.listen(
+      authServiceProvider,
+      (_, _) {},
+      fireImmediately: true,
+    );
+  }
+
+  late final ProviderSubscription<AuthState> _subscription;
+
+  late final _FakeFirebaseAuth firebaseAuth;
+  late final _FakeApiService api;
+  late final _RecordingPushRegistrationService push;
+  late final ProviderContainer container;
+
+  /// Both non-null only when constructed with `useRealPushService: true`.
+  _TestablePushRegistrationService? realPush;
+  _FakeMessaging? messaging;
+
+  /// Shared ordering log — every fake appends to it, so cross-collaborator
+  /// sequencing (e.g. clearOnLogout before firebase.signOut) is assertable.
+  final List<String> events = [];
+
+  /// Drive the Firebase auth-state stream the way a real sign-in does, and
+  /// wait for the listener's async work to settle.
+  Future<void> signIn(User user) async {
+    firebaseAuth.currentUser = user;
+    return emitAuthState(user);
+  }
+
+  Future<void> emitAuthState(User? user) async {
+    firebaseAuth.currentUser = user;
+    firebaseAuth.authStateController.add(user);
+    await pumpEventQueue();
+  }
+
+  void dispose() {
+    _subscription.close();
+    container.dispose();
+    firebaseAuth.authStateController.close();
+    // The real push service subscribes to onTokenRefresh; leaving the
+    // controller open outlives the test.
+    messaging?.tokenRefreshController.close();
+  }
+}
+
+/// Injects the fake FirebaseAuth through the production `@visibleForTesting`
+/// seam, so no test needs Firebase.initializeApp().
+class _TestableAuthService extends AuthService {
+  _TestableAuthService(this._firebaseAuth);
+
+  final FirebaseAuth _firebaseAuth;
+
+  @override
+  FirebaseAuth get firebaseAuth => _firebaseAuth;
+}
+
+/// Records the three lifecycle calls AuthService is responsible for making.
+/// Extends rather than implements so the real constructor and any unoverridden
+/// member stay real — `messaging` is a lazy getter, so nothing touches
+/// Firebase.
+class _RecordingPushRegistrationService extends PushRegistrationService {
+  _RecordingPushRegistrationService(super.apiService, this._events);
+
+  final List<String> _events;
+
+  List<String> get calls => _events.where(_isPushEvent).toList();
+
+  static bool _isPushEvent(String e) =>
+      e == 'syncAfterLogin' || e == 'clearOnLogout' || e == 'detach';
+
+  /// Holds `clearOnLogout` open so a test can resume an in-flight exchange
+  /// mid-sign-out, while Firebase still reports the user as current.
+  Completer<void>? clearOnLogoutGate;
+
+  @override
+  Future<void> syncAfterLogin() async => _events.add('syncAfterLogin');
+
+  @override
+  Future<void> clearOnLogout() async {
+    _events.add('clearOnLogout');
+    final gate = clearOnLogoutGate;
+    if (gate != null) await gate.future;
+  }
+
+  @override
+  void detach() => _events.add('detach');
+}
+
+/// The real service with only its Firebase seam faked — used by the
+/// exemption test, which must exercise the production `clearOnLogout`.
+class _TestablePushRegistrationService extends PushRegistrationService {
+  _TestablePushRegistrationService(super.apiService, this._messaging);
+
+  final FirebaseMessaging _messaging;
+
+  @override
+  FirebaseMessaging get messaging => _messaging;
+}
+
+class _RequestCall {
+  _RequestCall(this.path, this.data, this.options);
+
+  final String path;
+  final Map<String, dynamic>? data;
+  final Options? options;
+}
+
+class _FakeApiService extends ApiService {
+  _FakeApiService({required List<String> events})
+    : _events = events,
+      super(baseUrl: 'http://fake.local', authToken: null);
+
+  final List<String> _events;
+  final List<_RequestCall> postCalls = [];
+  final List<_RequestCall> patchCalls = [];
+  Exception? postError;
+  Completer<void>? postGate;
+
+  /// Whatever AuthService.build() installed, so the test can fire the
+  /// session-expired path the way the real 401 interceptor would.
+  Future<void> Function()? sessionExpiredHandler;
+
+  @override
+  void setSessionExpiredHandler(Future<void> Function()? onSessionExpired) {
+    sessionExpiredHandler = onSessionExpired;
+    super.setSessionExpiredHandler(onSessionExpired);
+  }
+
+  @override
+  Future<Response> post(
+    String path, {
+    dynamic data,
+    Map<String, dynamic>? queryParameters,
+    Options? options,
+  }) async {
+    _events.add('api.post $path');
+    final gate = postGate;
+    if (gate != null) await gate.future;
+    postCalls.add(_RequestCall(path, data as Map<String, dynamic>?, options));
+    final error = postError;
+    if (error != null) throw error;
+    return Response<dynamic>(
+      requestOptions: RequestOptions(path: path),
+      data: {'access_token': 'django-jwt', 'refresh_token': 'django-refresh'},
+    );
+  }
+
+  @override
+  Future<Response> patch(
+    String path, {
+    dynamic data,
+    Map<String, dynamic>? queryParameters,
+    Options? options,
+  }) async {
+    patchCalls.add(_RequestCall(path, data as Map<String, dynamic>?, options));
+    return Response<dynamic>(requestOptions: RequestOptions(path: path));
+  }
+}
+
+class _FakeFirebaseAuth implements FirebaseAuth {
+  _FakeFirebaseAuth({required List<String> events, User? currentUser})
+    : _events = events,
+      _currentUser = currentUser;
+
+  final List<String> _events;
+  User? _currentUser;
+  final StreamController<User?> authStateController =
+      StreamController<User?>.broadcast();
+
+  @override
+  User? get currentUser => _currentUser;
+
+  set currentUser(User? user) => _currentUser = user;
+
+  @override
+  Stream<User?> authStateChanges() => authStateController.stream;
+
+  @override
+  Future<void> signOut() async {
+    _events.add('firebase.signOut');
+    _currentUser = null;
+  }
+
+  /// Anything the notifier starts using that is not faked here fails loudly
+  /// rather than silently no-op'ing.
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _FakeUser implements User {
+  _FakeUser({required this.uid, this.getIdTokenOverride});
+
+  @override
+  final String uid;
+
+  /// Read by AuthService's kDebugMode logging (via redactEmail), which is
+  /// live under `flutter test` — a noSuchMethod fallthrough would throw.
+  @override
+  String? get email => '$uid@example.com';
+
+  final Future<String?> Function()? getIdTokenOverride;
+
+  @override
+  Future<String?> getIdToken([bool forceRefresh = false]) async {
+    final override = getIdTokenOverride;
+    if (override != null) return override();
+    return 'firebase-id-token';
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+/// Only the members the real [PushRegistrationService] touches; anything else
+/// is a loud NoSuchMethodError.
+class _FakeMessaging implements FirebaseMessaging {
+  final StreamController<String> tokenRefreshController =
+      StreamController<String>.broadcast();
+
+  @override
+  Future<NotificationSettings> requestPermission({
+    bool alert = true,
+    bool announcement = false,
+    bool badge = true,
+    bool carPlay = false,
+    bool criticalAlert = false,
+    bool provisional = false,
+    bool sound = true,
+    bool providesAppNotificationSettings = false,
+  }) async => _FakeSettings();
+
+  @override
+  Future<String?> getToken({
+    String? serviceWorkerScriptPath,
+    String? vapidKey,
+  }) async => 'device-token-1';
+
+  @override
+  Stream<String> get onTokenRefresh => tokenRefreshController.stream;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _FakeSettings implements NotificationSettings {
+  @override
+  AuthorizationStatus get authorizationStatus => AuthorizationStatus.authorized;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}

--- a/todos/archive/288-completed-p3-flutter-authservice-test-harness.md
+++ b/todos/archive/288-completed-p3-flutter-authservice-test-harness.md
@@ -1,5 +1,5 @@
 ---
-status: pending
+status: completed
 priority: p3
 issue_id: "288"
 tags: [flutter, testing, firebase, notifications]
@@ -92,16 +92,127 @@ indirectly, so a refactor that drops one of them fails no test.
 
 ## Acceptance Criteria
 
-- [ ] `test/services/auth_service_test.dart` exists and constructs the notifier
+- [x] `test/services/auth_service_test.dart` exists and constructs the notifier
       without touching real Firebase
-- [ ] All three push wiring points asserted: `syncAfterLogin` post-exchange,
+- [x] All three push wiring points asserted: `syncAfterLogin` post-exchange,
       `clearOnLogout` in `signOut`, `detach` on signed-out state
-- [ ] `clearOnLogout`-before-Firebase-sign-out ordering pinned
-- [ ] Session-expiry exemption pinned: a 401 on the FCM-clear PATCH does not
+- [x] `clearOnLogout`-before-Firebase-sign-out ordering pinned
+- [x] Session-expiry exemption pinned: a 401 on the FCM-clear PATCH does not
       trigger `_handleSessionExpired` / a "session expired" error state
-- [ ] `flutter test` passes; `flutter analyze` clean
+- [x] `flutter test` passes; `flutter analyze` clean
 
 ## Work Log
+
+### 2026-07-31 - Implemented and verified (run 2026-07-31-0411)
+
+13 tests in `test/services/auth_service_test.dart` (11 at first pass,
++2 from review), modelled on
+`push_registration_service_test.dart` (hand-rolled fakes, no mocking library).
+
+**Two obstacles the todo did not anticipate, both solved without a production
+seam:**
+
+1. `_secureStorage` is a plain `const FlutterSecureStorage()` field with no
+   injection point, and every notifier path writes or deletes a JWT — a real
+   write throws `MissingPluginException` under `flutter test`. Solved with the
+   package's own `FlutterSecureStorage.setMockInitialValues({})` (a
+   `@visibleForTesting` static shipped in flutter_secure_storage 10.x that
+   swaps in an in-memory platform). No `auth_service.dart` change needed.
+2. `authServiceProvider` is **autoDispose**. A bare `container.read()` builds
+   the notifier and immediately tears it down, so the *next* read rebuilds it —
+   re-running `build()`'s unawaited token exchange against a disposed `Ref`
+   ("Cannot use Ref after dispose"). The harness now holds a
+   `container.listen(..., fireImmediately: true)` subscription for its
+   lifetime, so there is exactly one notifier instance, as in the app.
+
+**Correction confirmed.** The todo's note that todo 272 was wrong about a
+`_signingOut` flag is accurate — there is none, and the exemption is
+request-side. The test asserts it through `Options.extra`, per the todo.
+
+**Beyond the todo's ask:** the session-expiry AC is pinned *end-to-end* rather
+than by flag presence alone. A local `HttpServer` returning 401 backs a real
+`ApiService`, and the test asserts the handler fires for an unexempt 401 and
+does NOT fire for an exempt one — the flag is worthless if the interceptor
+ignores it, and nothing previously covered either side.
+
+Every assertion was **mutation-verified** — regressions introduced one at a
+time into `auth_service.dart` / `push_registration_service.dart`:
+
+```
+drop syncAfterLogin                  -> RED: ...calls syncAfterLogin
+drop clearOnLogout                   -> RED: ...signOut calls clearOnLogout (+3 more)
+drop detach                          -> RED: ...signed-out auth state calls detach
+clearOnLogout AFTER firebase signOut -> RED: ...ordering ... BEFORE Firebase sign-out
+drop signOut epoch bump              -> RED: ...generation bump alone kills a mid-sign-out exchange
+drop skipSessionExpiry flag          -> RED: ...FCM-clear PATCH carries skipSessionExpiryKey
+```
+
+The fifth mutant initially came back **GREEN (not caught)**: `_isCurrentExchange`
+ANDs the generation check with `currentUser?.uid == user.uid`, and the fake's
+sign-out clears `currentUser` — so the uid arm alone killed the stale exchange
+and `signOut()`'s `_authGeneration++` could have been deleted silently. Added
+`the generation bump alone kills a mid-sign-out exchange`, which resumes the
+exchange while sign-out is parked on `clearOnLogout` (i.e. *before* Firebase
+clears `currentUser`), where only the generation guard can stop it. That mutant
+is now caught.
+
+Also updated the class-head comment in `auth_service.dart`, which still said
+"NO UNIT-TEST HARNESS". `build_runner build --delete-conflicting-outputs` was
+re-run for the CI codegen gate (which local `flutter analyze` does not catch);
+it reported the output "same" and `auth_service.g.dart` is byte-identical —
+`_$authServiceHash` is `8fbb70b6…` before and after, so riverpod_generator's
+source hash is not sensitive to a comment-only edit. Running the regen is still
+the right move: that insensitivity is a generator implementation detail, not a
+contract to rely on.
+
+Verification:
+
+```
+$ flutter analyze
+No issues found! (ran in 2.9s)
+
+$ flutter test
+00:16 +231 ~3: All tests passed!
+```
+
+### 2026-07-31 - Review and repair
+
+`flutter-dart-reviewer`. Two mediums and four lows; all but one repaired.
+
+**Repaired (medium): `_handleSessionExpired` was never exercised.** The
+exemption tests proved the flag and the interceptor, but nothing asserted that
+`build()` installs the handler at all — deleting
+`apiService.setSessionExpiredHandler(_handleSessionExpired)` would have left
+every test green while 401s silently stopped signing anyone out. Added a
+`session expiry` group: one test fires the registered handler and asserts the
+resulting state (`'Your session expired. Please sign in again.'`, JWT cleared,
+Firebase sign-out recorded), one asserts the handler is UNinstalled on
+disposal (a handler closing over a dead `Ref` is how "Cannot use Ref after
+dispose" reaches production). Both mutation-verified — the suite now catches
+8 of 8 mutants, up from 6.
+
+**Repaired (low):** `patchCalls.last` replaced with a `singleWhere` on the
+payload (with the real push service the build-time exchange also PATCHes that
+endpoint, so `.last` leaned on production ordering); `_FakeMessaging` is now
+held by the harness and its `tokenRefreshController` closed in `dispose()`
+(the real `syncAfterLogin` subscribes to it); `realPush` made nullable instead
+of a `late final` that threw `LateInitializationError` in the default harness
+mode; the misleading `final inFlight = harness.signIn(...)` captures removed —
+`pumpEventQueue()` after the gate completes is the real synchronisation point,
+now said so in a comment.
+
+**Not repaired, recorded deliberately (medium): checkpoint 3 of the epoch
+guard is not isolated.** `_exchangeFirebaseTokenForJWT` re-checks the
+generation at five points; checkpoints 1 and 2 are pinned, but the third —
+which runs *after* the JWT is written to secure storage and calls
+`_clearJWTIfMatches` to undo it — cannot be reached without a gate between the
+storage write and that check. `_secureStorage` is a plain `const` field, so
+isolating it needs either a production seam on `AuthService` or promoting
+`flutter_secure_storage_platform_interface` (currently transitive) to a
+dev_dependency so a gating platform can be installed. Both are wider than a
+p3 test-coverage todo, and `_clearJWTIfMatches` is a compensating cleanup
+whose failure mode is a stale token in storage, not a wrong auth state. Left
+uncovered on purpose rather than papered over.
 
 ### 2026-07-29 - Spun out of todo 272 (item 6)
 


### PR DESCRIPTION
Closes todo 288.

## Problem

`plant_community_mobile/lib/services/auth_service.dart` (478 lines) owns Firebase auth state, the Django JWT exchange, and the push-registration lifecycle — and had **no test file**. Its three push wiring points and its session-expiry handling were pinned only indirectly (by `PushRegistrationService`'s own tests and the on-device E2E), so a refactor that dropped one of them failed nothing.

## What's pinned

13 tests in a new `test/services/auth_service_test.dart`, modelled on `push_registration_service_test.dart` — hand-rolled fakes, no mocking library, injected through the existing `@visibleForTesting firebaseAuth` seam.

- `syncAfterLogin` after a successful exchange — **and not after a failed one**, so the first assertion can't pass on a call moved out of the success branch
- `clearOnLogout` in `signOut`
- `detach` on a signed-out auth state (session expiry / external sign-out reach this *without* `signOut()`)
- the **order**: `clearOnLogout` before Firebase sign-out, because the clear PATCH needs the still-valid JWT
- the `_authGeneration` epoch guard, at two different checkpoints plus the bump itself
- the session-expired handler's registration **and** unregistration on disposal, plus the state it produces
- the request-side `skipSessionExpiryKey` exemption

## Two obstacles, both solved without a production seam

1. **`_secureStorage` has no injection point** — it's a plain `const FlutterSecureStorage()` field, and nearly every notifier path writes or deletes a JWT, which throws `MissingPluginException` under `flutter test`. Used the package's own `FlutterSecureStorage.setMockInitialValues({})`, a `@visibleForTesting` static shipped in 10.x that swaps in an in-memory platform.
2. **`authServiceProvider` is autoDispose** — a bare `container.read()` builds the notifier and immediately tears it down, so the *next* read rebuilds it and re-runs `build()`'s unawaited token exchange against a disposed `Ref`. The harness holds a `container.listen(..., fireImmediately: true)` for its lifetime, so there is exactly one notifier instance, as in the app.

## The exemption is pinned end-to-end, not by flag presence

A local `HttpServer` returning 401 backs a **real** `ApiService`; the test asserts the session-expired handler fires for an unexempt 401 and does **not** for an exempt one. The flag is worthless if the interceptor ignores it, and neither side had any coverage before.

## Mutation-verified

Every assertion was checked by introducing the regression it claims to catch — 8 mutants, one at a time, each turning the suite red:

| Mutant | Caught by |
|---|---|
| drop `syncAfterLogin` | …calls syncAfterLogin |
| drop `clearOnLogout` | …signOut calls clearOnLogout (+3 more) |
| drop `detach` | …signed-out auth state calls detach |
| `clearOnLogout` after Firebase sign-out | …ordering …BEFORE Firebase sign-out |
| drop `signOut` epoch bump | …generation bump alone kills a mid-sign-out exchange |
| drop handler registration | …build() registers _handleSessionExpired |
| drop handler unregistration | …handler is unregistered when the notifier is disposed |
| drop `skipSessionExpiryKey` | …FCM-clear PATCH carries skipSessionExpiryKey |

The epoch-bump mutant initially came back **GREEN**: `_isCurrentExchange` ANDs the generation check with `currentUser?.uid == user.uid`, and Firebase sign-out already breaks the uid arm — so `signOut()`'s `_authGeneration++` could have been deleted silently. Added a test that resumes the exchange while sign-out is parked on `clearOnLogout` (i.e. *before* `currentUser` is cleared), where only the generation guard can stop it.

## Review

`flutter-dart-reviewer`: 2 medium + 4 low. Repaired the `_handleSessionExpired` gap (the medium — nothing asserted the handler was installed at all) and all four lows (order-dependent `patchCalls.last`, an unclosed `_FakeMessaging` controller, a `late final` that threw in the default harness mode, misleading `inFlight` captures).

**One medium left uncovered on purpose**, recorded in the todo's Work Log: epoch-guard checkpoint 3 (the `_clearJWTIfMatches` compensating cleanup) can't be isolated without a gate between the secure-storage write and that check, which needs either a production seam or promoting `flutter_secure_storage_platform_interface` to a dev_dependency. Both are wider than a p3 test-coverage todo, and the failure mode is a stale token in storage, not a wrong auth state.

## Non-test change

The class-head comment still read "NO UNIT-TEST HARNESS"; it now describes what is pinned. `build_runner` was re-run for the CI codegen gate — output byte-identical (`_$authServiceHash` unchanged), so no `.g.dart` diff.

```
flutter analyze  →  No issues found!
flutter test     →  233 passed, 3 skipped
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)