### PR TITLE
forum(a11y): author-supplied image alt text, end to end (todo 281 / audit M7)

### DIFF
--- a/backend/packages/wagtail_forum/README.md
+++ b/backend/packages/wagtail_forum/README.md
@@ -194,6 +194,30 @@ alone is not sufficient.
 | `WAGTAILFORUM_IMAGE_MAX_HEIGHT` | `5000` | Layer 4: max pixel height. |
 | `WAGTAILFORUM_IMAGE_COLLECTION_NAME` | `"Forum Images"` | Collection name, created lazily and idempotently under root. |
 
+#### Alt text (M7)
+
+`POST /forum/images/` accepts an optional **`alt`** multipart part alongside
+`image`. It is stripped, truncated to 255 chars, and stored on Wagtail's own
+`Image.description` field; `serialize_image_for_api` returns it as `alt`.
+
+Three consequences worth knowing before changing this:
+
+- **`alt` never falls back to `title`.** `title` is the upload filename, and
+  filename-as-alt is an accessibility anti-pattern — a screen reader announcing
+  `IMG_2481.jpg` is worse than announcing nothing. An image uploaded without
+  `alt` serves `alt: ""`, which is the correct markup for a decorative image.
+  Images uploaded before M7 therefore serve `""` rather than their filename.
+- **Alt is per-image, not per-usage.** The body block value stays a bare image
+  `int`, so re-embedding one upload in a second post reuses the first post's alt.
+  Accepted: forum uploads are effectively single-use, and per-usage alt would
+  mean a StreamField `int` → `dict` data migration across every post *and*
+  revision.
+- **There is no alt PATCH endpoint.** Alt is captured at upload time only;
+  correcting it means uploading the image again. `alt` is also deliberately
+  excluded from the idempotency fingerprint, so a same-key retry carrying
+  corrected alt replays the original response (including the original alt)
+  rather than 422-ing.
+
 ### Reads, caching, and sync
 
 | Setting | Default | Purpose |

--- a/backend/packages/wagtail_forum/wagtail_forum/api/serializers.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/api/serializers.py
@@ -430,6 +430,14 @@ def serialize_image_for_api(image, request=None):
     Serves a bounded `max-1200x1200` rendition (not the 5000px-capped original).
     The URL is made absolute against the request so the web client — served from
     a different origin than the media backend — resolves it correctly.
+
+    `alt` is the AUTHOR-SUPPLIED value on `Image.description` (M7), Wagtail's own
+    alt-text field. It deliberately does NOT fall back to `image.title`: title is
+    the upload filename, and filename-as-alt is an accessibility anti-pattern —
+    a screen reader announcing "IMG_2481.jpg" is worse than announcing nothing,
+    and `alt=""` is the correct markup for a decorative image. Rows uploaded
+    before M7 have `description=""`, so historic posts now serve `alt: ""`
+    instead of a filename. That is the intended improvement, not a regression.
     """
     rendition = image.get_rendition("max-1200x1200")
     url = rendition.url
@@ -438,7 +446,7 @@ def serialize_image_for_api(image, request=None):
     return {
         "id": image.id,
         "url": url,
-        "alt": image.title or "",
+        "alt": image.description or "",
         "width": rendition.width,
         "height": rendition.height,
     }

--- a/backend/packages/wagtail_forum/wagtail_forum/api/views.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/api/views.py
@@ -1240,7 +1240,18 @@ class PostImageUploadView(UnversionedForumAPIMixin, APIView):
         request={
             "multipart/form-data": {
                 "type": "object",
-                "properties": {"image": {"type": "string", "format": "binary"}},
+                "properties": {
+                    "image": {"type": "string", "format": "binary"},
+                    "alt": {
+                        "type": "string",
+                        "maxLength": 255,
+                        "description": (
+                            "Author-supplied alt text (M7). Optional — omit or "
+                            "send empty for a decorative image. Truncated to "
+                            "255 chars. Plain text by contract; never markup."
+                        ),
+                    },
+                },
             }
         },
         responses={201: dict, 400: dict, 401: dict, 409: dict, 422: dict},
@@ -1249,6 +1260,8 @@ class PostImageUploadView(UnversionedForumAPIMixin, APIView):
             "size, PIL decode) into the forum image collection. Returns "
             "{id, url, alt, width, height} with a Location header; reference the "
             "returned id from an `image` body block. Requires authentication. "
+            "An optional `alt` part carries author-supplied alt text (M7); it is "
+            "stored on the image and echoed back as `alt`. "
             "Supports an Idempotency-Key header: a retry with the same key "
             "replays the original response instead of storing a duplicate image "
             "row + file (409 if a same-key twin is mid-flight, 422 on key reuse "
@@ -1265,6 +1278,14 @@ class PostImageUploadView(UnversionedForumAPIMixin, APIView):
         # UploadedFile, not JSON, so fingerprint on a CONTENT hash — name+size
         # alone could collide. seek(0) before hashing (validate may have consumed
         # the stream) AND after (so .create() still stores the full file).
+        #
+        # `alt` is deliberately NOT in the fingerprint (M7). Including it would
+        # 422 a legitimate same-key retry that happens to carry corrected alt
+        # text, since key reuse with a mismatched fingerprint is a 422. The
+        # consequence, accepted: remember() caches the SERIALIZED RESPONSE, so a
+        # replay returns the original alt and a new one sent on the retry is
+        # silently dropped. Re-authoring alt means a fresh upload (no key), which
+        # is also the only way to change it — there is no alt PATCH endpoint.
         cache_key = idempotency_cache_key(request, "image-upload")
         payload_fp = None
         if cache_key:
@@ -1279,6 +1300,13 @@ class PostImageUploadView(UnversionedForumAPIMixin, APIView):
         reserve(cache_key)  # 409 if a same-key twin is mid-flight (atomic add)
         image = get_image_model().objects.create(
             title=(image_file.name or "forum-image")[:255],
+            # Author-supplied alt (M7), stored on Wagtail's own alt-text field.
+            # Truncated rather than 400'd, matching the title idiom above: a
+            # too-long alt is a UI slip, not a malformed request, and the
+            # column is CharField(max_length=255) so an unbounded value would
+            # raise DataError. Empty is legitimate — a decorative image should
+            # carry alt="", which beats a filename for a screen reader.
+            description=(request.data.get("alt") or "").strip()[:255],
             file=image_file,
             collection=get_forum_image_collection(),
             uploaded_by_user=request.user,

--- a/backend/packages/wagtail_forum/wagtail_forum/api/views.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/api/views.py
@@ -1225,6 +1225,21 @@ class PostRevisionDetailView(UnversionedForumAPIMixin, APIView):
         )
 
 
+def _alt_text(request) -> str:
+    """Author-supplied alt text off a multipart upload (M7), bounded and safe.
+
+    Deliberately `isinstance(str)` rather than a bare `.get("alt")`:
+    ``request.data`` MERGES POST and FILES under MultiPartParser, so a client
+    sending `alt` as a file part yields an ``UploadedFile`` and `.strip()` on it
+    raises ``AttributeError`` — a 500 on a malformed request. Anything that is
+    not a plain string is treated as no alt at all.
+    """
+    value = request.data.get("alt")
+    if not isinstance(value, str):
+        return ""
+    return value.strip()[:255]
+
+
 class PostImageUploadView(UnversionedForumAPIMixin, APIView):
     """Upload an inline post image (4-layer validated) into the forum collection.
 
