### PR TITLE
todos(forum-mobile): close 279 by promoting all 9 deferred items (todos 291–295)

### DIFF
--- a/todos/291-pending-p2-mobile-forum-reply-not-visible-after-posting.md
+++ b/todos/291-pending-p2-mobile-forum-reply-not-visible-after-posting.md
@@ -1,0 +1,84 @@
+---
+status: pending
+priority: p2
+issue_id: "291"
+tags: [forum, flutter, mobile, bug]
+dependencies: ["260"]
+source_review: "todo 279 (promoted 2026-07-31)"
+---
+
+# Mobile: a new reply is invisible after posting on a multi-page thread
+
+## Problem
+
+On a thread long enough to paginate, posting a reply lands it on the LAST
+page, but the mobile client only refetches page 1 — so the user sees no trace
+of the reply they just wrote. The write succeeded; the UI says nothing
+happened, which reads as a failure and invites a duplicate post.
+
+Promoted out of todo 279 (deferred scope from todo 260) as its own todo, at a
+higher priority than its siblings: this is the only item in that list that is a
+**defect** rather than absent functionality.
+
+## Findings
+
+- Deferred item 8 of todo 279, itself deferred from todo 260's Recommended
+  Action to keep that epic's first PR reviewable.
+- The web client already solved this: it has a `collectAllPosts` /
+  deep-link-to-post path. Mirror that rather than inventing a mobile-only
+  approach.
+- Related, already fixed on web: the I1 "deep-link past page 1" chain
+  documented in `docs/LEARNINGS.md` — read it before implementing, the
+  page-bound edge cases are enumerated there.
+- The `/forum/topics/{id}/posts/` endpoint is cursor-paginated
+  (`PostCursorPagination`), so "jump to the last page" is not an offset — the
+  web fix is the reference for how it is actually done.
+
+## Recommended Action
+
+1. Mirror the web client's post-collection behaviour: after a successful
+   reply, land the user on the new post rather than refetching page 1.
+2. Reuse the existing idempotency pattern on the write — do not add a second
+   write path for this.
+3. Cover the multi-page case specifically. A single-page thread passes either
+   way, so a one-page test proves nothing.
+
+## Technical Details
+
+- Client lives in `plant_community_mobile/lib/features/forum/` — `models/`,
+  `providers/`, `screens/` (`forum_topics_screen.dart`,
+  `forum_thread_screen.dart`, `forum_composer_screen.dart`), `services/`
+  (`forum_api.dart`, `forum_composer_controller.dart`, `forum_sync_service.dart`,
+  `forum_sync_store.dart`), `widgets/`.
+- `ForumApi` (`services/forum_api.dart`) is the seam to extend: add the method
+  plus its fake, mirroring the existing endpoints.
+- Codegen gate: editing a `@riverpod` source needs
+  `flutter pub run build_runner build --delete-conflicting-outputs` and a
+  committed `.g.dart`. CI blocks on this; local `flutter analyze` does NOT
+  catch it. A clean rebuild is required — incremental can miss the hash.
+- Read `plant_community_mobile/docs/patterns/riverpod.md` and
+  `.../flutter-patterns.md` before writing.
+
+## Acceptance Criteria
+
+- [ ] After posting a reply to a thread with more than one page of posts, the
+      new reply is visible without a manual refresh — widget test on a
+      multi-page fixture
+- [ ] A single-page thread still behaves as before — test
+- [ ] `flutter test` passes; `flutter analyze` clean
+
+## Work Log
+
+### 2026-07-31 - Promoted out of todo 279
+
+- Todo 279 was a parking todo whose only AC was "prioritize the above into
+  concrete slices". Per `CLAUDE.md` → Review Doc Tracking, promote-all is the
+  only terminal state for a parking epic — re-deferring keeps it open forever.
+  Its 9 deferred items were grouped into 5 todos by what ships together, not
+  split 1:1.
+
+## Notes
+
+p2, not p3 like its siblings: a user-visible defect on the primary platform's
+write path, and the failure mode (invisible successful write) actively invites
+duplicate posts. Promoted from todo 279 on 2026-07-31.

