### PR TITLE
todo(280): record the operator decision — not enabling the LLM spam backend yet

### DIFF
--- a/todos/280-in_progress-p3-forum-spam-llm-enable-in-env.md
+++ b/todos/280-in_progress-p3-forum-spam-llm-enable-in-env.md
@@ -213,3 +213,20 @@ Read-only check of the Railway project `PlantID Community` on 2026-07-31:
 
 So flipping the setting means enabling it in production, with real spend, on the
 first try. That is the operator's call, not an automated run's.
+
+**Operator decision, 2026-07-31: not yet — leave this todo open.** Nothing was
+spent and no Railway variable was written. The engineering gate is now fully
+clear (274 + this run's AC1), so enabling is a pure ops action whenever the
+spend is acceptable:
+
+1. Set `WAGTAILFORUM_SPAM_BACKEND=apps.forum_host.spam.LLMSpamBackend` on the
+   `plant_id_community` service.
+2. Restart and watch the four log lines in `backend/docs/patterns/domain/forum.md`
+   → "LLM spam backend" → Enable procedure. `[CIRCUIT] Forum spam LLM attempts
+   cap reached` is the one to alert on — it means screening is holding every
+   post.
+3. Roll back by unsetting the variable; the heuristic default returns with no
+   code change.
+
+Caps in force on day one: 200 verdicts/hr (then degrade to heuristic → publish)
+and 400 provider calls/hr (then hold). Review both against real volume — AC4.


### PR DESCRIPTION
Follow-up to #524, which merged before this note was pushed.

#524 shipped **AC1** of todo 280 (the attempts counter that caps LLM spend
during provider misbehaviour). **AC2–4** — set `WAGTAILFORUM_SPAM_BACKEND` in an
environment, observe a real screen in that environment's logs, review the
tunables against real volume — are operator actions.

Railway has exactly one environment (`production`), `OPENAI_API_KEY` is already
set there, and `WAGTAILFORUM_SPAM_BACKEND` is unset (heuristic default is live),
so enabling means enabling in production on the first try. **Operator decision
2026-07-31: not yet.** No Railway variable was written; nothing was spent.

Todo 280 therefore stays `in_progress` with AC1 checked and AC2–4 open. This
commit records the concrete enable steps and the caps that will be in force
(200 verdicts/hr → degrade to heuristic; 400 provider calls/hr → hold), so the
remaining work is a pure ops action whenever the bill is acceptable.

Docs-only — no code, no tests affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)