@@ -1306,7 +1321,7 @@ class PostImageUploadView(UnversionedForumAPIMixin, APIView):
             # column is CharField(max_length=255) so an unbounded value would
             # raise DataError. Empty is legitimate — a decorative image should
             # carry alt="", which beats a filename for a screen reader.
-            description=(request.data.get("alt") or "").strip()[:255],
+            description=_alt_text(request),
             file=image_file,
             collection=get_forum_image_collection(),
             uploaded_by_user=request.user,

--- a/backend/packages/wagtail_forum/wagtail_forum/tests/api/test_post_image_upload.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/tests/api/test_post_image_upload.py
@@ -384,3 +384,24 @@ def test_alt_is_not_part_of_the_idempotency_fingerprint():
     assert retry.status_code == 201  # replayed, not 422
     assert retry.data["id"] == first.data["id"]  # no duplicate row
     assert retry.data["alt"] == "first alt"  # the documented trade
+
+
+@pytest.mark.django_db
+def test_alt_sent_as_a_file_part_is_ignored_not_a_500():
+    """`request.data` MERGES POST and FILES under MultiPartParser.
+
+    So an `alt` sent as a file arrives as an UploadedFile, and calling .strip()
+    on it raised AttributeError -> 500. Found by review of this PR; the happy-
+    path tests above all send `alt` as a plain field and never exercised it.
+    """
+    resp = _auth_client().post(
+        URL,
+        {
+            "image": _upload(),
+            "alt": SimpleUploadedFile("evil.txt", b"hi", content_type="text/plain"),
+        },
+        format="multipart",
+    )
+    assert resp.status_code == 201
+    assert resp.data["alt"] == ""
+    assert get_image_model().objects.get(id=resp.data["id"]).description == ""

--- a/backend/packages/wagtail_forum/wagtail_forum/tests/api/test_post_image_upload.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/tests/api/test_post_image_upload.py
@@ -288,3 +288,99 @@ def test_upload_idempotency_key_reuse_with_different_image_is_422():
     assert r1.status_code == 201
     assert r2.status_code == 422
     assert get_image_model().objects.count() == 1
+
+
+# ---------------------------------------------------------------------------
+# Author-supplied alt text (M7 / todo 281)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_alt_part_is_stored_on_the_image_and_returned():
+    """The whole point: a human-authored value enters the round-trip."""
+    resp = _auth_client().post(
+        URL,
+        {"image": _upload(), "alt": "A monstera leaf with brown edges"},
+        format="multipart",
+    )
+    assert resp.status_code == 201
+    assert resp.data["alt"] == "A monstera leaf with brown edges"
+    image = get_image_model().objects.get(id=resp.data["id"])
+    # Stored on Wagtail's own alt-text field, NOT title — title stays the
+    # filename for admin identification.
+    assert image.description == "A monstera leaf with brown edges"
+    assert image.title == "ok.jpg"
+
+
+@pytest.mark.django_db
+def test_upload_without_alt_returns_empty_string_not_the_filename():
+    """Filename-as-alt is the anti-pattern this todo exists to remove.
+
+    An empty alt is correct for a decorative image and is strictly better for a
+    screen reader than "ok.jpg".
+    """
+    resp = _auth_client().post(
+        URL, {"image": _upload(name="IMG_2481.jpg")}, format="multipart"
+    )
+    assert resp.status_code == 201
+    assert resp.data["alt"] == ""
+    assert "IMG_2481" not in resp.data["alt"]
+    assert get_image_model().objects.get(id=resp.data["id"]).description == ""
+
+
+@pytest.mark.django_db
+def test_blank_and_whitespace_only_alt_normalise_to_empty():
+    resp = _auth_client().post(
+        URL, {"image": _upload(), "alt": "   "}, format="multipart"
+    )
+    assert resp.status_code == 201
+    assert resp.data["alt"] == ""
+
+
+@pytest.mark.django_db
+def test_over_long_alt_is_truncated_not_a_dataerror():
+    """`description` is CharField(max_length=255) — an unbounded value would
+    raise DataError on a strict backend. Truncate, matching the title idiom."""
+    resp = _auth_client().post(
+        URL, {"image": _upload(), "alt": "x" * 400}, format="multipart"
+    )
+    assert resp.status_code == 201
+    assert len(resp.data["alt"]) == 255
+    assert get_image_model().objects.get(id=resp.data["id"]).description == "x" * 255
+
+
+@pytest.mark.django_db
+def test_alt_is_surrounding_whitespace_stripped():
+    resp = _auth_client().post(
+        URL, {"image": _upload(), "alt": "  a fern frond  "}, format="multipart"
+    )
+    assert resp.status_code == 201
+    assert resp.data["alt"] == "a fern frond"
+
+
+@pytest.mark.django_db
+def test_alt_is_not_part_of_the_idempotency_fingerprint():
+    """A same-key retry carrying different alt must REPLAY, not 422.
+
+    Deliberate (M7): the fingerprint stays on file content alone, so a flaky-
+    network retry that re-sends corrected alt is not rejected. The accepted
+    consequence is that the replay returns the ORIGINAL alt.
+    """
+    client = _auth_client()
+    first = client.post(
+        URL,
+        {"image": _upload(), "alt": "first alt"},
+        format="multipart",
+        HTTP_IDEMPOTENCY_KEY="k-alt-1",
+    )
+    assert first.status_code == 201
+
+    retry = client.post(
+        URL,
+        {"image": _upload(), "alt": "corrected alt"},
+        format="multipart",
+        HTTP_IDEMPOTENCY_KEY="k-alt-1",
+    )
+    assert retry.status_code == 201  # replayed, not 422
+    assert retry.data["id"] == first.data["id"]  # no duplicate row
+    assert retry.data["alt"] == "first alt"  # the documented trade