--- a/todos/292-pending-p3-mobile-forum-edit-and-delete.md
+++ b/todos/292-pending-p3-mobile-forum-edit-and-delete.md
@@ -1,0 +1,84 @@
+---
+status: pending
+priority: p3
+issue_id: "292"
+tags: [forum, flutter, mobile]
+dependencies: ["260"]
+source_review: "todo 279 (promoted 2026-07-31)"
+---
+
+# Mobile forum: post edit and delete
+
+## Problem
+
+The Flutter forum client can create topics and replies but cannot edit or
+delete them — the backend endpoints and the per-post capability flags both
+exist and are simply unused by the mobile client. A user who typos a reply on
+mobile has to open the web app to fix it.
+
+## Findings
+
+- Deferred item 2 of todo 279 (from todo 260's Recommended Action).
+- Backend is ready: `PATCH /forum/posts/{id}/` returns `moderation_status`, and
+  `DELETE /forum/posts/{id}/` returns 204. Opening posts cannot be deleted.
+- The serializer already ships `can_edit` / `can_delete` per post — the client
+  has the gating data and ignores it.
+- The frozen-topic guard is deliberately symmetric: PATCH and DELETE are both
+  409 on a closed/locked topic **including for moderators** (a product
+  decision, see `docs/rules/forum.md`). The mobile UI must surface that 409,
+  not treat it as an error to retry.
+
+## Recommended Action
+
+1. Add `editPost` / `deletePost` to `ForumApi` plus their fakes.
+2. Gate the affordances on `post.canEdit` / `post.canDelete` — do not
+   re-derive ownership client-side.
+3. Edit reuses the idempotency pattern already used by create. Per
+   `docs/rules/flutter.md`: one `Idempotency-Key` per action, **rotated when
+   the composed content changes** — an edit-then-retry with a stale key wedges
+   a permanent 422.
+4. Surface `moderation_status` on the edit response the way the create path
+   already surfaces pending moderation; an edit can send a post back to the
+   queue.
+
+## Technical Details
+
+- Client lives in `plant_community_mobile/lib/features/forum/` — `models/`,
+  `providers/`, `screens/` (`forum_topics_screen.dart`,
+  `forum_thread_screen.dart`, `forum_composer_screen.dart`), `services/`
+  (`forum_api.dart`, `forum_composer_controller.dart`, `forum_sync_service.dart`,
+  `forum_sync_store.dart`), `widgets/`.
+- `ForumApi` (`services/forum_api.dart`) is the seam to extend: add the method
+  plus its fake, mirroring the existing endpoints.
+- Codegen gate: editing a `@riverpod` source needs
+  `flutter pub run build_runner build --delete-conflicting-outputs` and a
+  committed `.g.dart`. CI blocks on this; local `flutter analyze` does NOT
+  catch it. A clean rebuild is required — incremental can miss the hash.
+- Read `plant_community_mobile/docs/patterns/riverpod.md` and
+  `.../flutter-patterns.md` before writing.
+
+## Acceptance Criteria
+
+- [ ] Edit and delete are reachable from a post the user owns, and absent on
+      one they do not — widget test asserting both
+- [ ] An edit that returns `moderation_status: pending` surfaces that state
+      rather than silently showing the old body — test
+- [ ] A 409 on a frozen topic surfaces as a clear message, not a retry — test
+- [ ] Editing then retrying with changed content does not 422 (key rotation) —
+      test
+- [ ] `flutter test` passes; `flutter analyze` clean
+
+## Work Log
+
+### 2026-07-31 - Promoted out of todo 279
+
+- Todo 279 was a parking todo whose only AC was "prioritize the above into
+  concrete slices". Per `CLAUDE.md` → Review Doc Tracking, promote-all is the
+  only terminal state for a parking epic — re-deferring keeps it open forever.
+  Its 9 deferred items were grouped into 5 todos by what ships together, not
+  split 1:1.
+
+## Notes
+
+p3. Promoted from todo 279 on 2026-07-31. Related: todo 291 (the same write
+path's visibility defect).

--- a/todos/293-pending-p3-mobile-forum-notification-loop.md
+++ b/todos/293-pending-p3-mobile-forum-notification-loop.md
@@ -1,0 +1,93 @@
+---
+status: pending
+priority: p3
+issue_id: "293"
+tags: [forum, flutter, mobile, notifications]
+dependencies: ["260"]
+source_review: "todo 279 (promoted 2026-07-31)"
+---
+
+# Mobile forum: the notification loop — subscriptions, list, push-tap routing
+
+## Problem
+
+The mobile client can receive a push (proven by todo 260 AC4) but the loop
+around it is missing at both ends: a user cannot subscribe to a topic, cannot
+see a notifications list, and tapping a push does not route anywhere. The three
+are one feature — subscribing is what generates the notifications that the list
+shows and the tap opens — so they are grouped rather than shipped separately.
+
+## Findings
+
+- Deferred items 3, 4 and 5 of todo 279 (from todo 260's Recommended Action),
+  grouped here because they are one user-facing loop.
+- Backend is ready on all three: `POST`/`DELETE
+  /forum/topics/{id}/subscription/`; `TopicDetail.isSubscribed` already
+  serialized; `GET /forum/notifications/` (cursor), `unread-count/`,
+  `mark-read/`.
+- The `/forum/topics/:id` param route added in todo 260 is the deep-link
+  target foundation — the routing work is tap → that route, not new routes.
+- **Only the tap→screen routing remains** on the push side. "Receives a push"
+  is already proven; the unbuilt part is the whole `onMessage` /
+  `onMessageOpenedApp` / `getInitialMessage` / background-handler subsystem.
+- Notification payloads carry `post_id` and deep-link data (Wave 1, PR #473),
+  so the tap target can be the exact post, not just the topic.
+- Copy for these notifications now lives in ONE backend table,
+  `backend/apps/forum_host/notification_copy.py` (todo 287) — read the tray
+  wording from there rather than assuming it from a screenshot.
+
+## Recommended Action
+
+1. Subscriptions first (smallest, and it produces the data the other two
+   render): `ForumApi` subscribe/unsubscribe + a toggle on the thread screen
+   driven by `TopicDetail.isSubscribed`.
+2. Notifications list + unread badge: cursor pagination, `mark-read` on tap.
+   **DRF cursor `next`/`previous` are ABSOLUTE URLs** — fetch them verbatim,
+   do not re-prefix the API base (`docs/rules/api.md`).
+3. Push-tap routing last, since it reuses the list's navigation target.
+   `getInitialMessage` (cold start) and `onMessageOpenedApp` (warm) are
+   different entry points and both need covering.
+
+## Technical Details
+
+- Client lives in `plant_community_mobile/lib/features/forum/` — `models/`,
+  `providers/`, `screens/` (`forum_topics_screen.dart`,
+  `forum_thread_screen.dart`, `forum_composer_screen.dart`), `services/`
+  (`forum_api.dart`, `forum_composer_controller.dart`, `forum_sync_service.dart`,
+  `forum_sync_store.dart`), `widgets/`.
+- `ForumApi` (`services/forum_api.dart`) is the seam to extend: add the method
+  plus its fake, mirroring the existing endpoints.
+- Codegen gate: editing a `@riverpod` source needs
+  `flutter pub run build_runner build --delete-conflicting-outputs` and a
+  committed `.g.dart`. CI blocks on this; local `flutter analyze` does NOT
+  catch it. A clean rebuild is required — incremental can miss the hash.
+- Read `plant_community_mobile/docs/patterns/riverpod.md` and
+  `.../flutter-patterns.md` before writing.
+
+## Acceptance Criteria
+
+- [ ] Subscribe/unsubscribe from the thread screen; the toggle reflects
+      `isSubscribed` on load — test
+- [ ] Notifications screen lists notifications and pages correctly through an
+      ABSOLUTE cursor URL — test asserting the second page is fetched verbatim
+- [ ] Unread badge clears on mark-read — test
+- [ ] Tapping a push routes to the topic (and to the post when `post_id` is
+      present), from BOTH a cold start and a warm resume — a test per entry
+      point
+- [ ] `flutter test` passes; `flutter analyze` clean
+
+## Work Log
+
+### 2026-07-31 - Promoted out of todo 279
+
+- Todo 279 was a parking todo whose only AC was "prioritize the above into
+  concrete slices". Per `CLAUDE.md` → Review Doc Tracking, promote-all is the
+  only terminal state for a parking epic — re-deferring keeps it open forever.
+  Its 9 deferred items were grouped into 5 todos by what ships together, not
+  split 1:1.
+
+## Notes
+
+p3. Promoted from todo 279 on 2026-07-31. Related: todo 286 (iOS APNs
+entitlement — blocks push actually arriving on a distributed iOS build, so
+verify tap routing on Android or a dev build until that lands).

--- a/todos/294-pending-p3-mobile-forum-composer-richness.md
+++ b/todos/294-pending-p3-mobile-forum-composer-richness.md
@@ -1,0 +1,84 @@
+---
+status: pending
+priority: p3
+issue_id: "294"
+tags: [forum, flutter, mobile, composer]
+dependencies: ["260"]
+source_review: "todo 279 (promoted 2026-07-31)"
+---
+
+# Mobile forum composer: images and rich text
+
+## Problem
+
+The mobile composer is text-first — it emits only `paragraph` blocks. Images
+cannot be attached at all, and bold/italic/links/lists/mentions/inline-code are
+**rendered** on read but not authorable on mobile. On a plant forum, where the
+question is usually "what is wrong with this leaf", not being able to attach a
+photo from the composer is the sharper of the two gaps.
+
+## Findings
+
+- Deferred items 1 and 9 of todo 279 (from todo 260's Recommended Action),
+  grouped: both are "what the composer can emit".
+- Image path is ready end to end except the client: `POST /forum/images/`
+  (multipart, field `image`, 4-layer validated) returns an id, and the
+  `ForumImageBlock` render path already exists — the composer just needs to
+  append an `image` body block referencing it.
+- The web composer's TipTap FORUM allowlist is the parity target for rich
+  text; the renderer already handles all of it.
+- Upload is security-sensitive: the backend validates extension, MIME, size and
+  PIL-decode, and a settable image reference is checked against the caller's
+  own uploads within the forum collection. The client must not assume an id is
+  usable just because the upload returned one.
+
+## Recommended Action
+
+1. Images first — higher value on this product, and independent of the
+   rich-text work. `image_picker` → `POST /forum/images/` → append an `image`
+   block referencing the returned id.
+2. Rich text second, scoped to the web FORUM allowlist. Do not invent
+   mobile-only marks the renderer cannot display.
+3. Handle upload failure explicitly: a rejected image (size/MIME/decode) must
+   leave the composed text intact, not discard the draft.
+
+## Technical Details
+
+- Client lives in `plant_community_mobile/lib/features/forum/` — `models/`,
+  `providers/`, `screens/` (`forum_topics_screen.dart`,
+  `forum_thread_screen.dart`, `forum_composer_screen.dart`), `services/`
+  (`forum_api.dart`, `forum_composer_controller.dart`, `forum_sync_service.dart`,
+  `forum_sync_store.dart`), `widgets/`.
+- `ForumApi` (`services/forum_api.dart`) is the seam to extend: add the method
+  plus its fake, mirroring the existing endpoints.
+- Codegen gate: editing a `@riverpod` source needs
+  `flutter pub run build_runner build --delete-conflicting-outputs` and a
+  committed `.g.dart`. CI blocks on this; local `flutter analyze` does NOT
+  catch it. A clean rebuild is required — incremental can miss the hash.
+- Read `plant_community_mobile/docs/patterns/riverpod.md` and
+  `.../flutter-patterns.md` before writing.
+
+## Acceptance Criteria
+
+- [ ] An image picked from the device is uploaded and appears as an `image`
+      block in the composed body — test with a fake API
+- [ ] A rejected upload surfaces the error and leaves the drafted text intact —
+      test
+- [ ] Bold/italic/link/list/inline-code round-trip through compose → render —
+      test per mark
+- [ ] `flutter test` passes; `flutter analyze` clean
+
+## Work Log
+
+### 2026-07-31 - Promoted out of todo 279
+
+- Todo 279 was a parking todo whose only AC was "prioritize the above into
+  concrete slices". Per `CLAUDE.md` → Review Doc Tracking, promote-all is the
+  only terminal state for a parking epic — re-deferring keeps it open forever.
+  Its 9 deferred items were grouped into 5 todos by what ships together, not
+  split 1:1.
+
+## Notes
+
+p3. Promoted from todo 279 on 2026-07-31. The image half is worth doing alone
+if the rich-text half slips — they are sequenced, not coupled.

--- a/todos/295-pending-p3-mobile-forum-search-and-profiles.md
+++ b/todos/295-pending-p3-mobile-forum-search-and-profiles.md
@@ -1,0 +1,83 @@
+---
+status: pending
+priority: p3
+issue_id: "295"
+tags: [forum, flutter, mobile]
+dependencies: ["260"]
+source_review: "todo 279 (promoted 2026-07-31)"
+---
+
+# Mobile forum: search and public profiles
+
+## Problem
+
+Two read-path gaps in the mobile client: there is no search, and author names
+and avatars render inert — tapping one does nothing, even though a public
+profile endpoint exists. Both are discovery features, both are read-only, and
+both are backed by endpoints that already ship.
+
+## Findings
+
+- Deferred items 6 and 7 of todo 279 (from todo 260's Recommended Action),
+  grouped: both are read-only discovery over existing endpoints.
+- `GET /forum/search/?q=&board=` is offset-paged and returns `*_has_more`
+  flags — a different pagination shape from the cursor-paged topic/post lists,
+  so it needs its own paging code, not the existing helper.
+- Search has a documented honesty contract from Wave 1 (PR #473): the response
+  reports what was actually searched. Surface that rather than implying
+  full-corpus coverage.
+- The premium semantic section (`?semantic=1`) is gated by
+  `FORUM_VECTOR_SEARCH_ENABLED` and reports `semantic_status: "unavailable"`
+  when off — the client must handle that state, not treat it as an error.
+- `GET /forum/users/{username}/` backs the profile screen. Author identity is
+  serialized through one shared shape with a `[deleted]` sentinel OBJECT —
+  a deleted author is not a null, and tapping one must not navigate.
+
+## Recommended Action
+
+1. Search screen: query + optional board filter, offset paging off
+   `*_has_more`. Render the honesty/`semantic_status` state rather than
+   hiding it.
+2. Make author names/avatars tappable through to a profile screen, EXCEPT the
+   `[deleted]` sentinel.
+3. Reuse the existing author widget so the identity shape stays single-sourced
+   with the thread and topic lists.
+
+## Technical Details
+
+- Client lives in `plant_community_mobile/lib/features/forum/` — `models/`,
+  `providers/`, `screens/` (`forum_topics_screen.dart`,
+  `forum_thread_screen.dart`, `forum_composer_screen.dart`), `services/`
+  (`forum_api.dart`, `forum_composer_controller.dart`, `forum_sync_service.dart`,
+  `forum_sync_store.dart`), `widgets/`.
+- `ForumApi` (`services/forum_api.dart`) is the seam to extend: add the method
+  plus its fake, mirroring the existing endpoints.
+- Codegen gate: editing a `@riverpod` source needs
+  `flutter pub run build_runner build --delete-conflicting-outputs` and a
+  committed `.g.dart`. CI blocks on this; local `flutter analyze` does NOT
+  catch it. A clean rebuild is required — incremental can miss the hash.
+- Read `plant_community_mobile/docs/patterns/riverpod.md` and
+  `.../flutter-patterns.md` before writing.
+
+## Acceptance Criteria
+
+- [ ] Search returns results and pages via `*_has_more` — test
+- [ ] With vector search disabled, `semantic_status: "unavailable"` renders as
+      a state, not an error — test
+- [ ] Tapping an author opens their profile; tapping a `[deleted]` author does
+      nothing — test asserting both
+- [ ] `flutter test` passes; `flutter analyze` clean
+
+## Work Log
+
+### 2026-07-31 - Promoted out of todo 279
+
+- Todo 279 was a parking todo whose only AC was "prioritize the above into
+  concrete slices". Per `CLAUDE.md` → Review Doc Tracking, promote-all is the
+  only terminal state for a parking epic — re-deferring keeps it open forever.
+  Its 9 deferred items were grouped into 5 todos by what ships together, not
+  split 1:1.
+
+## Notes
+
+p3. Promoted from todo 279 on 2026-07-31.

--- a/todos/archive/279-completed-p3-forum-mobile-client-followups.md
+++ b/todos/archive/279-completed-p3-forum-mobile-client-followups.md
@@ -1,5 +1,5 @@
 ---
-status: pending
+status: completed
 priority: p3
 issue_id: "279"
 tags: [forum, flutter, mobile]
@@ -58,11 +58,66 @@ tracks them.
 
 ## Acceptance Criteria
 
-- [ ] Prioritize the above into concrete slices (Flutter-client wave of the
+- [x] Prioritize the above into concrete slices (Flutter-client wave of the
       forum app-loop roadmap) — this is a tracking/grouping todo, not a single
       unit of work; split per item as picked up.
 
+## Promotion map (2026-07-31)
+
+Every one of the 9 deferred items is promoted. Nothing is re-deferred — per
+`CLAUDE.md` → Review Doc Tracking, promote-all is the only terminal state for a
+parking todo, because re-deferring keeps it open forever.
+
+| Deferred item | Promoted to |
+| --- | --- |
+| 8. Reply-visibility after posting | **todo 291** (p2) |
+| 2. Edit / delete | todo 292 |
+| 3. FCM push-tap deep-linking | todo 293 |
+| 4. Subscriptions | todo 293 |
+| 5. Notifications list | todo 293 |
+| 1. Image-in-composer | todo 294 |
+| 9. Rich composer | todo 294 |
+| 6. Search | todo 295 |
+| 7. Public profiles | todo 295 |
+
+Grouped by what ships together rather than split 1:1 — 9 one-item todos would
+have been bookkeeping, not planning (precedent: todo 263 produced 4 from a
+comparable list, todo 272 produced 3).
+
+- **291 is p2, not p3** — the only item in the list that is a *defect* rather
+  than absent functionality, and its failure mode (a successful write that
+  leaves no visible trace) actively invites duplicate posts.
+- **293 groups three items** because subscriptions, the notifications list and
+  push-tap routing are one loop: subscribing generates what the list shows and
+  the tap opens. Shipping them apart means shipping a list with nothing in it.
+- **294 groups two** because both answer "what can the composer emit"; the
+  image half is sequenced first and is worth shipping alone if the rich-text
+  half slips.
+- **295 groups two** because both are read-only discovery over endpoints that
+  already exist.
+
 ## Work Log
+
+### 2026-07-31 - Closed by promote-all (run 2026-07-31-0411)
+
+- All 9 deferred items promoted into todos 291–295 (see the Promotion map
+  above). Each carries `source_review: "todo 279 (promoted 2026-07-31)"`,
+  `dependencies: ["260"]`, and concrete acceptance criteria — this todo's items
+  were feature *descriptions*, not testable criteria, which is why it could
+  never be finished as written.
+- Verification for this todo is the files existing, not a command: its AC is a
+  planning outcome. Evidence quoted in the run summary
+  (`git status --short` showing the five new todo files).
+- Facts re-checked against the code before promoting rather than trusted from
+  the 2026-07-25 text: the client layout under
+  `plant_community_mobile/lib/features/forum/` (models/providers/screens/
+  services/widgets, with `forum_api.dart` as the seam) is as described, and
+  each item's backend endpoint was confirmed to exist. Two details were added
+  that the original list did not carry and that change how the work is done:
+  search is **offset**-paged with `*_has_more` (not cursor-paged like the other
+  lists, so it needs its own paging code), and forum notification copy now
+  lives in a single backend table (`apps/forum_host/notification_copy.py`,
+  todo 287) rather than being duplicated per surface.
 
 ### 2026-07-25 - Created from todo 260 (deferred scope)
 


### PR DESCRIPTION
Closes todo 279. **Docs only** — no code changes.

## Why this couldn't just be "done"

Todo 279 was a *parking todo*: 9 items deferred from the mobile forum client epic (todo 260) under a single acceptance criterion — "prioritize the above into concrete slices". Its items were feature *descriptions*, not testable criteria, so it could never be finished as written.

Per `CLAUDE.md` → Review Doc Tracking, **promote-all is the only terminal state for a parking epic**: re-deferring keeps it open forever. So every one of the 9 is promoted; nothing is re-deferred.

## Promotion map

| Deferred item | → |
|---|---|
| 8. Reply-visibility after posting | **291 (p2)** |
| 2. Edit / delete | 292 |
| 3. Push-tap deep-linking · 4. Subscriptions · 5. Notifications list | 293 |
| 1. Image-in-composer · 9. Rich composer | 294 |
| 6. Search · 7. Public profiles | 295 |

Grouped by what ships together rather than split 1:1 — 9 one-item todos would have been bookkeeping, not planning. (Precedent: todo 263 produced 4 from a comparable list; 272 produced 3.)

- **291 is p2, not p3** like its siblings. It is the only item in the list that is a *defect* rather than absent functionality, and its failure mode — a successful write that leaves no visible trace — actively invites duplicate posts.
- **293 groups three** because subscriptions, the list, and push-tap routing are one loop: subscribing generates what the list shows and the tap opens. Shipping them apart means shipping a list with nothing in it.
- **294 groups two** because both answer "what can the composer emit". The image half is sequenced first and is worth shipping alone if rich text slips — on a plant forum, "attach a photo of the leaf" beats bold/italic.
- **295 groups two** because both are read-only discovery over endpoints that already exist.

## Re-verified, not transcribed

Facts were checked against the code before promoting rather than trusted from the 2026-07-25 text. Two details the original list did not carry, both of which change how the work is done:

- **Forum search is OFFSET-paged** with `*_has_more` flags — a different shape from the cursor-paged topic/post lists, so it needs its own paging code rather than the existing helper.
- **Forum notification copy now lives in one backend table** (`apps/forum_host/notification_copy.py`, todo 287) rather than duplicated per surface, so 293 should read tray wording from there.

Each new todo also carries the relevant standing gotchas inline — idempotency-key rotation on edit (a stale key wedges a permanent 422), absolute DRF cursor URLs, the `[deleted]` author sentinel being an object rather than a null, and the codegen gate CI enforces but `flutter analyze` does not.

## Verification

The AC here is a planning outcome, not a command — evidence is the files existing:

```
$ git status --short
A  todos/291-pending-p2-mobile-forum-reply-not-visible-after-posting.md
A  todos/292-pending-p3-mobile-forum-edit-and-delete.md
A  todos/293-pending-p3-mobile-forum-notification-loop.md
A  todos/294-pending-p3-mobile-forum-composer-richness.md
A  todos/295-pending-p3-mobile-forum-search-and-profiles.md
R  todos/279-pending-... -> todos/archive/279-completed-...
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)