### PR TITLE
docs: codify findings from the 2026-07-31 p3 sweep

### DIFF
--- a/.claude/agents/cross-cutting-reviewer.md
+++ b/.claude/agents/cross-cutting-reviewer.md
@@ -110,6 +110,36 @@ sharpens a rule already there, cite that rule rather than re-flagging it.
       (Firestore owner-scoping and IAM least-privilege are in
       `docs/rules/firebase.md` — audit against Step 1, don't restate here)
 
+**Would this test fail?** (added 2026-07-31; three shipped-as-coverage tests in
+one session pinned nothing)
+
+- [ ] For each NEW test, name the single change that would turn it red. If you
+      cannot, that is the finding — report it as a hollow test even when the
+      assertions look substantive
+- [ ] Does the test body **reimplement** the call it names (a copied
+      `get_or_create(defaults={…})`, request construction, or lambda) instead of
+      invoking the production function? A hand-rolled copy is correct by
+      construction and can never fail — the real call site regresses freely
+- [ ] For a test pinning one arm of a compound condition (`A and B`), could the
+      OTHER arm satisfy it alone? Fakes that clear related state (a sign-out
+      fake nulling `currentUser`) routinely mask the arm under test
+- [ ] For a status-code assertion on an endpoint with layered validation: could
+      a different validator return that same code? Assert the message
+- [ ] Does a fixture use `.update()` and then pass the STALE in-memory instance
+      to `force_authenticate` / a view / a service? The test then exercises the
+      pre-change value
+
+**Refactor blast radius**
+
+- [ ] Grep the callers of anything refactored for a stated invariant in prose
+      ("can never raise", "always returns", "never blocks"). A caller's retry
+      config or error handling may depend on it, from a file the diff never
+      opens — "unreachable today" is not a reason to skip a guard an invariant
+      rests on (`docs/rules/celery.md`)
+- [ ] After deleting a function, sweep for resources only it referenced
+      (templates via `template_name=`, enum members, settings keys) — and verify
+      each candidate individually rather than deleting by association
+
 ## Output Format (Review Mode)
 
 Return ONLY this JSON structure (no surrounding prose, no markdown fences in the actual response — the example fences below show the schema):

--- a/docs/LEARNINGS.md
+++ b/docs/LEARNINGS.md
@@ -2589,3 +2589,91 @@ Edit/Write calls against repo files, and the load-bearing half of this is a
 `gh api` action against repo settings, which is invisible to it (same limitation
 as the 2026-07-14 entry).
 **Agent**: n/a — repo-settings + CI action, not a reviewable application diff.
+
+---
+
+## 2026-07-31 — A background reviewer agent is a second pytest invocation (todo 285)
+
+**What broke.** Mid-way through todo 285, a passing 8-test file started failing
+7 of 8 at *setup* with:
+
+```
+psycopg2.errors.UniqueViolation: duplicate key value violates unique constraint
+  "pg_type_typname_nsp_index"
+DETAIL:  Key (typname, typnamespace)=(wagtailsearch_indexentry, 2200) already exists.
+```
+
+No code had changed between the green run and the red one. The next run
+reported `1 passed` for the same 8 tests.
+
+**Root cause.** A `wagtail-reviewer` subagent had been launched with
+`run_in_background: true`. Reviewer agents have `Bash`, and this one ran the
+test suite to check the diff — concurrently with the foreground run. Both
+`pytest-django` processes raced to create the same test database. This project
+already had the rule "never run two pytest invocations concurrently — they share
+one test DB and produce phantom mass failures"; what was not written down is
+that **a background subagent counts as one of the two**, and it is invisible in
+the shell.
+
+**Fix.** Wait for the background agent, then `--create-db`. The failures
+vanished with no source change, which is itself the tell: a mass failure at
+*setup* with an unchanged diff is infrastructure, not code — do not start
+debugging the diff.
+
+**Second, worse consequence.** The same agent was still running when the
+foreground work moved to the next todo and switched branches. It said so in its
+own output: *"the shared checkout was switched by a concurrent process to a
+different branch, so the new/changed tests in this file were never confirmed to
+execute cleanly against this diff."* Its findings were still real — one was a
+comment at `wagtail_forum/api/views.py` that this exact diff had made false, at
+the precise call site the change lands on — and cost a follow-up commit on an
+already-pushed PR.
+
+**Rules taken from this:**
+
+- A background subagent with `Bash` shares the working tree, the branch, AND the
+  test database. Treat it as a second developer in the same checkout.
+- Run reviewers **synchronously** when the next step is `git checkout`, or do not
+  switch branches until they report. A reviewer that outlives its branch reviews
+  a checkout that no longer matches its diff.
+- Never run pytest while one is outstanding.
+
+**Related:** `docs/LEARNINGS.md` 2026-06-22 (the original `--reuse-db` phantom
+failures), todo 265 (51 fake failures vs a clean 533).
+
+---
+
+## 2026-07-31 — Consolidating duplicated copy can falsify an invariant in a file you never open (todo 287)
+
+**Context.** Todo 287 folded forum notification wording — previously duplicated
+in the email service and the FCM push tray — into one table. A pure refactor,
+no user-facing string changed, full suite green.
+
+**What review found.** The new email path did
+`subject, message = email_content("reply_added", ...)`, unpacking a value whose
+signature says it can be `None`. Unreachable today, so it was left unguarded
+under "don't write speculative branches."
+
+But `apps/forum_host/tasks.py::send_forum_email_batch` justifies its
+`autoretry_for=(OperationalError,)` with an explicit documented invariant: *the
+send loop can never raise*, because email has no collapse-key dedup, so a retry
+after a partial send double-emails everyone. A `TypeError` from that unpack is
+not in `autoretry_for` — it would abort the batch mid-loop and **silently skip
+every remaining recipient**, with no retry and no error surfaced to the
+recipients who never got their email.
+
+**The generalisable lesson.** "Is this branch reachable?" is the wrong question
+when a caller's safety argument depends on the callee never raising. The
+invariant lived in a docstring in a different app, in a file the change never
+opened, and no test could have caught it — the failure needs a table state that
+does not exist yet. Grep the callers of anything you refactor for a stated
+invariant ("can never raise", "always returns", "never blocks") before deciding
+a guard is speculative. Codified as a bullet in `docs/rules/celery.md`.
+
+**Also worth carrying:** deleting a method orphans its resources. Removing three
+uncalled `send_forum_*` methods orphaned `templates/emails/new_forum_topic.html`
+(its only reference was that method's `template_name=`). Two sibling templates
+and their `EmailType` members looked equally orphaned but were NOT — they stay
+wired in `_get_email_template_for_type` and drive preference gating. Sweep for
+residue after a deletion, and verify each candidate rather than deleting by
+association.

--- a/docs/rules/celery.md
+++ b/docs/rules/celery.md
@@ -29,3 +29,15 @@ Compact checklist auto-injected before edits. Long-form:
   most 4 distinct collapse keys per offline device, so unique per-post keys
   silently drop all but 4 notifications accumulated offline; a fixed
   per-event key still dedupes the retry-after-timeout case it exists for.
+- **A retry config justified by "this loop can never raise" is load-bearing, and
+  a change to any CALLEE can falsify it from another file.** `send_forum_email_batch`
+  documents that all `OperationalError`-raising DB access happens before the send
+  loop, so `autoretry_for` can only fire before any email is sent — email has no
+  collapse-key dedup, so a retry after a partial send double-emails everyone. A
+  refactor of `notification_service` introduced an unpack that could raise
+  `TypeError` inside that loop: not in `autoretry_for`, so it would abort the
+  batch mid-loop and silently skip every remaining recipient, with no retry.
+  When you edit anything a task's loop calls, re-read the task's docstring for a
+  stated invariant and guard rather than propagate (return a falsy result + log).
+  "Unreachable today" is not a reason to skip the guard when an invariant depends
+  on it (todo 287).

--- a/docs/rules/database.md
+++ b/docs/rules/database.md
@@ -114,3 +114,14 @@ Compact checklist auto-injected before edits. Long-form:
   and clamp rather than trust a configurable bound: `min(get_setting("X"), COLUMN_MAX)`.
   A host raising a setting past the column width must not be able to turn a
   validation error into a server error (todo 276, taggit `Tag.name` VARCHAR(100)).
+- **A `get_or_create(defaults=…)` value that costs a query must be a CALLABLE, not
+  a computed value.** Django resolves callable defaults only inside the
+  `except DoesNotExist` branch (`params = dict(resolve_callables(params))`,
+  `db/models/query.py` — verified against the installed 6.0.7), so
+  `defaults={"x": lambda: expensive_lookup()}` pays nothing on the common
+  already-exists path, while `defaults={"x": expensive_lookup()}` pays on EVERY
+  call. This matters most in signal handlers, where the row usually exists:
+  `wagtail_forum/signals.py::_refresh_profile` runs on every post
+  publish/unpublish. Pin it by driving the production function under
+  `CaptureQueriesContext` and asserting the extra table is untouched — not by
+  copying the `get_or_create` into the test.

--- a/docs/rules/forum.md
+++ b/docs/rules/forum.md
@@ -107,3 +107,13 @@ Compact checklist auto-injected before edits to the forum code. Long-form:
   rendering it in whichever locale was active at write time corrupts the
   moderation audit trail. Translate what is *displayed*, never what is *stored*
   or *keyed on*.
+- **Resolve a host User by pk with `get_user_model()._base_manager`, never
+  `_default_manager`.** A host whose User model filters its default manager
+  (soft-delete, active-only) returns `None` for exactly those rows, and package
+  code that falls back on `None` then silently degrades for the affected
+  accounts rather than failing. `_base_manager` is unfiltered by contract — it
+  is what Django itself uses to resolve related objects. Same host-agnosticism
+  rule as `settings.AUTH_USER_MODEL` and `get_full_name()`: the package cannot
+  assume this host's manager semantics. Caught in review on todo 285's
+  `ForumProfile.initial_read_watermark_for_user_id`, where the fallback would
+  have reinstated the very bug the todo closed.

--- a/docs/rules/testing.md
+++ b/docs/rules/testing.md
@@ -196,3 +196,30 @@ Compact checklist auto-injected before edits.
   is what exposed it (neuter the guard, expect red); a status-only assertion on an
   endpoint with layered validation is close to a tautology. Assert the specific
   error text so the test fails for the reason it claims (todo 276).
+- **Mutation-verify any test that claims to pin behavior X: break X, expect red,
+  restore.** "It passes" only proves the test runs. Three tests this project
+  shipped as coverage turned out to pin nothing, and each was found this way, not
+  by reading: a query-count test that hand-rolled its own `get_or_create` instead
+  of calling the production function (correct by construction, so it could never
+  fail); a Flutter epoch-guard test satisfied by a *different* arm of an `and`
+  (the uid check, which sign-out breaks anyway — so the generation bump could be
+  deleted silently); a 400-status test that a second validator also satisfied.
+  Restore the source and re-run before proceeding; assert `git status` is clean.
+  Where the same mutation is worth re-running, script it (see todo 288's Work Log
+  for a 6-mutant loop) rather than hand-editing.
+- **A test that reimplements the call it is testing is hollow by construction.**
+  Copying the production `get_or_create(defaults={...})`/request/lambda into the
+  test body and asserting on *that* proves only that your copy is correct — the
+  real call site can regress freely. Drive the production function and assert on
+  its observable effect (captured queries, recorded calls, response), even when
+  that means a looser assertion: `assert not [q for q in captured if user_table
+  in q["sql"]]` beats an exact count over a hand-rolled call. Two independent
+  reviewers flagged the same instance of this in todo 285.
+- **`Model.objects.filter(pk=…).update(field=…)` does not touch your in-memory
+  instance — and `force_authenticate(instance)` hands THAT object to the view.**
+  So a test that backdates `date_joined` (or flips any field) with `.update()`
+  and then authenticates the stale object silently exercises the pre-change
+  value and asserts nothing. Add `instance.refresh_from_db()` with a comment
+  saying it is load-bearing. Cost a full debugging cycle in todo 285; the test
+  failed with a *plausible* message ("a single read collapsed the whole
+  backlog"), which reads like a real bug rather than a broken fixture.

--- a/docs/rules/triggers.json
+++ b/docs/rules/triggers.json
@@ -794,5 +794,21 @@
     "source": "codify: forum/todo-276-content-authoring-remainder",
     "added": "2026-07-29",
     "severity": "warn"
+  },
+  {
+    "id": "package-default-manager-host-user",
+    "domains": [
+      "forum",
+      "database"
+    ],
+    "path_glob": [
+      "backend/packages/**/*.py"
+    ],
+    "content_present": "get_user_model\\(\\)\\._default_manager",
+    "message": "Reusable package: use get_user_model()._base_manager, not _default_manager. A host whose User model filters its default manager (soft-delete/active-only) returns None for those rows, and a None-fallback then silently degrades for exactly those accounts. _base_manager is unfiltered by contract.",
+    "pattern_ref": "docs/rules/forum.md",
+    "source": "codify: codify-2026-07-31-p3-sweep",
+    "added": "2026-07-30",
+    "severity": "warn"
   }
 ]

--- a/plant_community_mobile/docs/patterns/riverpod.md
+++ b/plant_community_mobile/docs/patterns/riverpod.md
@@ -203,3 +203,58 @@ Handle `409` (a twin still in flight → back off and retry the same key) and
 Reference: `lib/features/forum/services/forum_composer_controller.dart`. Note
 the web client sends no key at all — do not copy that; the backend is built for
 mobile retries. See `docs/rules/flutter.md`.
+
+## Unit-testing an `@riverpod` notifier (todo 288)
+
+Two obstacles bite every notifier harness in this repo. Neither needs a
+production seam.
+
+**1. An autoDispose provider must be held, or it rebuilds under you.**
+
+`container.read(someProvider)` on an autoDispose provider builds the notifier
+and immediately tears it down, so the *next* read builds a SECOND one. If
+`build()` starts async work (`AuthService` fires an unawaited token exchange
+when a user is already signed in), that work lands on a disposed `Ref` and
+throws `Cannot use Ref after dispose` — from a line the test never touched.
+Hold a subscription for the harness's lifetime instead:
+
+```dart
+_subscription = container.listen(
+  authServiceProvider,
+  (_, _) {},
+  fireImmediately: true,
+);
+// ...and in dispose(): _subscription.close(); container.dispose();
+```
+
+One notifier instance, as in the app. Also drain `build()`'s fire-and-forget
+work with `await pumpEventQueue()` before teardown, or it lands post-dispose.
+
+**2. `flutter_secure_storage` has a built-in in-memory platform.**
+
+A notifier that reads or writes tokens throws `MissingPluginException` under
+`flutter test`. Do not add an injection seam for it and do not hand-roll a
+method-channel mock — call the package's own `@visibleForTesting` static in
+`setUp`:
+
+```dart
+setUp(() => FlutterSecureStorage.setMockInitialValues({}));
+```
+
+It installs `TestFlutterSecureStoragePlatform` (shipped in
+flutter_secure_storage 10.x). No extra dependency: reaching for
+`FlutterSecureStoragePlatform.instance` directly would require importing the
+transitive `flutter_secure_storage_platform_interface` package, which trips
+`depend_on_referenced_packages`.
+
+**Assert ordering across collaborators with one shared log.** Give every fake
+the same `List<String> events` and append to it. That is what makes a
+cross-object constraint testable — e.g. `clearOnLogout` must run BEFORE the
+Firebase sign-out that invalidates the JWT its PATCH needs:
+
+```dart
+expect(harness.events, containsAllInOrder(['clearOnLogout', 'firebase.signOut']));
+```
+
+Reference: `test/services/auth_service_test.dart`,
+`test/services/push_registration_service_test.dart`.


### PR DESCRIPTION
Codification for the P3 sweep (todos 285, 287, 288, 279 — PRs #516–#519). **Docs + one review-agent checklist. No code.**

Cut as its own branch off `main` rather than folded into any of the four: they all append to `docs/LEARNINGS.md`, so per-branch codification would conflict at merge.

## `docs/rules/`

**testing** — mutation-verify any test that claims to pin behavior X: break X, expect red, restore. Three tests shipped *as coverage* in this one session turned out to pin nothing, and each was found this way rather than by reading:

| Hollow test | Why it could never fail |
|---|---|
| query-count pin (285) | hand-rolled its own `get_or_create` instead of calling the production function |
| epoch-guard pin (288) | satisfied by the *other* arm of an `and` — the uid check, which sign-out breaks anyway |
| 400-status pin (276, prior) | a second validator returned the same code |

Plus the two generalisable shapes: a test that reimplements the call it names is correct by construction; `.update()` followed by `force_authenticate(stale_instance)` silently exercises the pre-change value.

**database** — a `get_or_create(defaults=…)` value that costs a query must be a **callable**. Django resolves callable defaults only inside the `except DoesNotExist` branch (`resolve_callables`, verified against the installed 6.0.7), so a lambda keeps the lookup off the already-exists path — the common one in signal handlers.

**forum** — resolve a host User by pk with `_base_manager`, never `_default_manager`. A soft-delete/active-only host returns `None` for exactly the affected rows, and a `None`-fallback then degrades silently for them. Also registered as a **write-time trigger** (`docs/rules/triggers.json`), scoped to `backend/packages/**/*.py`; `test_match_triggers.py` → 44 tests OK.

**celery** — a retry config justified by "this loop can never raise" is load-bearing, and a change to any *callee* can falsify it from another file.

## `docs/LEARNINGS.md` (2 entries)

**A background reviewer subagent is a second pytest invocation.** One raced the foreground run for the shared test DB and produced 7 phantom `pg_type_typname_nsp_index` setup failures against an unchanged diff. The project already had "never run two pytest invocations concurrently"; what wasn't written down is that a subagent with `Bash` counts as one, invisibly. The same agent then **outlived its branch** — it reported that the checkout had been switched under it and it could not confirm its tests ran against the diff it reviewed. Its findings were real (a comment this very diff had falsified) and cost a follow-up commit on an already-pushed PR.

**Consolidating duplicated copy falsified an invariant in a file the change never opened.** `send_forum_email_batch`'s `autoretry_for` is justified by a docstring invariant — *the send loop can never raise* — because email has no collapse-key dedup, so a retry after a partial send double-emails everyone. The refactor introduced an unpack that could raise `TypeError` inside that loop; not in `autoretry_for`, so it would abort the batch and silently skip every remaining recipient. "Is this branch reachable?" is the wrong question when a caller's safety argument depends on the callee never raising.

## `plant_community_mobile/docs/patterns/riverpod.md`

Unit-testing an `@riverpod` notifier: hold a `container.listen` subscription (an autoDispose provider otherwise rebuilds and lands `build()`'s unawaited work on a disposed `Ref`); use `FlutterSecureStorage.setMockInitialValues` rather than adding a seam or importing the transitive platform-interface package; assert cross-object ordering with one shared events log.

## `.claude/agents/cross-cutting-reviewer.md`

A **"Would this test fail?"** checklist — for each new test, name the single change that would turn it red; if you can't, that's the finding. Plus a refactor-blast-radius checklist (grep callers for prose invariants; sweep for resources orphaned by a deletion, verifying each rather than deleting by association).

🤖 Generated with [Claude Code](https://claude.com/claude-code)