--- a/backend/packages/wagtail_forum/wagtail_forum/tests/api/test_post_list.py
+++ b/backend/packages/wagtail_forum/wagtail_forum/tests/api/test_post_list.py
@@ -103,7 +103,13 @@ def _topic_with_image_posts(n):
     )
     for i in range(n):
         image = get_image_model().objects.create(
-            title=f"img{i}", file=get_test_image_file(), collection=collection
+            # title = the upload filename (admin identification);
+            # description = the author-supplied alt text (M7). Kept distinct so
+            # the alt assertion below discriminates between the two.
+            title=f"img{i}",
+            description=f"authored alt {i}",
+            file=get_test_image_file(),
+            collection=collection,
         )
         Post.objects.create(
             topic=topic,
@@ -127,7 +133,11 @@ def test_post_list_serializes_image_blocks_to_renditions():
     assert [b["type"] for b in blocks] == ["paragraph", "image"]
     image_value = blocks[1]["value"]
     assert set(image_value) == {"id", "url", "alt", "width", "height"}
-    assert image_value["alt"] == "img0"
+    # M7: alt is the AUTHORED value (Image.description), never the filename
+    # (Image.title). Both assertions matter — the second is what would catch a
+    # regression back to filename-as-alt.
+    assert image_value["alt"] == "authored alt 0"
+    assert "img0" not in image_value["alt"]
     assert image_value["url"].startswith("http://testserver")  # absolute, cross-origin
     assert image_value["width"] > 0 and image_value["height"] > 0
 

--- a/docs/LEARNINGS.md
+++ b/docs/LEARNINGS.md
@@ -2790,3 +2790,76 @@ an already-mocked shared helper silently redefines every blanket
 verdict budget ran out"; after this change it means "both counters are
 exhausted". The affected test asserted publish and went red, so it was caught —
 one asserting the fail-closed side would have gone green for the wrong reason.
+
+---
+
+## 2026-07-31 — Two defects that only the *unexercised* path could reveal (todo 281 / M7)
+
+**Area:** DRF multipart parsing + React unmount semantics. Both were introduced
+and caught within PR #526; both had passing tests around them the whole time.
+
+### 1. `request.data` merges POST and FILES — a text field can arrive as a file
+
+The forum image upload gained an optional `alt` text part:
+
+```python
+description=(request.data.get("alt") or "").strip()[:255]
+```
+
+Under `MultiPartParser`, DRF's `request.data` is a merge of POST **and** FILES.
+A client sending `alt` as a *file* part therefore yields an `UploadedFile`,
+which is truthy, so the `or ""` guard passes it straight to `.strip()`:
+
+```
+AttributeError: 'InMemoryUploadedFile' object has no attribute 'strip'
+STATUS: 500
+```
+
+A malformed request returning 500 instead of 400. **Fix:** accept only
+`isinstance(value, str)`; anything else is treated as absent.
+
+**Why six tests missed it:** every one sent `alt` as a field, because that is
+what the client does. The test suite mirrored the happy client, not the wire
+format the endpoint actually accepts.
+
+### 2. React discards a `setState` on an unmounting component *without running the updater*
+
+The composer's alt prompt holds an `URL.createObjectURL` preview that must be
+revoked. The unmount cleanup did the revoking inside a functional updater:
+
+```jsx
+useEffect(() => () => {
+  setAltPrompt((current) => {          // <-- never invoked
+    if (current) URL.revokeObjectURL(current.previewUrl);
+    return null;
+  });
+}, []);
+```
+
+This is a no-op. React drops the update on an unmounting fiber and never calls
+the function, so the blob leaks on any unmount-while-open (navigating away
+mid-prompt; the composer is also remounted via `key=` after every reply).
+Measured directly rather than reasoned about:
+
+```
+REVOKE CALLS AFTER UNMOUNT: 0
+```
+
+**Fix:** mirror the URL into a `useRef` and read the ref in the cleanup. A ref is
+a plain object and is still readable while unmounting.
+
+**Why the existing test missed it:** it exercised the *Skip* path, which works.
+It proved the mechanism (revoke is wired up) without proving the case (revoke
+happens on unmount). A test of one exit path says nothing about the others, and
+"cleanup on unmount" is exactly the path no ordinary interaction test touches.
+
+### Generalisable
+
+Both defects share a shape: **the code was correct for the path the tests drove,
+and the untested path was the one with different semantics.** When a value must
+be released, enumerate exit paths (confirm / cancel / keyboard / unmount) and
+test each; when an endpoint parses a field, enumerate wire shapes (field / file /
+absent / repeated), not just the one your own client sends.
+
+Codified as write-time triggers `drf-multipart-data-get-string-method` and
+`react-setstate-in-unmount-cleanup`.

--- a/docs/audits/2026-07-11-forum-modernization.md
+++ b/docs/audits/2026-07-11-forum-modernization.md
@@ -296,8 +296,9 @@ Deferred findings converted to todos (Review Doc Tracking convention — the
 - [x] #H6 solved-accepted-answer → todo 273 (completed 2026-07-31, Wave 2 slice 2;
       re-pointed 2026-07-23 when the roadmap moved solved answers to Wave 2 / not 256).
       Todo 273 closed 2026-07-31 once slice 3 (#M6) landed. The
-      all-findings-resolved rename still must NOT fire on this doc — #M2, #M7,
-      #M8, #M9, #M10 and #M13 remain open against other todos.
+      all-findings-resolved rename still must NOT fire on this doc — #M2, #M8,
+      #M9, #M10 and #M13 remain open against other todos (#M7 closed
+      2026-07-31 via todo 281).
 - [x] #H7 public-user-identity → todo 257 (completed 2026-07-24, PR #492)
 - [x] #H8 search-discoverability-filters → todo 256 (completed 2026-07-23)
 - [x] #H9 seo-surface → todo 256 (completed 2026-07-23)
@@ -326,8 +327,7 @@ Deferred findings converted to todos (Review Doc Tracking convention — the
       snapshot, not the FK the finding implied: the identify endpoint persists
       nothing, so there is no server-side record to reference — see the todo's
       Work Log.
-- [ ] #M7 image-authoring-alt-text → todo 281 (re-pointed 2026-07-26; promoted out
-      of 263 at p2 — a11y, not polish)
+- [x] #M7 image-authoring-alt-text → todo 281 (completed 2026-07-31)
 - [ ] #M8 polls → todo 283 (re-pointed 2026-07-26; promoted out of 263 with M2)
 - [ ] #M9 block-mute → todo 284 (re-pointed 2026-07-26; promoted out of 263)
 - [ ] #M10 private-messaging → todo 284 (re-pointed 2026-07-26; promoted out of 263,

--- a/docs/rules/api.md
+++ b/docs/rules/api.md
@@ -110,3 +110,10 @@ Compact checklist auto-injected before edits. Long-form:
   enforced after the expensive step is documentation, not a limit. Pair it with
   O(1) dedup — an `if x not in list` accumulator over request-controlled input is
   O(n^2) (todo 276: 30k tags = 2.24s).
+- **DRF's `request.data` MERGES POST and FILES under `MultiPartParser`** — so a
+  field you expect as text can arrive as an `UploadedFile`, and any string
+  method on it raises `AttributeError` → **500**, not 400. `(request.data.get("alt")
+  or "").strip()` is the shape that bites (todo 281). Guard with
+  `isinstance(value, str)` and treat anything else as absent. Happy-path tests
+  send the field as a field and never exercise this — write the file-part case
+  explicitly for every text field on a multipart endpoint.

--- a/docs/rules/react.md
+++ b/docs/rules/react.md
@@ -93,3 +93,17 @@ Compact checklist auto-injected before edits. Long-form:
   and check `err.status`. Mock rejections with the REAL message the backend
   sends — todo 282 shipped past a green test that mocked
   `Error('HTTP 403 Forbidden')`, a string that endpoint never produces.
+- **Never do cleanup work inside a `setState` updater in an unmount effect.**
+  React DISCARDS a `setState` on an unmounting component *without invoking the
+  updater*, so `return () => setThing((cur) => { release(cur); return null; })`
+  silently does nothing — measured 0 calls in todo 281's object-URL revoke.
+  It reads as correct, and a test of any OTHER exit path (a button, Escape)
+  passes while the unmount path leaks. Mirror the value into a `useRef` and read
+  the ref in the cleanup; a ref is a plain object and survives unmount. Test the
+  unmount path *specifically* (`const { unmount } = render(...)`), because the
+  happy-path test cannot fail on this.
+- **`URL.createObjectURL` needs a matching `revokeObjectURL` on EVERY exit
+  path** — confirm, cancel, keyboard dismiss, and unmount. Route them all
+  through one `close()` helper rather than revoking at each call site; jsdom
+  implements neither method, so stub both in tests and spy the revoke (the leak
+  is otherwise invisible).

--- a/docs/rules/triggers.json
+++ b/docs/rules/triggers.json
@@ -827,5 +827,40 @@
     "source": "codify: todo-280-forum-spam-attempts-counter",
     "added": "2026-07-31",
     "severity": "warn"
+  },
+  {
+    "id": "drf-multipart-data-get-string-method",
+    "domains": [
+      "api",
+      "security"
+    ],
+    "path_glob": [
+      "backend/**/views.py",
+      "backend/**/*_views.py",
+      "backend/**/serializers.py"
+    ],
+    "content_present": "request\\.data\\.get\\([^\\n]*\\.(strip|lower|upper|split|startswith|encode)\\(",
+    "content_absent": "isinstance\\(",
+    "message": "String method called on request.data.get(...) — under MultiPartParser request.data MERGES POST and FILES, so a text field sent as a FILE part is an UploadedFile and .strip() raises AttributeError (500, not 400). Guard with isinstance(value, str). Happy-path tests send it as a field and never catch this.",
+    "pattern_ref": "backend/docs/patterns/security/file-upload.md",
+    "source": "codify: todo-281-forum-image-alt-text",
+    "added": "2026-07-31",
+    "severity": "warn"
+  },
+  {
+    "id": "react-setstate-in-unmount-cleanup",
+    "domains": [
+      "react",
+      "typescript"
+    ],
+    "path_glob": [
+      "web/**/*.tsx"
+    ],
+    "content_present": "return \\(\\) =>[^\\n]*\\n?[^\\n]*set[A-Z]\\w*\\(\\(",
+    "message": "setState with a functional updater inside an unmount cleanup — React DISCARDS the update without invoking the updater, so any release/cleanup work inside it silently never runs (measured 0 calls, todo 281). Mirror the value into a useRef and read the ref in the cleanup; test the unmount path specifically.",
+    "pattern_ref": "web/docs/patterns/react-typescript.md",
+    "source": "codify: todo-281-forum-image-alt-text",
+    "added": "2026-07-31",
+    "severity": "warn"
   }
 ]

--- a/todos/281-in_progress-p2-forum-image-alt-text-authoring.md
+++ b/todos/281-in_progress-p2-forum-image-alt-text-authoring.md
@@ -1,5 +1,5 @@
 ---
-status: pending
+status: in_progress
 priority: p2
 issue_id: "281"
 tags: [forum, a11y, web, drf, wagtail]
@@ -132,20 +132,20 @@ be captured and stored.
 
 ## Acceptance Criteria
 
-- [ ] `POST` to the post-image upload endpoint with an `alt` part stores it and
+- [x] `POST` to the post-image upload endpoint with an `alt` part stores it and
       returns it — asserted by a backend test that reads `Image.description`
       from the DB and the `alt` key from the response body
-- [ ] Uploading with no `alt` part returns `alt: ""` (not the filename) —
+- [x] Uploading with no `alt` part returns `alt: ""` (not the filename) —
       backend test asserts the filename does NOT appear in the serialized alt
-- [ ] An over-long alt is bounded to 255 chars (or rejected with 400) rather
+- [x] An over-long alt is bounded to 255 chars (or rejected with 400) rather
       than raising a `DataError` — backend test
-- [ ] The composer sends author-entered alt text on upload — Vitest test on the
+- [x] The composer sends author-entered alt text on upload — Vitest test on the
       image-insert flow asserting the value reaches `uploadPostImage`
-- [ ] A rendered post image carries the authored alt — Vitest test on the post
+- [x] A rendered post image carries the authored alt — Vitest test on the post
       renderer
-- [ ] `manage.py spectacular` passes with `alt` present in the upload request
+- [x] `manage.py spectacular` passes with `alt` present in the upload request
       schema
-- [ ] `pytest` forum suite and `npm run test` both green
+- [x] `pytest` forum suite and `npm run test` both green
 
 ## Work Log
 
@@ -158,6 +158,93 @@ be captured and stored.
   field exists in the pinned wagtail 7.4.2 — this is the detail that makes the
   change non-breaking and was not known when the audit filed M7 as a "contract
   change".
+
+### 2026-07-31 - Implemented by completing-todos skill (run 2026-07-31-1827)
+
+Option 1 (`Image.description`) as recommended. Verified the load-bearing fact
+first — the whole "no migration" claim rests on it:
+
+```
+wagtail (7, 4, 2, 'final', 1)
+267:    description = models.CharField(
+0027_image_description.py
+```
+
+**Shipped**
+
+1. `PostImageUploadView.post` accepts an optional `alt` multipart part →
+   stripped, `[:255]`, stored as `description=`. `title` still holds the
+   filename for Wagtail-admin identification. `alt` added to the
+   `extend_schema` multipart properties.
+2. `serialize_image_for_api` returns `image.description or ""` — with **no
+   fallback to `title`**. That is the point of the change, not an oversight:
+   `alt=""` is correct for a decorative image and strictly better for a screen
+   reader than `IMG_2481.jpg`.
+3. Composer prompts for alt **before** upload (`TipTapEditor`), with a local
+   `URL.createObjectURL` preview so the author can see what they're describing.
+   Mirrors the M24 link-popover shape. `uploadPostImage(file, alt?)` sends the
+   part only when non-empty.
+4. `wagtail_forum/README.md` + the `forumBody.ts` alt note updated.
+
+**Decisions made during implementation**
+
+- **No alt PATCH endpoint** (Recommended Action step 5, explicitly optional).
+  It would add a route needing host-mount parity (`test_host_api_routes_match_package`),
+  throttling, and OpenAPI for a correction path. Instead alt is captured at
+  upload only, and the composer hint says so verbatim: "This can only be set
+  now — to change it later, remove the image and add it again."
+- **Skip ≠ submit-what's-typed.** "Skip" and Escape upload with `alt=''`,
+  discarding anything half-typed; "Add image" sends the typed value. Two buttons
+  that did the same thing was the first draft and it was wrong.
+- **`alt` stays out of the idempotency fingerprint** (the todo's recommendation).
+  Including it would 422 a legitimate same-file retry carrying corrected alt.
+  Accepted consequence, now tested and documented: a replay returns the
+  *original* alt.
+
+**Deliberate contract change to an existing test.**
+`test_post_list_serializes_image_blocks_to_renditions` asserted
+`alt == "img0"` — filename-as-alt, the exact defect. Its fixture now sets a
+`description` distinct from `title`, and it asserts both the authored value AND
+that the filename does not appear. Two composer tests also changed shape: file
+selection no longer uploads directly, it opens the prompt.
+
+**Visible API change for historic content:** images uploaded before this serve
+`alt: ""` instead of their filename. Intended improvement, called out in the PR.
+
+### Verification
+
+`manage.py spectacular` — AC6 checked by parsing the schema, not by exit code:
+
+```
+PATH: /forum/images/
+PROPERTIES: ['image', 'alt']
+ALT SPEC: {'type': 'string', 'maxLength': 255, 'description': 'Author-supplied alt text (M7)...'}
+```
+
+Full backend suite, single invocation, fresh DB (`pytest -q --create-db`):
+
+```
+Pytest: 1449 passed, 0 failed, 8 skipped
+```
+
+Full web suite (`npm run test`):
+
+```
+Test Files  58 passed (58)
+     Tests  806 passed (806)
+```
+
+`npx tsc --noEmit` → `No errors found`; `npm run lint` → 0 errors (1 warning in
+a coverage artifact, not source).
+
+Mutation check — restoring the filename fallback
+(`image.description or image.title or ""`) turns the new tests red, so they are
+not hollow:
+
+```
+assert resp.data["alt"] == ""
+E   AssertionError: assert 'IMG_2481.jpg' == ''
+```
 
 ## Notes
 

--- a/todos/archive/281-completed-p2-forum-image-alt-text-authoring.md
+++ b/todos/archive/281-completed-p2-forum-image-alt-text-authoring.md
@@ -1,5 +1,5 @@
 ---
-status: in_progress
+status: completed
 priority: p2
 issue_id: "281"
 tags: [forum, a11y, web, drf, wagtail]
@@ -245,6 +245,21 @@ not hollow:
 assert resp.data["alt"] == ""
 E   AssertionError: assert 'IMG_2481.jpg' == ''
 ```
+
+### 2026-07-31 - Completed by completing-todos skill (run 2026-07-31-1827)
+
+- Verification: all 7 acceptance criteria passed with quoted evidence above.
+- Review: checklist orchestrator returned 0 findings. The deep pass on PR #526
+  found **2 real defects in this PR's own code**, both fixed with regression
+  tests before merge:
+  1. `alt` sent as a FILE part 500'd (`request.data` merges POST and FILES under
+     MultiPartParser, so `.strip()` hit an `UploadedFile`). Now `isinstance(str)`
+     guarded via `_alt_text()`.
+  2. The unmount cleanup never revoked the preview object URL — it revoked
+     inside a `setState` functional updater, which React discards on an
+     unmounting component (measured 0 calls). Now a `useRef`.
+  Both codified as write-time triggers.
+- Shipped as PR #526.
 
 ## Notes
 

--- a/web/src/components/StreamFieldRenderer.test.tsx
+++ b/web/src/components/StreamFieldRenderer.test.tsx
@@ -70,6 +70,43 @@ describe('StreamFieldRenderer', () => {
       expect(img).toHaveAttribute('src', 'https://cdn.example/img.jpg');
     });
 
+    it('renders the AUTHORED alt on a post image, and an empty alt stays empty (M7)', () => {
+      // Two halves of the same contract. The backend now serves
+      // Image.description (what the author typed) and deliberately does NOT
+      // fall back to the filename, so an image with no description arrives as
+      // alt: "". The renderer must pass that through untouched — a "helpful"
+      // fallback here (filename, "image", the post title) would re-introduce
+      // exactly the noise M7 removed for screen-reader users.
+      const blocks: StreamFieldBlock[] = [
+        {
+          id: '1',
+          type: 'image',
+          value: {
+            id: 7,
+            url: 'https://cdn.example/IMG_2481.jpg',
+            alt: 'A monstera leaf with brown edges',
+          },
+        },
+        {
+          id: '2',
+          type: 'image',
+          value: { id: 8, url: 'https://cdn.example/IMG_2482.jpg', alt: '' },
+        },
+      ];
+      render(<StreamFieldRenderer blocks={blocks} />);
+
+      expect(screen.getByRole('img', { name: 'A monstera leaf with brown edges' })).toHaveAttribute(
+        'src',
+        'https://cdn.example/IMG_2481.jpg'
+      );
+
+      // A decorative image is alt="" — presentational to a screen reader, and
+      // therefore absent from the accessibility tree entirely.
+      const decorative = document.querySelector('img[src="https://cdn.example/IMG_2482.jpg"]');
+      expect(decorative).toHaveAttribute('alt', '');
+      expect(screen.queryByRole('img', { name: /IMG_2482/ })).not.toBeInTheDocument();
+    });
+
     it('renders quote block with string value', () => {
       const blocks: StreamFieldBlock[] = [{ id: '1', type: 'quote', value: 'Test quote text' }];
       render(<StreamFieldRenderer blocks={blocks} />);

--- a/web/src/components/forum/IdentificationCard.test.tsx
+++ b/web/src/components/forum/IdentificationCard.test.tsx
@@ -7,7 +7,9 @@ const IDENTIFICATION: ThreadIdentification = {
   image: {
     id: 7,
     url: 'http://localhost:8000/media/images/plant.jpg',
-    alt: 'plant.jpg',
+    // Post-M7 the backend never sends a filename here: `alt` is the author's
+    // own text or "". "" is the common case for an identification photo.
+    alt: '',
     width: 800,
     height: 600,
   },
@@ -43,14 +45,32 @@ describe('IdentificationCard', () => {
     expect(screen.getByText(/plant_id/)).toBeInTheDocument();
   });
 
-  it('renders the submitted photo with role-describing alt, not the filename', () => {
+  it('describes the photo by its role when the author supplied no alt (M7)', () => {
     render(<IdentificationCard identification={IDENTIFICATION} />);
 
     const img = screen.getByRole('img');
     expect(img).toHaveAttribute('src', IDENTIFICATION.image!.url);
-    // The backend's `alt` is the Wagtail image title, which the upload endpoint
-    // sets to the filename — reading out "plant.jpg" helps nobody.
+    // An identification photo has exactly one role on the page, so naming that
+    // role beats silence when there is nothing authored to say.
     expect(img).toHaveAccessibleName('Photo the author submitted for identification');
+  });
+
+  it('prefers the author-supplied alt over the role fallback (M7)', () => {
+    render(
+      <IdentificationCard
+        identification={{
+          ...IDENTIFICATION,
+          image: { ...IDENTIFICATION.image!, alt: 'A yellowing monstera leaf with brown spots' },
+        }}
+      />
+    );
+
+    // Before M7 this position held the upload filename, which is why the card
+    // hardcoded a role sentence. Now that it carries the author's own words,
+    // they win — they say what the role sentence cannot.
+    expect(screen.getByRole('img')).toHaveAccessibleName(
+      'A yellowing monstera leaf with brown spots'
+    );
   });
 
   it('falls back to text-only when the photo is gone (SET_NULL)', () => {

--- a/web/src/components/forum/IdentificationCard.tsx
+++ b/web/src/components/forum/IdentificationCard.tsx
@@ -47,13 +47,14 @@ export default function IdentificationCard({
         {image && (
           <img
             src={image.url}
-            // Hardcoded, NOT `image.alt`: the backend derives that from the
-            // Wagtail image title, which the upload endpoint sets to the
-            // filename — so it would read out "IMG_4021.jpg". Unlike an inline
-            // post image (author-supplied alt is audit M7 / todo 281), this
-            // image has exactly one role on the page, so describing that role
-            // is strictly better than any filename.
-            alt="Photo the author submitted for identification"
+            // Prefer the author's own description, fall back to the image's
+            // ROLE on the page. Before M7 (todo 281) `image.alt` was derived
+            // from the Wagtail title — i.e. the upload filename — so this was
+            // hardcoded to avoid reading out "IMG_4021.jpg". It now carries
+            // author-supplied text, which beats a generic role sentence; the
+            // fallback still covers an image uploaded without alt (including
+            // every pre-M7 row, which serves "").
+            alt={image.alt || 'Photo the author submitted for identification'}
             width={image.width}
             height={image.height}
             className="w-full max-w-56 self-start rounded-lg object-cover"

--- a/web/src/components/forum/TipTapEditor.test.tsx
+++ b/web/src/components/forum/TipTapEditor.test.tsx
@@ -389,6 +389,27 @@ describe('TipTapEditor', () => {
     await waitFor(() => expect(revokeObjectURL).toHaveBeenCalledWith('blob:preview-mock'));
   });
 
+  it('revokes the preview when the composer unmounts with the prompt open (M7)', async () => {
+    // The path the Skip test above does NOT cover, and the one that was broken:
+    // the cleanup originally revoked inside a setState functional updater, but
+    // React DISCARDS a setState on an unmounting component without invoking the
+    // updater — so it silently did nothing (measured: 0 revoke calls). Reading a
+    // ref in the cleanup is what makes this work. Navigating away mid-prompt is
+    // a real path; this editor is also remounted via `key=` after every reply.
+    const { container, unmount } = render(<TipTapEditor onChange={vi.fn()} />);
+    await waitFor(() => expect(container.querySelector('.ProseMirror')).toBeInTheDocument());
+
+    fireEvent.change(screen.getByTestId('forum-image-input'), {
+      target: { files: [new File(['x'], 'ok.jpg', { type: 'image/jpeg' })] },
+    });
+    await screen.findByLabelText('Describe this image');
+
+    revokeObjectURL.mockClear();
+    unmount();
+
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:preview-mock');
+  });
+
   it('opens a styled link editor instead of window.prompt, and validates the URL (M24)', async () => {
     const promptSpy = vi.spyOn(window, 'prompt');
     render(<TipTapEditor onChange={vi.fn()} />);

--- a/web/src/components/forum/TipTapEditor.test.tsx
+++ b/web/src/components/forum/TipTapEditor.test.tsx
@@ -38,6 +38,19 @@ beforeAll(() => {
   }
 });
 
+/**
+ * jsdom implements neither `URL.createObjectURL` nor `revokeObjectURL` (no blob
+ * URL store), so the M7 alt prompt's preview would throw on open. Stub both —
+ * `revokeObjectURL` is a spy because "the preview is released" is itself an
+ * assertion (one leaked blob per inserted image otherwise).
+ */
+const revokeObjectURL = vi.fn();
+beforeAll(() => {
+  const url = URL as unknown as Record<string, unknown>;
+  url.createObjectURL = vi.fn(() => 'blob:preview-mock');
+  url.revokeObjectURL = revokeObjectURL;
+});
+
 describe('TipTapEditor', () => {
   beforeEach(() => {
     // The compose-assist unavailability latch is session-scoped module state in
@@ -270,7 +283,10 @@ describe('TipTapEditor', () => {
     const file = new File(['x'], 'ok.jpg', { type: 'image/jpeg' });
     fireEvent.change(input, { target: { files: [file] } });
 
-    await waitFor(() => expect(uploadSpy).toHaveBeenCalledWith(file));
+    // M7: selecting a file now opens the alt prompt; the upload happens on
+    // confirm. Skip is the shortest path to "just upload it".
+    await userEvent.click(await screen.findByRole('button', { name: 'Skip' }));
+    await waitFor(() => expect(uploadSpy).toHaveBeenCalledWith(file, ''));
   });
 
   it('surfaces an upload failure as an error message (L13)', async () => {
@@ -282,8 +298,95 @@ describe('TipTapEditor', () => {
     const input = screen.getByTestId('forum-image-input');
     const file = new File(['x'], 'ok.jpg', { type: 'image/jpeg' });
     fireEvent.change(input, { target: { files: [file] } });
+    await userEvent.click(await screen.findByRole('button', { name: 'Skip' }));
 
     expect(await screen.findByText('server exploded')).toBeInTheDocument();
+  });
+
+  // -------------------------------------------------------------------------
+  // Author-supplied alt text (M7 / todo 281)
+  // -------------------------------------------------------------------------
+
+  it('prompts for alt text before uploading, not after (M7)', async () => {
+    const uploadSpy = vi.spyOn(forumService, 'uploadPostImage');
+    const { container } = render(<TipTapEditor onChange={vi.fn()} />);
+    await waitFor(() => expect(container.querySelector('.ProseMirror')).toBeInTheDocument());
+
+    fireEvent.change(screen.getByTestId('forum-image-input'), {
+      target: { files: [new File(['x'], 'ok.jpg', { type: 'image/jpeg' })] },
+    });
+
+    // The prompt is up and NOTHING has been uploaded — the alt must ride the
+    // upload request, so capturing it afterwards would be too late.
+    expect(await screen.findByLabelText('Describe this image')).toBeInTheDocument();
+    expect(uploadSpy).not.toHaveBeenCalled();
+  });
+
+  it('sends author-entered alt text on upload (M7)', async () => {
+    const uploadSpy = vi.spyOn(forumService, 'uploadPostImage').mockResolvedValue({
+      id: 1,
+      url: 'https://cdn.example/x.jpg',
+      alt: 'A monstera leaf with brown edges',
+      width: 10,
+      height: 10,
+    });
+    const { container } = render(<TipTapEditor onChange={vi.fn()} />);
+    await waitFor(() => expect(container.querySelector('.ProseMirror')).toBeInTheDocument());
+
+    const file = new File(['x'], 'ok.jpg', { type: 'image/jpeg' });
+    fireEvent.change(screen.getByTestId('forum-image-input'), { target: { files: [file] } });
+
+    await userEvent.type(
+      await screen.findByLabelText('Describe this image'),
+      'A monstera leaf with brown edges'
+    );
+    await userEvent.click(screen.getByRole('button', { name: 'Add image' }));
+
+    await waitFor(() =>
+      expect(uploadSpy).toHaveBeenCalledWith(file, 'A monstera leaf with brown edges')
+    );
+  });
+
+  it('Skip uploads with an empty alt and discards anything typed (M7)', async () => {
+    const uploadSpy = vi.spyOn(forumService, 'uploadPostImage').mockResolvedValue({
+      id: 1,
+      url: 'https://cdn.example/x.jpg',
+      alt: '',
+      width: 10,
+      height: 10,
+    });
+    const { container } = render(<TipTapEditor onChange={vi.fn()} />);
+    await waitFor(() => expect(container.querySelector('.ProseMirror')).toBeInTheDocument());
+
+    const file = new File(['x'], 'ok.jpg', { type: 'image/jpeg' });
+    fireEvent.change(screen.getByTestId('forum-image-input'), { target: { files: [file] } });
+
+    await userEvent.type(await screen.findByLabelText('Describe this image'), 'half-typed');
+    await userEvent.click(screen.getByRole('button', { name: 'Skip' }));
+
+    // Skip means "no description", not "submit whatever is in the box" — an
+    // empty alt is correct for a decorative image and must not block posting.
+    await waitFor(() => expect(uploadSpy).toHaveBeenCalledWith(file, ''));
+  });
+
+  it('revokes the preview object URL when the prompt closes (M7)', async () => {
+    vi.spyOn(forumService, 'uploadPostImage').mockResolvedValue({
+      id: 1,
+      url: 'https://cdn.example/x.jpg',
+      alt: '',
+      width: 10,
+      height: 10,
+    });
+    const { container } = render(<TipTapEditor onChange={vi.fn()} />);
+    await waitFor(() => expect(container.querySelector('.ProseMirror')).toBeInTheDocument());
+
+    fireEvent.change(screen.getByTestId('forum-image-input'), {
+      target: { files: [new File(['x'], 'ok.jpg', { type: 'image/jpeg' })] },
+    });
+    await userEvent.click(await screen.findByRole('button', { name: 'Skip' }));
+
+    // Without this the composer leaks one blob per inserted image.
+    await waitFor(() => expect(revokeObjectURL).toHaveBeenCalledWith('blob:preview-mock'));
   });
 
   it('opens a styled link editor instead of window.prompt, and validates the URL (M24)', async () => {

--- a/web/src/components/forum/TipTapEditor.tsx
+++ b/web/src/components/forum/TipTapEditor.tsx
@@ -117,14 +117,21 @@ export default function TipTapEditor({
     previewUrl: string;
     alt: string;
   } | null>(null);
+  // The live preview URL, mirrored in a ref because the unmount cleanup below
+  // cannot read it from state: React DISCARDS a setState on an unmounting
+  // component without ever invoking the updater, so revoking inside a
+  // functional updater silently does nothing on that path (measured: 0 calls).
+  // A ref is a plain object and is still readable during cleanup.
+  const previewUrlRef = useRef<string | null>(null);
 
   // Close the alt prompt and release its object URL. Every exit path — confirm,
   // skip, Escape, unmount — must go through here or the blob leaks.
   const closeAltPrompt = () => {
-    setAltPrompt((current) => {
-      if (current) URL.revokeObjectURL(current.previewUrl);
-      return null;
-    });
+    if (previewUrlRef.current) {
+      URL.revokeObjectURL(previewUrlRef.current);
+      previewUrlRef.current = null;
+    }
+    setAltPrompt(null);
   };
 
   const handleImageSelect = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -144,7 +151,9 @@ export default function TipTapEditor({
     // Ask for alt text BEFORE uploading (M7) — the value has to ride the upload
     // request, so there is no second chance to collect it.
     closeAltPrompt(); // revoke a previous preview if one was somehow still open
-    setAltPrompt({ file, previewUrl: URL.createObjectURL(file), alt: '' });
+    const previewUrl = URL.createObjectURL(file);
+    previewUrlRef.current = previewUrl;
+    setAltPrompt({ file, previewUrl, alt: '' });
   };
 
   // Upload the pending image and insert it. `alt` is passed explicitly so the
@@ -257,15 +266,14 @@ export default function TipTapEditor({
   }, [editor]);
 
   // Release a pending alt-prompt preview if the composer unmounts while it is
-  // open (this editor is remounted via `key=` after every reply, so that is a
-  // routine path, not an edge case). Reads the URL from a ref-free closure over
-  // state is unsafe here — use the functional updater in closeAltPrompt.
+  // open — e.g. navigating away mid-prompt (this editor is also remounted via
+  // `key=` after every reply). Reads the ref, not state: see previewUrlRef.
   useEffect(() => {
     return () => {
-      setAltPrompt((current) => {
-        if (current) URL.revokeObjectURL(current.previewUrl);
-        return null;
-      });
+      if (previewUrlRef.current) {
+        URL.revokeObjectURL(previewUrlRef.current);
+        previewUrlRef.current = null;
+      }
     };
   }, []);
 

--- a/web/src/components/forum/TipTapEditor.tsx
+++ b/web/src/components/forum/TipTapEditor.tsx
@@ -107,8 +107,27 @@ export default function TipTapEditor({
   // that replaces the native window.prompt — M24).
   const [linkDraft, setLinkDraft] = useState<string | null>(null);
   const [linkError, setLinkError] = useState<string | null>(null);
+  // Alt-text prompt (M7): null = closed. Collected BEFORE upload so the authored
+  // value rides the one multipart request — there is no alt PATCH endpoint, and
+  // htmlToBodyBlocks drops the editor node's alt on write, so upload time is the
+  // only moment the value can be captured. `previewUrl` is an object URL that
+  // MUST be revoked (see closeAltPrompt) or every inserted image leaks a blob.
+  const [altPrompt, setAltPrompt] = useState<{
+    file: File;
+    previewUrl: string;
+    alt: string;
+  } | null>(null);
 
-  const handleImageSelect = async (event: React.ChangeEvent<HTMLInputElement>) => {
+  // Close the alt prompt and release its object URL. Every exit path — confirm,
+  // skip, Escape, unmount — must go through here or the blob leaks.
+  const closeAltPrompt = () => {
+    setAltPrompt((current) => {
+      if (current) URL.revokeObjectURL(current.previewUrl);
+      return null;
+    });
+  };
+
+  const handleImageSelect = (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
     event.target.value = ''; // allow re-selecting the same file after an error
     if (!file || !editor) return;
@@ -122,9 +141,22 @@ export default function TipTapEditor({
       setImageError(`Image is too large — ${IMAGE_LIMIT_HINT}.`);
       return;
     }
+    // Ask for alt text BEFORE uploading (M7) — the value has to ride the upload
+    // request, so there is no second chance to collect it.
+    closeAltPrompt(); // revoke a previous preview if one was somehow still open
+    setAltPrompt({ file, previewUrl: URL.createObjectURL(file), alt: '' });
+  };
+
+  // Upload the pending image and insert it. `alt` is passed explicitly so the
+  // Skip path sends "" rather than whatever happens to be typed — an empty alt
+  // is a legitimate choice (decorative image) and must never block posting.
+  const uploadPendingImage = async (alt: string) => {
+    if (!altPrompt || !editor) return;
+    const { file } = altPrompt;
+    closeAltPrompt();
     setUploadingImage(true);
     try {
-      const image = await uploadPostImage(file);
+      const image = await uploadPostImage(file, alt);
       // insertContent (not setImage) so the custom imageId attr rides along.
       editor
         .chain()
@@ -223,6 +255,19 @@ export default function TipTapEditor({
       }
     };
   }, [editor]);
+
+  // Release a pending alt-prompt preview if the composer unmounts while it is
+  // open (this editor is remounted via `key=` after every reply, so that is a
+  // routine path, not an edge case). Reads the URL from a ref-free closure over
+  // state is unsafe here — use the functional updater in closeAltPrompt.
+  useEffect(() => {
+    return () => {
+      setAltPrompt((current) => {
+        if (current) URL.revokeObjectURL(current.previewUrl);
+        return null;
+      });
+    };
+  }, []);
 
   if (!editor) {
     return <div className="p-4 text-ink-3">Loading editor...</div>;
@@ -348,6 +393,66 @@ export default function TipTapEditor({
             data-testid="forum-image-input"
             onChange={handleImageSelect}
           />
+        </div>
+      )}
+
+      {/* Alt-text prompt (M7) — collected before upload, because the value has
+          to ride the multipart request. "Skip" is a first-class choice: a
+          decorative image is correctly alt="", and empty must never block
+          posting. */}
+      {editable && altPrompt !== null && (
+        <div className="flex flex-wrap items-center gap-2 border-b border-line-2 bg-surface p-2">
+          <img
+            src={altPrompt.previewUrl}
+            alt=""
+            className="h-14 w-14 shrink-0 rounded object-cover"
+          />
+          <div className="flex min-w-0 flex-1 flex-col gap-1">
+            <label htmlFor="tiptap-image-alt" className="text-sm font-medium text-ink">
+              Describe this image
+            </label>
+            <input
+              id="tiptap-image-alt"
+              type="text"
+              autoFocus
+              maxLength={255}
+              value={altPrompt.alt}
+              onChange={(e) =>
+                setAltPrompt((current) => (current ? { ...current, alt: e.target.value } : current))
+              }
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  e.preventDefault();
+                  void uploadPendingImage(altPrompt.alt);
+                } else if (e.key === 'Escape') {
+                  // Escape SKIPS (uploads with no alt); it does not cancel the
+                  // insert — the user already chose to add this image.
+                  void uploadPendingImage('');
+                }
+              }}
+              placeholder="e.g. A monstera leaf with brown edges"
+              aria-describedby="tiptap-image-alt-hint"
+              className="min-h-11 w-full rounded border border-line-2 bg-surface-1 px-3 text-sm text-ink"
+            />
+            <span id="tiptap-image-alt-hint" className="text-xs text-ink-3">
+              Helps people using screen readers. Leave blank if the image is decorative. This can
+              only be set now — to change it later, remove the image and add it again.
+            </span>
+          </div>
+          <button
+            type="button"
+            onClick={() => void uploadPendingImage(altPrompt.alt)}
+            className="min-h-11 rounded bg-primary/20 px-3 text-sm font-medium text-ink"
+          >
+            Add image
+          </button>
+          <button
+            type="button"
+            onClick={() => void uploadPendingImage('')}
+            className="min-h-11 rounded px-3 text-sm text-ink-2"
+          >
+            Skip
+          </button>
         </div>
       )}
 

--- a/web/src/services/forumService.test.ts
+++ b/web/src/services/forumService.test.ts
@@ -541,6 +541,32 @@ describe('forumService (wagtail_forum API contract)', () => {
     expect(url).toContain('/api/v1/forum/images/');
     expect(opts.body).toBeInstanceOf(FormData);
     expect((opts.body as FormData).has('image')).toBe(true);
+    // No alt argument → no alt part, so the request is byte-identical to the
+    // pre-M7 shape.
+    expect((opts.body as FormData).has('alt')).toBe(false);
+  });
+
+  it('uploadPostImage sends author-supplied alt text as an "alt" part (M7)', async () => {
+    const file = new File(['x'], 'IMG_2481.jpg', { type: 'image/jpeg' });
+    fetchMock.mockResolvedValueOnce(
+      okJson({ id: 7, url: 'http://x/a.jpg', alt: 'A fern frond', width: 800, height: 600 })
+    );
+    await uploadPostImage(file, '  A fern frond  ');
+    const [, opts] = fetchMock.mock.calls[0];
+    // Trimmed on the way out — the backend strips too, but sending clean data
+    // keeps the stored value and the echoed value identical.
+    expect((opts.body as FormData).get('alt')).toBe('A fern frond');
+  });
+
+  it('uploadPostImage omits the alt part when the author skipped it (M7)', async () => {
+    const file = new File(['x'], 'a.jpg', { type: 'image/jpeg' });
+    fetchMock.mockResolvedValueOnce(
+      okJson({ id: 7, url: 'http://x/a.jpg', alt: '', width: 800, height: 600 })
+    );
+    await uploadPostImage(file, '   ');
+    const [, opts] = fetchMock.mock.calls[0];
+    // Whitespace-only is "no description", not a description made of spaces.
+    expect((opts.body as FormData).has('alt')).toBe(false);
   });
 
   // --- Error propagation ----------------------------------------------------

--- a/web/src/services/forumService.ts
+++ b/web/src/services/forumService.ts
@@ -423,10 +423,19 @@ export interface UploadedImage {
  * the returned id is referenced from an `image` body block (see utils/forumBody).
  * Multipart, so let the browser set Content-Type; CSRF + cookie auth as usual.
  */
-export async function uploadPostImage(imageFile: File): Promise<UploadedImage> {
+/**
+ * Upload an inline post image, optionally with author-supplied alt text (M7).
+ *
+ * `alt` is sent only when non-empty — an omitted part and an empty one mean the
+ * same thing to the backend (a decorative image, served as `alt: ""`), and not
+ * sending it keeps the request identical to the pre-M7 shape.
+ */
+export async function uploadPostImage(imageFile: File, alt?: string): Promise<UploadedImage> {
   const csrfToken = await getCsrfToken();
   const formData = new FormData();
   formData.append('image', imageFile);
+  const trimmedAlt = alt?.trim();
+  if (trimmedAlt) formData.append('alt', trimmedAlt);
   const response = await fetch(`${FORUM_BASE}/images/`, {
     method: 'POST',
     credentials: 'include',

--- a/web/src/utils/forumBody.ts
+++ b/web/src/utils/forumBody.ts
@@ -44,6 +44,11 @@ function blockquoteText(el: Element): string {
  * blocks; each inline `<img data-image-id>` becomes its own `image` block (value
  * = the wagtail image id — the url/alt in the editor are display-only and are
  * re-derived by the backend, so they are intentionally dropped here).
+ *
+ * What the backend re-derives `alt` FROM changed in M7: it is now the author's
+ * own text, captured at upload time and stored on the image row, not the upload
+ * filename. Dropping the editor's copy here is still correct — but it is also
+ * why alt cannot be edited after insert without re-uploading the image.
  */
 export function htmlToBodyBlocks(html: string): ForumBodyWriteBlock[] {
   const doc = new DOMParser().parseFromString(html, 'text/html');


### PR DESCRIPTION
## Problem

A photo-centric plant community shipped inline post images with **no
author-supplied alt text anywhere in the chain**. Every image a member posted
reached a screen reader as its upload filename — `IMG_2481.jpg`. That is an
accessibility anti-pattern, not a cosmetic gap.

The alt round-trip was already *structurally* complete. The one thing missing
was a human-authored value entering it. Nothing here is undone — a value is
captured and stored.

## Approach — Option 1 (`Image.description`)

Verified the load-bearing fact before writing anything, since the whole
"non-breaking, no migration" claim rests on it:

```
wagtail (7, 4, 2, 'final', 1)
267:    description = models.CharField(
0027_image_description.py
```

The body block value stays a bare `int`, so stored bodies, revisions,
`build_forum_image_map`, `validate_forum_body`, and the mobile client are all
untouched. Option 2 (a `StructBlock`) would have meant an `int` → `dict` data
migration across every post *and* revision for a per-usage nicety.

## What changed

**Backend**
- `POST /forum/images/` accepts an optional `alt` multipart part → stripped,
  truncated to 255, stored on `Image.description`. `title` still holds the
  filename for Wagtail-admin identification.
- `serialize_image_for_api` returns `image.description or ""` with **no
  fallback to `title`**. That is the point of the change: `alt=""` is correct
  markup for a decorative image and is strictly better for a screen reader than
  a filename.
- `alt` added to the `extend_schema` multipart properties.

**Web**
- The composer prompts for alt **before** upload, with an object-URL preview so
  the author can see what they're describing. It has to be captured then: the
  value rides the one multipart request, `htmlToBodyBlocks` drops the editor
  node's alt on write, and there is no alt PATCH endpoint.
- Skip and Escape upload with `alt=""` and discard anything half-typed; "Add
  image" sends the typed value. Empty alt never blocks posting.
- `IdentificationCard` hardcoded a role sentence *because* alt used to be the
  filename — its comment named this todo by number. It now prefers the authored
  text and keeps the role sentence as the fallback.

## Two deliberate contract changes, both visible

1. **Images uploaded before this serve `alt: ""` instead of their filename.**
   Intended improvement, but it is an API value change for historic posts.
2. **`test_post_list_serializes_image_blocks_to_renditions` asserted
   `alt == "img0"`** — filename-as-alt, the exact defect. Its fixture now sets a
   `description` distinct from `title`, and it asserts both the authored value
   AND that the filename is absent. Two composer tests also changed shape: file
   selection no longer uploads directly, it opens the prompt.

## Decisions worth reviewing

- **No alt PATCH endpoint** (Recommended Action step 5, explicitly optional).
  It would need host-mount route parity (`test_host_api_routes_match_package`),
  throttling, and OpenAPI for a correction path. Alt is capture-at-upload only,
  and the composer hint says so verbatim.
- **`alt` stays out of the idempotency fingerprint.** Including it would 422 a
  legitimate same-file retry carrying corrected alt. Accepted, tested, and
  documented consequence: a replay returns the *original* alt.
- **Alt is per-image, not per-usage.** Re-embedding one upload in a second post
  reuses the first post's alt. Noted in the package README.

## Verification

```
$ pytest -q --create-db          # full backend suite, single invocation
Pytest: 1449 passed, 0 failed, 8 skipped

$ npm run test
Test Files  58 passed (58)
     Tests  807 passed (807)

$ npx tsc --noEmit  → No errors found
$ npm run lint      → 0 errors
```

AC6 checked by parsing the schema rather than trusting the exit code:

```
PATH: /forum/images/
PROPERTIES: ['image', 'alt']
ALT SPEC: {'type': 'string', 'maxLength': 255, 'description': 'Author-supplied alt text (M7)...'}
```

Mutation check — restoring the filename fallback turns the new tests red, so
they are not hollow:

```
assert resp.data["alt"] == ""
E   AssertionError: assert 'IMG_2481.jpg' == ''
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)